### PR TITLE
Revert "Try fail CI if codecov errors"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,7 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: "codecov/codecov-action@v1"
         with:
-          fail_ci_if_error: true
+          # This is flaky so maybe we do not fail if error, meaning our
+          # coverage reports may be incomplete. See:
+          # https://github.com/codecov/codecov-action/issues/37.
+          fail_ci_if_error: false


### PR DESCRIPTION
Reverts VWS-Python/vws-python-mock#621 due to CI errors.