### PR TITLE
Remove git from Dockerfiles

### DIFF
--- a/src/mock_vws/_flask_server/dockerfiles/target_manager/Dockerfile
+++ b/src/mock_vws/_flask_server/dockerfiles/target_manager/Dockerfile
@@ -1,7 +1,4 @@
 FROM python:3.9.1-slim-buster
-RUN apt update --yes
-# git is needed for setuptools-scm.
-RUN apt install --yes git
 COPY . /app
 WORKDIR /app
 RUN pip install .

--- a/src/mock_vws/_flask_server/dockerfiles/vwq/Dockerfile
+++ b/src/mock_vws/_flask_server/dockerfiles/vwq/Dockerfile
@@ -1,7 +1,4 @@
 FROM python:3.9.1-slim-buster
-RUN apt update --yes
-# git is needed for setuptools-scm.
-RUN apt install --yes git
 COPY . /app
 WORKDIR /app
 RUN pip install .

--- a/src/mock_vws/_flask_server/dockerfiles/vws/Dockerfile
+++ b/src/mock_vws/_flask_server/dockerfiles/vws/Dockerfile
@@ -1,7 +1,4 @@
 FROM python:3.9.1-slim-buster
-RUN apt update --yes
-# git is needed for setuptools-scm.
-RUN apt install --yes git
 COPY . /app
 WORKDIR /app
 RUN pip install .


### PR DESCRIPTION
Installing git caused the ARM builds to fail.

Git was needed for setuptools_scm, but we now have a fallback version string and we do not rely on the version inside Docker containers.