### PR TITLE
Remove torchvision dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,15 +39,14 @@ dependencies = [
     "flask",
     # Pin numpy to avoid:
     # https://github.com/pytorch/pytorch/issues/128860
-    # When we remove this, also remove the deptry ignore.
-    "numpy<2.0.0; sys_platform=='win32'",
+    "numpy<2.0.0",
     "pillow",
     "piq",
     "pydantic-settings",
     "requests",
     "requests-mock",
+    "torch",
     "torchmetrics",
-    "torchvision",
     "tzdata; sys_platform=='win32'",
     "vws-auth-tools",
     "werkzeug",
@@ -313,9 +312,6 @@ DEP002 = [
     # tzdata is needed on Windows for zoneinfo to work.
     # See https://docs.python.org/3/library/zoneinfo.html#data-sources.
     "tzdata",
-    # numpy is pinned to avoid:
-    # https://github.com/pytorch/pytorch/issues/128860.
-    "numpy",
 ]
 
 [tool.pyproject-fmt]

--- a/src/mock_vws/image_matchers.py
+++ b/src/mock_vws/image_matchers.py
@@ -3,11 +3,12 @@
 import io
 from typing import Protocol, runtime_checkable
 
+import numpy as np
+import torch
 from PIL import Image
 from torchmetrics.image import (
     StructuralSimilarityIndexMeasure,
 )
-from torchvision import transforms  # type: ignore[import-untyped]
 
 
 @runtime_checkable
@@ -74,13 +75,18 @@ class StructuralSimilarityMatcher:
         first_image = first_image.resize(size=target_size)
         second_image = second_image.resize(size=target_size)
 
-        transform = transforms.ToTensor()
+        first_image_np = np.array(first_image, dtype=np.float32)
+        first_image_tensor = torch.tensor(first_image_np).float() / 255
 
-        first_image_tensor = transform(pic=first_image)
-        second_image_tensor = transform(pic=second_image)
+        second_image_np = np.array(second_image, dtype=np.float32)
+        second_image_tensor = torch.tensor(second_image_np).float() / 255
 
-        first_image_tensor_batch_dimension = first_image_tensor.unsqueeze(0)
-        second_image_tensor_batch_dimension = second_image_tensor.unsqueeze(0)
+        first_image_tensor_batch_dimension = first_image_tensor.permute(
+            2, 0, 1
+        ).unsqueeze(0)
+        second_image_tensor_batch_dimension = second_image_tensor.permute(
+            2, 0, 1
+        ).unsqueeze(0)
 
         ssim = StructuralSimilarityIndexMeasure(data_range=1.0)
         ssim_value = ssim(

--- a/src/mock_vws/image_matchers.py
+++ b/src/mock_vws/image_matchers.py
@@ -77,15 +77,29 @@ class StructuralSimilarityMatcher:
 
         first_image_np = np.array(first_image, dtype=np.float32)
         first_image_tensor = torch.tensor(first_image_np).float() / 255
+        first_image_tensor = first_image_tensor.view(
+            first_image.size[1],
+            first_image.size[0],
+            len(first_image.getbands()),
+        )
 
         second_image_np = np.array(second_image, dtype=np.float32)
         second_image_tensor = torch.tensor(second_image_np).float() / 255
+        second_image_tensor = second_image_tensor.view(
+            second_image.size[1],
+            second_image.size[0],
+            len(second_image.getbands()),
+        )
 
         first_image_tensor_batch_dimension = first_image_tensor.permute(
-            2, 0, 1
+            2,
+            0,
+            1,
         ).unsqueeze(0)
         second_image_tensor_batch_dimension = second_image_tensor.permute(
-            2, 0, 1
+            2,
+            0,
+            1,
         ).unsqueeze(0)
 
         ssim = StructuralSimilarityIndexMeasure(data_range=1.0)

--- a/src/mock_vws/target_raters.py
+++ b/src/mock_vws/target_raters.py
@@ -28,6 +28,11 @@ def _get_brisque_target_tracking_rating(image_content: bytes) -> int:
     image = Image.open(fp=image_file)
     image_np = np.array(image, dtype=np.float32)
     image_tensor = torch.tensor(image_np).float() / 255
+    image_tensor = image_tensor.view(
+        image.size[1],
+        image.size[0],
+        len(image.getbands()),
+    )
     image_tensor = image_tensor.permute(2, 0, 1).unsqueeze(0)
     try:
         brisque_score = piq.brisque(x=image_tensor, data_range=255)

--- a/src/mock_vws/target_raters.py
+++ b/src/mock_vws/target_raters.py
@@ -6,9 +6,10 @@ import math
 import secrets
 from typing import Protocol, runtime_checkable
 
+import numpy as np
 import piq  # type: ignore[import-untyped]
+import torch
 from PIL import Image
-from torchvision import transforms  # type: ignore[import-untyped]
 
 
 @functools.cache
@@ -25,9 +26,9 @@ def _get_brisque_target_tracking_rating(image_content: bytes) -> int:
     """
     image_file = io.BytesIO(initial_bytes=image_content)
     image = Image.open(fp=image_file)
-    transform = transforms.ToTensor()
-    image_tensor = transform(pic=image)
-    image_tensor = image_tensor.unsqueeze(0)
+    image_np = np.array(image, dtype=np.float32)
+    image_tensor = torch.tensor(image_np).float() / 255
+    image_tensor = image_tensor.permute(2, 0, 1).unsqueeze(0)
     try:
         brisque_score = piq.brisque(x=image_tensor, data_range=255)
     except (AssertionError, IndexError):


### PR DESCRIPTION
It doesn't ship type hints, and doesn't look like it will soon. Part of the journey towards more type-safe code.