### PR TITLE
Revert "Bump pytest from 8.0.2 to 8.1.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,7 +313,7 @@ dev = [
     "pyproject-fmt==1.7.0",
     "pyright==1.1.352",
     "pyroma==4.2",
-    "pytest==8.1.0",
+    "pytest==8.0.2",
     "pytest-cov==4.1",
     "pytest-retry==1.6.2",
     "pytest-xdist==3.5.0",


### PR DESCRIPTION
Reverts VWS-Python/vws-python-mock#1962

8.1.0 has been yanked