### PR TITLE
Add trailing commas from COM812 suggestions

### DIFF
--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -274,7 +274,8 @@ def get_target(target_id: str) -> Response:
 
 
 @VWS_FLASK_APP.route(
-    "/targets/<string:target_id>", methods=[HTTPMethod.DELETE]
+    "/targets/<string:target_id>",
+    methods=[HTTPMethod.DELETE],
 )
 def delete_target(target_id: str) -> Response:
     """
@@ -433,7 +434,8 @@ def target_summary(target_id: str) -> Response:
 
 
 @VWS_FLASK_APP.route(
-    "/duplicates/<string:target_id>", methods=[HTTPMethod.GET]
+    "/duplicates/<string:target_id>",
+    methods=[HTTPMethod.GET],
 )
 def get_duplicates(target_id: str) -> Response:
     """

--- a/src/mock_vws/_services_validators/content_type_validators.py
+++ b/src/mock_vws/_services_validators/content_type_validators.py
@@ -26,7 +26,7 @@ def validate_content_type_header_given(
             request requires one.
     """
     request_needs_content_type = bool(
-        request_method in {HTTPMethod.POST, HTTPMethod.PUT}
+        request_method in {HTTPMethod.POST, HTTPMethod.PUT},
     )
     if request_headers.get("Content-Type") or not request_needs_content_type:
         return

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -293,7 +293,8 @@ class TestQueryImageMatchers:
     ) -> None:
         """The structural similarity matcher matches similar images."""
         monkeypatch.setenv(
-            name="QUERY_IMAGE_MATCHER", value="structural_similarity"
+            name="QUERY_IMAGE_MATCHER",
+            value="structural_similarity",
         )
         database = VuforiaDatabase()
         vws_client = VWS(

--- a/tests/mock_vws/test_query.py
+++ b/tests/mock_vws/test_query.py
@@ -1773,7 +1773,7 @@ class TestUpdate:
         # second.
         assert target_timestamp >= original_target_timestamp
         time_difference = abs(
-            approximate_target_updated - target_timestamp.timestamp()
+            approximate_target_updated - target_timestamp.timestamp(),
         )
         max_time_difference = 5
         assert time_difference < max_time_difference


### PR DESCRIPTION
Do not enable the rule as Ruff complains that it can conflict with the formatter.