### PR TITLE
Use keyword args for base64.b64encode calls

### DIFF
--- a/tests/mock_vws/fixtures/prepared_requests.py
+++ b/tests/mock_vws/fixtures/prepared_requests.py
@@ -51,7 +51,7 @@ def add_target(
     Return details of the endpoint for adding a target.
     """
     image_data = image_file_failed_state.read()
-    image_data_encoded = base64.b64encode(image_data).decode("ascii")
+    image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
     date = rfc_1123_date()
     data: dict[str, Any] = {
         "name": "example_name",

--- a/tests/mock_vws/test_add_target.py
+++ b/tests/mock_vws/test_add_target.py
@@ -166,7 +166,7 @@ class TestContentTypes:
         Any non-empty ``Content-Type`` header is allowed.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example",
@@ -192,7 +192,7 @@ class TestContentTypes:
         header is given.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example",
@@ -230,7 +230,7 @@ class TestMissingData:
         `name`, `width` and `image` are all required.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -272,7 +272,7 @@ class TestWidth:
         The width must be a number greater than zero.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -300,7 +300,7 @@ class TestWidth:
         Positive numbers are valid widths.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example",
@@ -348,7 +348,7 @@ class TestTargetName:
         Names between 1 and 64 characters in length are valid.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": name,
@@ -398,7 +398,7 @@ class TestTargetName:
         in a particular range.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": name,
@@ -437,7 +437,7 @@ class TestTargetName:
         Only one target can have a given name.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -471,7 +471,7 @@ class TestTargetName:
         A target can be added with the name of a deleted target.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -516,7 +516,7 @@ class TestImage:
         """
         image_file = image_files_failed_state
         image_data = image_file.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example",
@@ -543,7 +543,7 @@ class TestImage:
         greyscale or RGB color space.
         """
         image_data = bad_image_file.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -571,7 +571,7 @@ class TestImage:
         No error is returned when the given image is corrupted.
         """
         image_data = corrupted_image_file.getvalue()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -604,7 +604,7 @@ class TestImage:
         )
 
         image_data = png_not_too_large.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
         image_content_size = len(image_data)
         # We check that the image we created is just slightly smaller than the
         # maximum file size.
@@ -637,7 +637,7 @@ class TestImage:
         )
 
         image_data = png_too_large.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
         image_content_size = len(image_data)
         # We check that the image we created is just slightly smaller than the
         # maximum file size.
