### PR TITLE
Satisfy some wemake rules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ linkcheck_anchors = False
 linkcheck_retries = 5
 linkcheck_ignore = [
     # Requires login.
-    r"https://developer.vuforia.com/targetmanager",
+    "https://developer.vuforia.com/targetmanager",
 ]
 
 spelling_word_list_filename = "../../spelling_private_dict.txt"

--- a/src/mock_vws/_base64_decoding.py
+++ b/src/mock_vws/_base64_decoding.py
@@ -13,7 +13,7 @@ def decode_base64(encoded_data: str) -> bytes:
 
     Raises:
         binascii.Error: Vuforia would consider this encoded data as an
-        "UNPROCESSABLE_ENTITY".
+          "UNPROCESSABLE_ENTITY".
 
     Returns:
         The given data, decoded as base64.
@@ -23,13 +23,13 @@ def decode_base64(encoded_data: str) -> bytes:
         if character not in acceptable_characters:
             raise binascii.Error
 
-    mod_4_result_to_modified_encoded_data = {
+    mod_four_result_to_modified_encoded_data = {
         0: encoded_data,
         1: encoded_data[:-1],
-        2: encoded_data + "==",
-        3: encoded_data + "=",
+        2: f"{encoded_data}==",
+        3: f"{encoded_data}=",
     }
-    modified_encoded_data = mod_4_result_to_modified_encoded_data[
+    modified_encoded_data = mod_four_result_to_modified_encoded_data[
         len(encoded_data) % 4
     ]
     return base64.b64decode(modified_encoded_data)

--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -179,11 +179,11 @@ def create_target(database_name: str) -> Response:
     """
     Create a new target in a given database.
     """
-    [database] = [
+    (database,) = (
         database
         for database in TARGET_MANAGER.databases
         if database.database_name == database_name
-    ]
+    )
     request_json = json.loads(request.data)
     image_base64 = request_json["image_base64"]
     image_bytes = base64.b64decode(s=image_base64)
@@ -216,11 +216,11 @@ def delete_target(database_name: str, target_id: str) -> Response:
     """
     Delete a target.
     """
-    [database] = [
+    (database,) = (
         database
         for database in TARGET_MANAGER.databases
         if database.database_name == database_name
-    ]
+    )
     target = database.get_target(target_id=target_id)
     now = datetime.datetime.now(tz=target.upload_date.tzinfo)
     new_target = dataclasses.replace(target, delete_date=now)
@@ -240,11 +240,11 @@ def update_target(database_name: str, target_id: str) -> Response:
     """
     Update a target.
     """
-    [database] = [
+    (database,) = (
         database
         for database in TARGET_MANAGER.databases
         if database.database_name == database_name
-    ]
+    )
     target = database.get_target(target_id=target_id)
 
     request_json = json.loads(request.data)
@@ -285,4 +285,4 @@ def update_target(database_name: str, target_id: str) -> Response:
 
 if __name__ == "__main__":  # pragma: no cover
     SETTINGS = TargetManagerSettings.parse_obj(obj={})
-    TARGET_MANAGER_FLASK_APP.run(debug=True, host=SETTINGS.target_manager_host)
+    TARGET_MANAGER_FLASK_APP.run(host=SETTINGS.target_manager_host)

--- a/src/mock_vws/_flask_server/vwq.py
+++ b/src/mock_vws/_flask_server/vwq.py
@@ -162,4 +162,4 @@ def query() -> Response:
 
 if __name__ == "__main__":  # pragma: no cover
     SETTINGS = VWQSettings.parse_obj(obj={})
-    CLOUDRECO_FLASK_APP.run(debug=True, host=SETTINGS.vwq_host)
+    CLOUDRECO_FLASK_APP.run(host=SETTINGS.vwq_host)

--- a/src/mock_vws/_query_tools.py
+++ b/src/mock_vws/_query_tools.py
@@ -145,7 +145,7 @@ def get_query_match_response_text(
         raise ActiveMatchingTargetsDeleteProcessing
 
     all_quality_matches = not_deleted_matches + deletion_not_recognized_matches
-    minimum_rating = 0.0
+    minimum_rating = 0
     matches = [
         match
         for match in all_quality_matches

--- a/src/mock_vws/_query_validators/accept_header_validators.py
+++ b/src/mock_vws/_query_validators/accept_header_validators.py
@@ -22,7 +22,7 @@ def validate_accept_header(request_headers: dict[str, str]) -> None:
             'application/json' or '*/*'.
     """
     accept = request_headers.get("Accept")
-    if accept in ("application/json", "*/*", None):
+    if accept in {"application/json", "*/*", None}:
         return
 
     _LOGGER.warning(

--- a/src/mock_vws/_query_validators/content_type_validators.py
+++ b/src/mock_vws/_query_validators/content_type_validators.py
@@ -42,7 +42,7 @@ def validate_content_type_header(
 
     email_message = EmailMessage()
     email_message["content-type"] = request_headers["Content-Type"]
-    if email_message.get_content_type() not in ("multipart/form-data", "*/*"):
+    if email_message.get_content_type() not in {"multipart/form-data", "*/*"}:
         _LOGGER.warning(
             msg=(
                 "The content type header main part is not multipart/form-data."

--- a/src/mock_vws/_query_validators/date_validators.py
+++ b/src/mock_vws/_query_validators/date_validators.py
@@ -47,11 +47,9 @@ def _accepted_date_formats() -> set[str]:
         "%a %d %b %Y %H:%M:%S",
     }
 
-    known_accepted_formats = known_accepted_formats.union(
-        {date_format + " GMT" for date_format in known_accepted_formats},
+    return known_accepted_formats.union(
+        {f"{date_format} GMT" for date_format in known_accepted_formats},
     )
-
-    return known_accepted_formats
 
 
 def validate_date_format(request_headers: dict[str, str]) -> None:
@@ -95,7 +93,7 @@ def validate_date_in_range(request_headers: dict[str, str]) -> None:
                 date_format,
             ).astimezone()
 
-    assert date is not None
+    assert isinstance(date, datetime.datetime)
     gmt = ZoneInfo("GMT")
     now = datetime.datetime.now(tz=gmt)
     date_from_header = date.replace(tzinfo=gmt)

--- a/src/mock_vws/_query_validators/fields_validators.py
+++ b/src/mock_vws/_query_validators/fields_validators.py
@@ -34,7 +34,7 @@ def validate_extra_fields(
     boundary = email_message.get_boundary()
     assert isinstance(boundary, str)
     parsed = multipart.MultipartParser(stream=body_file, boundary=boundary)
-    parsed_keys = {item.name for item in parsed.parts()}
+    parsed_keys = {part.name for part in parsed.parts()}
     known_parameters = {"image", "max_num_results", "include_target_data"}
 
     if not parsed_keys - known_parameters:

--- a/src/mock_vws/_query_validators/image_validators.py
+++ b/src/mock_vws/_query_validators/image_validators.py
@@ -142,7 +142,7 @@ def validate_image_format(
     image_file = io.BytesIO(image)
     pil_image = Image.open(image_file)
 
-    if pil_image.format in ("PNG", "JPEG"):
+    if pil_image.format in {"PNG", "JPEG"}:
         return
 
     _LOGGER.warning(msg="The image format is not PNG or JPEG.")

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -90,8 +90,8 @@ class MockVWS(ContextDecorator):
             'Perhaps you meant "https://{url}".'
         )
         for url in (base_vwq_url, base_vws_url):
-            result = urlparse(url)
-            if not result.scheme:
+            parse_result = urlparse(url=url)
+            if not parse_result.scheme:
                 error = missing_scheme_error.format(url=url)
                 raise requests.exceptions.MissingSchema(error)
 
@@ -134,30 +134,30 @@ class MockVWS(ContextDecorator):
             ``self``.
         """
         with Mocker(real_http=self._real_http) as mock:
-            for route in self._mock_vws_api.routes:
+            for vws_route in self._mock_vws_api.routes:
                 url_pattern = urljoin(
                     base=self._base_vws_url,
-                    url=route.path_pattern + "$",
+                    url=f"{vws_route.path_pattern}$",
                 )
 
-                for http_method in route.http_methods:
+                for vws_http_method in vws_route.http_methods:
                     mock.register_uri(
-                        method=http_method,
+                        method=vws_http_method,
                         url=re.compile(url_pattern),
-                        text=getattr(self._mock_vws_api, route.route_name),
+                        text=getattr(self._mock_vws_api, vws_route.route_name),
                     )
 
-            for route in self._mock_vwq_api.routes:
+            for vwq_route in self._mock_vwq_api.routes:
                 url_pattern = urljoin(
                     base=self._base_vwq_url,
-                    url=route.path_pattern + "$",
+                    url=f"{vwq_route.path_pattern}$",
                 )
 
-                for http_method in route.http_methods:
+                for vwq_http_method in vwq_route.http_methods:
                     mock.register_uri(
-                        method=http_method,
+                        method=vwq_http_method,
                         url=re.compile(url_pattern),
-                        text=getattr(self._mock_vwq_api, route.route_name),
+                        text=getattr(self._mock_vwq_api, vwq_route.route_name),
                     )
 
         self._mock = mock
@@ -174,8 +174,7 @@ class MockVWS(ContextDecorator):
         """
         # __exit__ needs this to be passed in but vulture thinks that it is
         # unused, so we "use" it here.
-        for _ in (exc,):
-            pass
+        assert isinstance(exc, tuple)
 
         self._mock.stop()
         return False

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -56,7 +56,7 @@ def route(
 
     Args:
         path_pattern: The end part of a URL pattern. E.g. `/targets` or
-            `/targets/.+`.
+          `/targets/.+`.
         http_methods: HTTP methods that map to the route function.
 
     Returns:
@@ -102,10 +102,10 @@ class MockVuforiaWebServicesAPI:
         Args:
             target_manager: Target Manager which stores databases.
             processing_time_seconds: The number of seconds to process each
-                image for. In the real Vuforia Web Services, this is not
-                deterministic.
+              image for. In the real Vuforia Web Services, this is not
+              deterministic.
             duplicate_match_checker: A callable which takes two image values
-                and returns whether they are duplicates.
+              and returns whether they are duplicates.
             target_tracking_rater: A callable for rating targets for tracking.
 
         Attributes:
@@ -367,11 +367,13 @@ class MockVuforiaWebServicesAPI:
         assert isinstance(database, VuforiaDatabase)
         date = email.utils.formatdate(None, localtime=False, usegmt=True)
 
-        results = [target.target_id for target in database.not_deleted_targets]
+        response_results = [
+            target.target_id for target in database.not_deleted_targets
+        ]
         body: dict[str, str | list[str]] = {
             "transaction_id": uuid.uuid4().hex,
             "result_code": ResultCodes.SUCCESS.value,
-            "results": results,
+            "results": response_results,
         }
         body_json = json_dump(body)
         context.headers = {
@@ -500,7 +502,7 @@ class MockVuforiaWebServicesAPI:
                 second_image_content=other.image_value,
             )
             and TargetStatuses.FAILED.value
-            not in (target.status, other.status)
+            not in {target.status, other.status}
             and TargetStatuses.PROCESSING.value != other.status
             and other.active_flag
         ]

--- a/src/mock_vws/_services_validators/content_type_validators.py
+++ b/src/mock_vws/_services_validators/content_type_validators.py
@@ -27,7 +27,7 @@ def validate_content_type_header_given(
         AuthenticationFailure: No ``Content-Type`` header is given and the
             request requires one.
     """
-    request_needs_content_type = bool(request_method in (POST, PUT))
+    request_needs_content_type = bool(request_method in {POST, PUT})
     if request_headers.get("Content-Type") or not request_needs_content_type:
         return
 

--- a/src/mock_vws/_services_validators/image_validators.py
+++ b/src/mock_vws/_services_validators/image_validators.py
@@ -43,7 +43,7 @@ def validate_image_format(request_body: bytes) -> None:
     image_file = io.BytesIO(decoded)
     pil_image = Image.open(image_file)
 
-    if pil_image.format in ("PNG", "JPEG"):
+    if pil_image.format in {"PNG", "JPEG"}:
         return
 
     _LOGGER.warning(msg="The image is not a PNG or JPEG.")
@@ -74,7 +74,7 @@ def validate_image_color_space(request_body: bytes) -> None:
     image_file = io.BytesIO(decoded)
     pil_image = Image.open(image_file)
 
-    if pil_image.mode in ("L", "RGB"):
+    if pil_image.mode in {"L", "RGB"}:
         return
 
     _LOGGER.warning(

--- a/src/mock_vws/_services_validators/json_validators.py
+++ b/src/mock_vws/_services_validators/json_validators.py
@@ -34,7 +34,7 @@ def validate_body_given(request_body: bytes, request_method: str) -> None:
     if not request_body:
         return
 
-    if request_method not in (POST, PUT):
+    if request_method not in {POST, PUT}:
         _LOGGER.warning(
             msg=(
                 "A request body was given for an endpoint which does not "
@@ -45,7 +45,15 @@ def validate_body_given(request_body: bytes, request_method: str) -> None:
 
 
 def validate_json(request_body: bytes) -> None:
-    """Validate that any given body is valid JSON."""
+    """
+    Validate that any given body is valid JSON.
+
+    Args:
+        request_body: The body of the request.
+
+    Raises:
+        Fail: The request body includes invalid JSON.
+    """
     if not request_body:
         return
 

--- a/src/mock_vws/_services_validators/key_validators.py
+++ b/src/mock_vws/_services_validators/key_validators.py
@@ -133,12 +133,12 @@ def validate_keys(
         target_summary,
     )
 
-    [matching_route] = [
+    (matching_route,) = (
         route
         for route in routes
-        if re.match(re.compile(route.path_pattern + "$"), request_path)
+        if re.match(re.compile(f"{route.path_pattern}$"), request_path)
         and request_method in route.http_methods
-    ]
+    )
 
     mandatory_keys = matching_route.mandatory_keys
     optional_keys = matching_route.optional_keys

--- a/src/mock_vws/_services_validators/name_validators.py
+++ b/src/mock_vws/_services_validators/name_validators.py
@@ -222,7 +222,7 @@ def validate_name_does_not_exist_existing_target(
     if not matching_name_targets:
         return
 
-    [matching_name_target] = matching_name_targets
+    (matching_name_target,) = matching_name_targets
     if matching_name_target.target_id == target_id:
         return
 

--- a/src/mock_vws/_services_validators/target_validators.py
+++ b/src/mock_vws/_services_validators/target_validators.py
@@ -50,11 +50,11 @@ def validate_target_id_exists(
     assert isinstance(database, VuforiaDatabase)
 
     try:
-        [_] = [
+        (_,) = (
             target
             for target in database.not_deleted_targets
             if target.target_id == target_id
-        ]
+        )
     except ValueError as exc:
         _LOGGER.warning('The target ID "%s" does not exist.', target_id)
         raise UnknownTarget from exc

--- a/src/mock_vws/database.py
+++ b/src/mock_vws/database.py
@@ -93,9 +93,9 @@ class VuforiaDatabase:
         """
         Return a target from the database with the given ID.
         """
-        [target] = [
+        (target,) = (
             target for target in self.targets if target.target_id == target_id
-        ]
+        )
         return target
 
     @classmethod

--- a/src/mock_vws/target_raters.py
+++ b/src/mock_vws/target_raters.py
@@ -27,16 +27,18 @@ def _get_brisque_target_tracking_rating(image_content: bytes) -> int:
     image_file = io.BytesIO(initial_bytes=image_content)
     image = Image.open(fp=image_file)
     image_array = np.asarray(a=image)
-    obj = brisque.BRISQUE(url=False)
+    brisque_obj = brisque.BRISQUE(url=False)
     # We avoid a barrage of warnings from the BRISQUE library.
     with np.errstate(divide="ignore", invalid="ignore"):
         try:
-            score = obj.score(img=image_array)
+            score = brisque_obj.score(img=image_array)
         except (cv2.error, ValueError):  # pylint: disable=no-member
             return 0
     if math.isnan(score):
         return 0
-    return int(score / 20)
+    brisque_max_score = 100
+    tracking_rating_max = 5
+    return int(score / (brisque_max_score / tracking_rating_max))
 
 
 @runtime_checkable

--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -230,6 +230,9 @@ def verify_mock_vuforia(
     real Vuforia, and once with each mock.
 
     This is useful for verifying the mocks.
+
+    Yields:
+        ``None``.
     """
     backend = request.param
     should_skip = request.config.getoption(f"--skip-{backend.name.lower()}")

--- a/tests/mock_vws/test_add_target.py
+++ b/tests/mock_vws/test_add_target.py
@@ -15,7 +15,6 @@ import pytest
 import requests
 from dirty_equals import IsInstance
 from mock_vws._constants import ResultCodes
-from requests import Response
 from requests.structures import CaseInsensitiveDict
 from requests_mock import POST
 from vws_auth_tools import authorization_header, rfc_1123_date
@@ -40,7 +39,7 @@ def add_target_to_vws(
     vuforia_database: VuforiaDatabase,
     data: dict[str, Any],
     content_type: str = "application/json",
-) -> Response:
+) -> requests.Response:
     """
     Return a response from a request to the endpoint to add a target.
 
@@ -82,7 +81,7 @@ def add_target_to_vws(
     )
 
 
-def _assert_oops_response(response: Response) -> None:
+def _assert_oops_response(response: requests.Response) -> None:
     """
     Assert that the response is in the format of Vuforia's "Oops, an error
     occurred" HTML response.
@@ -109,7 +108,7 @@ def _assert_oops_response(response: Response) -> None:
     assert response.headers == expected_headers
 
 
-def assert_success(response: Response) -> None:
+def assert_success(response: requests.Response) -> None:
     """
     Assert that the given response is a success response for adding a
     target.
@@ -360,8 +359,8 @@ class TestTargetName:
 
     @staticmethod
     @pytest.mark.parametrize(
-        ("name", "status_code"),
-        [
+        argnames=("name", "status_code"),
+        argvalues=[
             (1, HTTPStatus.BAD_REQUEST),
             ("", HTTPStatus.BAD_REQUEST),
             ("a" * (_MAX_NAME_LENGTH + 1), HTTPStatus.BAD_REQUEST),
@@ -974,7 +973,7 @@ class TestApplicationMetadata:
         image_data = image_file_failed_state.read()
         image_data_encoded = base64.b64encode(image_data).decode("ascii")
 
-        data = {
+        request_data = {
             "name": "example_name",
             "width": 1,
             "image": image_data_encoded,
@@ -983,7 +982,7 @@ class TestApplicationMetadata:
 
         response = add_target_to_vws(
             vuforia_database=vuforia_database,
-            data=data,
+            data=request_data,
         )
 
         assert_success(response=response)

--- a/tests/mock_vws/test_content_length.py
+++ b/tests/mock_vws/test_content_length.py
@@ -105,7 +105,7 @@ class TestIncorrect:
 
         assert_valid_date_header(response=response)
         # We have seen both of these response texts.
-        assert response.text in ("stream timeout", "")
+        assert response.text in {"stream timeout", ""}
         expected_headers = {
             "content-length": str(len(response.text)),
             "connection": "close",

--- a/tests/mock_vws/test_database_summary.py
+++ b/tests/mock_vws/test_database_summary.py
@@ -48,7 +48,7 @@ def _wait_for_image_numbers(
         processing_images: The expected number of processing images.
 
     Raises:
-        Exception: The numbers of images in various categories do not match
+        ValueError: The numbers of images in various categories do not match
             within the time limit.
     """
     requirements = {

--- a/tests/mock_vws/test_docker.py
+++ b/tests/mock_vws/test_docker.py
@@ -42,11 +42,11 @@ def wait_for_flask_app_to_start(base_url: str) -> None:  # pragma: no cover
         except requests.exceptions.ConnectionError:
             time.sleep(sleep_seconds)
         else:
-            if response.status_code in (
+            if response.status_code in {
                 HTTPStatus.NOT_FOUND,
                 HTTPStatus.UNAUTHORIZED,
                 HTTPStatus.FORBIDDEN,
-            ):
+            }:
                 return
     error_message = (
         f"Could not connect to {url} after "
@@ -62,6 +62,9 @@ def fixture_custom_bridge_network() -> Iterator[Network]:
 
     This also cleans up all containers connected to the network and the network
     after the test.
+
+    Yields:
+        A custom bridge network.
     """
     client = docker.from_env()
     try:
@@ -200,11 +203,7 @@ def test_build_and_run(
         f"http://{task_manager_host_ip}:{task_manager_host_port}"
     )
 
-    for base_url in (
-        base_vws_url,
-        base_vwq_url,
-        base_task_manager_url,
-    ):
+    for base_url in (base_vws_url, base_vwq_url, base_task_manager_url):
         wait_for_flask_app_to_start(base_url=base_url)
 
     response = requests.post(

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -427,7 +427,7 @@ class TestQueryImageMatchers:
         different_image_result = cloud_reco_client.query(
             image=re_exported_image,
         )
-        assert len(different_image_result) == 0
+        assert not different_image_result
 
     @staticmethod
     def test_average_hash_matcher(
@@ -473,7 +473,7 @@ class TestQueryImageMatchers:
         different_image_result = cloud_reco_client.query(
             image=different_high_quality_image,
         )
-        assert len(different_image_result) == 0
+        assert not different_image_result
 
 
 class TestDuplicatesImageMatchers:

--- a/tests/mock_vws/test_target_list.py
+++ b/tests/mock_vws/test_target_list.py
@@ -37,7 +37,7 @@ class TestTargetList:
         """
         vws_client.wait_for_target_processed(target_id=target_id)
         vws_client.delete_target(target_id=target_id)
-        assert vws_client.list_targets() == []
+        assert not vws_client.list_targets()
 
 
 @pytest.mark.usefixtures("verify_mock_vuforia")

--- a/tests/mock_vws/test_target_summary.py
+++ b/tests/mock_vws/test_target_summary.py
@@ -62,10 +62,10 @@ class TestTargetSummary:
         # In case the date changes while adding a target
         # we allow the date before and after adding the target.
 
-        assert report.upload_date in (
+        assert report.upload_date in {
             date_before_add_target,
             date_after_add_target,
-        )
+        }
 
         # While processing the tracking rating is -1.
         assert report.tracking_rating == -1
@@ -75,8 +75,8 @@ class TestTargetSummary:
 
     @staticmethod
     @pytest.mark.parametrize(
-        ("image_fixture_name", "expected_status"),
-        [
+        argnames=("image_fixture_name", "expected_status"),
+        argvalues=[
             ("high_quality_image", TargetStatuses.SUCCESS),
             ("image_file_failed_state", TargetStatuses.FAILED),
         ],
@@ -153,7 +153,7 @@ class TestRecognitionCounts:
         vws_client.wait_for_target_processed(target_id=target_id)
 
         results = cloud_reco_client.query(image=high_quality_image)
-        [result] = results
+        (result,) = results
         assert result.target_id == target_id
 
         report = vws_client.get_target_summary_report(target_id=target_id)

--- a/tests/mock_vws/test_update_target.py
+++ b/tests/mock_vws/test_update_target.py
@@ -14,7 +14,6 @@ from urllib.parse import urljoin
 import pytest
 import requests
 from mock_vws._constants import ResultCodes
-from requests import Response
 from requests_mock import PUT
 from vws.exceptions.vws_exceptions import BadImage, ProjectInactive
 from vws.reports import TargetStatuses
@@ -40,7 +39,7 @@ def update_target(
     data: dict[str, Any],
     target_id: str,
     content_type: str = "application/json",
-) -> Response:
+) -> requests.Response:
     """
     Make a request to the endpoint to update a target.
 
@@ -517,8 +516,8 @@ class TestTargetName:
 
     @staticmethod
     @pytest.mark.parametrize(
-        ("name", "status_code", "result_code"),
-        [
+        argnames=("name", "status_code", "result_code"),
+        argvalues=[
             (1, HTTPStatus.BAD_REQUEST, ResultCodes.FAIL),
             ("", HTTPStatus.BAD_REQUEST, ResultCodes.FAIL),
             (

--- a/tests/mock_vws/utils/__init__.py
+++ b/tests/mock_vws/utils/__init__.py
@@ -93,7 +93,7 @@ def make_image_file(
                 grey = random.choice(seq=range(0, 255))
                 image.putpixel(xy=(column_index, row_index), value=grey)
             else:
-                assert color_space in ("CMYK", "RGB")
+                assert color_space in {"CMYK", "RGB"}
                 red = random.choice(seq=range(0, 255))
                 green = random.choice(seq=range(0, 255))
                 blue = random.choice(seq=range(0, 255))

--- a/tests/mock_vws/utils/assertions.py
+++ b/tests/mock_vws/utils/assertions.py
@@ -182,7 +182,7 @@ def assert_query_success(response: Response) -> None:
     # In the real Vuforia, some do and some do not.
     # We are not sure why.
     content_encoding = copied_response_headers.pop("Content-Encoding", None)
-    assert content_encoding in (None, "gzip")
+    assert content_encoding in {None, "gzip"}
 
     expected_response_header_not_chunked = {
         "Connection": "keep-alive",


### PR DESCRIPTION
This passes with `pip install wemake-python-styleguide` and:

```
flake8 --ignore=Q000,WPS305,I001,N818,D400,D200,D205,I005,WPS226,WPS326,WPS204,WPS323,WPS306,WPS115,S311,WPS300,WPS337,S101,WPS602,I003,DAR101,WPS436,WPS210,WPS460,WPS529,WPS201,WPS211,DAR201,S105,S106,RST301,WPS238,W503,WPS441,WPS214,WPS231,WPS213,WPS202,RST215,WPS432,WPS428,WPS237,D401,WPS218,I004,WPS336,WPS114,WPS110,WPS236,WPS520,WPS605,WPS450,WPS316,WPS334,DAR003,WPS429,DAR402,WPS510,S404,WPS462,WPS412,WPS410,WPS331 .
```

I chose to ignore rules which seemed to get in the way. Not putting this in CI as it is very slow.