@@ -728,7 +728,7 @@ class TestImage:
         returned.
         """
         not_image_data = b"not_image_data"
-        image_data_encoded = base64.b64encode(not_image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=not_image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -791,7 +791,7 @@ class TestActiveFlag:
         Boolean values and NULL are valid active flags.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
         content_type = "application/json"
 
         data = {
@@ -819,7 +819,7 @@ class TestActiveFlag:
         """
         active_flag = "string"
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
         content_type = "application/json"
 
         data = {
@@ -851,7 +851,7 @@ class TestActiveFlag:
         The active flag defaults to True if it is not set.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "my_example_name",
@@ -878,7 +878,7 @@ class TestActiveFlag:
         The active flag defaults to True if it is set to NULL.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "my_example_name",
@@ -912,7 +912,7 @@ class TestUnexpectedData:
         A `BAD_REQUEST` response is returned when unexpected data is given.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -957,8 +957,8 @@ class TestApplicationMetadata:
         A base64 encoded string is valid application metadata.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
-        metadata_encoded = base64.b64encode(metadata).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
+        metadata_encoded = base64.b64encode(s=metadata).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -983,7 +983,7 @@ class TestApplicationMetadata:
         NULL is valid application metadata.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         request_data = {
             "name": "example_name",
@@ -1009,7 +1009,7 @@ class TestApplicationMetadata:
         metadata.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -1040,7 +1040,7 @@ class TestApplicationMetadata:
         application metadata.
         """
         image_content = high_quality_image.getvalue()
-        image_data_encoded = base64.b64encode(image_content).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_content).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -1067,7 +1067,7 @@ class TestApplicationMetadata:
         as application metadata.
         """
         image_content = high_quality_image.getvalue()
-        image_data_encoded = base64.b64encode(image_content).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_content).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -1097,9 +1097,9 @@ class TestApplicationMetadata:
         for application metadata.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
         metadata = b"a" * (_MAX_METADATA_BYTES + 1)
-        metadata_encoded = base64.b64encode(metadata).decode("ascii")
+        metadata_encoded = base64.b64encode(s=metadata).decode("ascii")
 
         data = {
             "name": "example_name",
@@ -1135,7 +1135,7 @@ class TestInactiveProject:
         If the project is inactive, a FORBIDDEN response is returned.
         """
         image_data = image_file_failed_state.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         data = {
             "name": "example",

--- a/tests/mock_vws/test_query.py
+++ b/tests/mock_vws/test_query.py
@@ -512,7 +512,7 @@ class TestSuccess:
         """
         image_file = high_quality_image
         image_content = image_file.getvalue()
-        metadata_encoded = base64.b64encode(b"example").decode("ascii")
+        metadata_encoded = base64.b64encode(s=b"example").decode("ascii")
         name = "example_name"
 
         target_id = vws_client.add_target(
@@ -557,7 +557,7 @@ class TestSuccess:
         results are returned.
         """
         image_file = image_file_success_state_low_rating
-        metadata_encoded = base64.b64encode(b"example").decode("ascii")
+        metadata_encoded = base64.b64encode(s=b"example").decode("ascii")
         name = "example_name"
 
         target_id = vws_client.add_target(
@@ -583,7 +583,7 @@ class TestSuccess:
         If a similar image to one that was added is queried for, target data is
         shown.
         """
-        metadata_encoded = base64.b64encode(b"example").decode("ascii")
+        metadata_encoded = base64.b64encode(s=b"example").decode("ascii")
         name_matching = "example_name_matching"
         name_not_matching = "example_name_not_matching"
 
@@ -1725,7 +1725,7 @@ class TestUpdate:
         metadata.
         """
         metadata = b"example_metadata"
-        metadata_encoded = base64.b64encode(metadata).decode("ascii")
+        metadata_encoded = base64.b64encode(s=metadata).decode("ascii")
         name = "example_name"
         target_id = vws_client.add_target(
             name=name,
@@ -1741,7 +1741,7 @@ class TestUpdate:
 
         new_name = name + "2"
         new_metadata = metadata + b"2"
-        new_metadata_encoded = base64.b64encode(new_metadata).decode("ascii")
+        new_metadata_encoded = base64.b64encode(s=new_metadata).decode("ascii")
 
         results = cloud_reco_client.query(image=high_quality_image)
         (result,) = results

--- a/tests/mock_vws/test_update_target.py
+++ b/tests/mock_vws/test_update_target.py
@@ -371,7 +371,7 @@ class TestApplicationMetadata:
         """
         A base64 encoded string is valid application metadata.
         """
-        metadata_encoded = base64.b64encode(metadata).decode("ascii")
+        metadata_encoded = base64.b64encode(s=metadata).decode("ascii")
         vws_client.wait_for_target_processed(target_id=target_id)
         vws_client.update_target(
             target_id=target_id,
@@ -464,7 +464,7 @@ class TestApplicationMetadata:
         for application metadata.
         """
         metadata = b"a" * (_MAX_METADATA_BYTES + 1)
-        metadata_encoded = base64.b64encode(metadata).decode("ascii")
+        metadata_encoded = base64.b64encode(s=metadata).decode("ascii")
         vws_client.wait_for_target_processed(target_id=target_id)
 
         response = _update_target(
@@ -676,7 +676,7 @@ class TestImage:
         """
         image_file = image_files_failed_state
         image_data = image_file.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
 
         vws_client.wait_for_target_processed(target_id=target_id)
 
@@ -747,7 +747,7 @@ class TestImage:
         vws_client.wait_for_target_processed(target_id=target_id)
 
         image_data = png_not_too_large.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
         image_content_size = len(image_data)
         # We check that the image we created is just slightly smaller than the
         # maximum file size.
@@ -781,7 +781,7 @@ class TestImage:
         )
 
         image_data = png_too_large.read()
-        image_data_encoded = base64.b64encode(image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=image_data).decode("ascii")
         image_content_size = len(image_data)
         # We check that the image we created is just slightly smaller than the
         # maximum file size.
@@ -867,7 +867,7 @@ class TestImage:
         returned.
         """
         not_image_data = b"not_image_data"
-        image_data_encoded = base64.b64encode(not_image_data).decode("ascii")
+        image_data_encoded = base64.b64encode(s=not_image_data).decode("ascii")
 
         vws_client.wait_for_target_processed(target_id=target_id)
 
@@ -924,7 +924,9 @@ class TestImage:
         is different to the old quality.
         """
         good_image = high_quality_image.read()
-        good_image_data_encoded = base64.b64encode(good_image).decode("ascii")
+        good_image_data_encoded = base64.b64encode(s=good_image).decode(
+            "ascii"
+        )
 
         target_id = vws_client.add_target(
             name=uuid.uuid4().hex,


### PR DESCRIPTION
This is useful for having the type checker be more precise with errors