### PR TITLE
Switch to responses from requests_mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "piq",
     "pydantic-settings",
     "requests",
-    "requests-mock",
+    "responses",
     "torch",
     "torchmetrics",
     "tzdata; sys_platform=='win32'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ optional-dependencies.dev = [
     "pytest-xdist==3.6.1",
     "python-dotenv==1.0.1",
     "pyyaml==6.0.2",
-    "requests-mock-flask==2024.8.30",
+    "requests-mock-flask==2024.8.30.1",
     "ruff==0.6.2",
     "sphinx==8.0.2",
     "sphinx-copybutton==0.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ optional-dependencies.dev = [
     "pytest-xdist==3.6.1",
     "python-dotenv==1.0.1",
     "pyyaml==6.0.2",
-    "requests-mock-flask==2023.5.14",
+    "requests-mock-flask==2024.8.30",
     "ruff==0.6.2",
     "sphinx==8.0.2",
     "sphinx-copybutton==0.5.2",

--- a/src/mock_vws/_requests_mock_server/__init__.py
+++ b/src/mock_vws/_requests_mock_server/__init__.py
@@ -1,3 +1,3 @@
 """
-An interface to the mock Vuforia which uses ``requests_mock``.
+An interface to the mock Vuforia which uses ``responses``.
 """

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -152,12 +152,8 @@ class MockVWS(ContextDecorator):
                 )
 
         if self._real_http:
-            combined_pattern = "|".join(
-                f"(?:{pattern.pattern})" for pattern in compiled_url_patterns
-            )
-            negated_pattern = f"(?!{combined_pattern})."
-            compiled_negated_pattern = re.compile(pattern=negated_pattern)
-            mock.add_passthru(prefix=compiled_negated_pattern)
+            all_requests_pattern = re.compile(pattern=".*")
+            mock.add_passthru(prefix=all_requests_pattern)
 
         self._mock = mock
         self._mock.start()

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -8,7 +8,7 @@ from typing import Literal, Self, SupportsFloat
 from urllib.parse import urljoin, urlparse
 
 import requests
-from requests_mock.mocker import Mocker
+from responses import RequestsMock
 
 from mock_vws.database import VuforiaDatabase
 from mock_vws.image_matchers import (
@@ -69,7 +69,7 @@ class MockVWS(ContextDecorator):
         """
         super().__init__()
         self._real_http = real_http
-        self._mock: Mocker
+        self._mock: RequestsMock
         self._target_manager = TargetManager()
 
         self._base_vws_url = base_vws_url
@@ -116,18 +116,24 @@ class MockVWS(ContextDecorator):
         Returns:
             ``self``.
         """
-        with Mocker(real_http=self._real_http) as mock:
+        compiled_url_patterns: set[re.Pattern[str]] = set()
+
+        with RequestsMock(assert_all_requests_are_fired=False) as mock:
             for vws_route in self._mock_vws_api.routes:
                 url_pattern = urljoin(
                     base=self._base_vws_url,
                     url=f"{vws_route.path_pattern}$",
                 )
+                compiled_url_pattern = re.compile(pattern=url_pattern)
+                compiled_url_patterns.add(compiled_url_pattern)
 
                 for vws_http_method in vws_route.http_methods:
-                    mock.register_uri(
+                    mock.add_callback(
                         method=vws_http_method,
-                        url=re.compile(url_pattern),
-                        text=getattr(self._mock_vws_api, vws_route.route_name),
+                        url=compiled_url_pattern,
+                        callback=getattr(
+                            self._mock_vws_api, vws_route.route_name
+                        ),
                     )
 
             for vwq_route in self._mock_vwq_api.routes:
@@ -135,16 +141,22 @@ class MockVWS(ContextDecorator):
                     base=self._base_vwq_url,
                     url=f"{vwq_route.path_pattern}$",
                 )
+                compiled_url_pattern = re.compile(pattern=url_pattern)
+                compiled_url_patterns.add(compiled_url_pattern)
 
                 for vwq_http_method in vwq_route.http_methods:
-                    mock.register_uri(
+                    mock.add_callback(
                         method=vwq_http_method,
-                        url=re.compile(url_pattern),
-                        text=getattr(self._mock_vwq_api, vwq_route.route_name),
+                        url=compiled_url_pattern,
+                        callback=getattr(
+                            self._mock_vwq_api, vwq_route.route_name
+                        ),
                     )
 
-        self._mock = mock
-        self._mock.start()
+            if self._real_http:
+                mock.add_passthru(prefix=re.compile(".*"))
+            self._mock = mock
+            self._mock.start()
 
         return self
 

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -132,6 +132,7 @@ class MockVWS(ContextDecorator):
                     method=vws_http_method,
                     url=compiled_url_pattern,
                     callback=getattr(self._mock_vws_api, vws_route.route_name),
+                    content_type=None,
                 )
 
         for vwq_route in self._mock_vwq_api.routes:
@@ -147,6 +148,7 @@ class MockVWS(ContextDecorator):
                     method=vwq_http_method,
                     url=compiled_url_pattern,
                     callback=getattr(self._mock_vwq_api, vwq_route.route_name),
+                    content_type=None,
                 )
 
         if self._real_http:

--- a/src/mock_vws/_requests_mock_server/mock_web_query_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_query_api.py
@@ -8,7 +8,6 @@ https://developer.vuforia.com/library/web-api/vuforia-query-web-api
 import email.utils
 from collections.abc import Callable
 from http import HTTPMethod
-from typing import TYPE_CHECKING
 
 from mock_vws._mock_common import Route
 from mock_vws._query_tools import (
@@ -20,11 +19,6 @@ from mock_vws._query_validators.exceptions import (
 )
 from mock_vws.image_matchers import ImageMatcher
 from mock_vws.target_manager import TargetManager
-
-if TYPE_CHECKING:
-    from requests_mock.request import Request
-    from requests_mock.response import Context
-
 
 _ROUTES: set[Route] = set()
 
@@ -77,7 +71,7 @@ class MockVuforiaWebQueryAPI:
     """
     A fake implementation of the Vuforia Web Query API.
 
-    This implementation is tied to the implementation of `requests_mock`.
+    This implementation is tied to the implementation of ``responses``.
     """
 
     def __init__(

--- a/src/mock_vws/_requests_mock_server/mock_web_query_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_query_api.py
@@ -7,7 +7,9 @@ https://developer.vuforia.com/library/web-api/vuforia-query-web-api
 
 import email.utils
 from collections.abc import Callable
-from http import HTTPMethod
+from http import HTTPMethod, HTTPStatus
+
+from requests.models import PreparedRequest
 
 from mock_vws._mock_common import Route
 from mock_vws._query_tools import (
@@ -22,7 +24,7 @@ from mock_vws.target_manager import TargetManager
 
 _ROUTES: set[Route] = set()
 
-_ResponseType = str
+_ResponseType = tuple[int, dict[str, str], str]
 
 
 def route(
@@ -64,11 +66,15 @@ def route(
     return decorator
 
 
-def _body_bytes(request: "Request") -> bytes:
+def _body_bytes(request: PreparedRequest) -> bytes:
     """
     Return the body of a request as bytes.
     """
-    return request.body or b""
+    if request.body is None:
+        return b""
+
+    assert isinstance(request.body, bytes)
+    return request.body
 
 
 class MockVuforiaWebQueryAPI:
@@ -97,28 +103,26 @@ class MockVuforiaWebQueryAPI:
         self._query_match_checker = query_match_checker
 
     @route(path_pattern="/v1/query", http_methods={HTTPMethod.POST})
-    def query(self, request: "Request", context: "Context") -> _ResponseType:
+    def query(self, request: PreparedRequest) -> _ResponseType:
         """
         Perform an image recognition query.
         """
         try:
             run_query_validators(
-                request_path=request.path,
+                request_path=request.path_url,
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
-                request_method=request.method,
+                request_method=request.method or "",
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
-            context.headers = exc.headers
-            context.status_code = exc.status_code
-            return exc.response_text
+            return exc.status_code, exc.headers, exc.response_text
 
         response_text = get_query_match_response_text(
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
-            request_method=request.method,
-            request_path=request.path,
+            request_method=request.method or "",
+            request_path=request.path_url,
             databases=self._target_manager.databases,
             query_match_checker=self._query_match_checker,
         )
@@ -128,11 +132,11 @@ class MockVuforiaWebQueryAPI:
             localtime=False,
             usegmt=True,
         )
-        context.headers = {
+        headers = {
             "Connection": "keep-alive",
             "Content-Type": "application/json",
             "Server": "nginx",
             "Date": date,
             "Content-Length": str(len(response_text)),
         }
-        return response_text
+        return HTTPStatus.OK, headers, response_text

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -9,11 +9,15 @@ import base64
 import dataclasses
 import datetime
 import email.utils
+import json
 import uuid
 from collections.abc import Callable
 from http import HTTPMethod, HTTPStatus
-from typing import SupportsFloat
+from typing import Any, SupportsFloat
 from zoneinfo import ZoneInfo
+
+from requests import Request, Response
+from requests.models import PreparedRequest
 
 from mock_vws._constants import ResultCodes, TargetStatuses
 from mock_vws._database_matchers import get_database_matching_server_keys
@@ -125,7 +129,7 @@ class MockVuforiaWebServicesAPI:
         path_pattern="/targets",
         http_methods={HTTPMethod.POST},
     )
-    def add_target(self, request: "Request", context: "Context") -> str:
+    def add_target(self, request: PreparedRequest) -> Response:
         """
         Add a target.
 
@@ -137,7 +141,7 @@ class MockVuforiaWebServicesAPI:
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
                 request_method=request.method,
-                request_path=request.path,
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
@@ -149,23 +153,23 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
 
-        given_active_flag = request.json().get("active_flag")
+        given_active_flag = request_json.get("active_flag")
         active_flag = {
             None: True,
             True: True,
             False: False,
         }[given_active_flag]
 
-        application_metadata = request.json().get("application_metadata")
+        application_metadata = request_json.get("application_metadata")
 
         new_target = Target(
-            name=request.json()["name"],
-            width=request.json()["width"],
-            image_value=base64.b64decode(s=request.json()["image"]),
+            name=request_json["name"],
+            width=request_json["width"],
+            image_value=base64.b64decode(s=request_json["image"]),
             active_flag=active_flag,
             processing_time_seconds=self._processing_time_seconds,
             application_metadata=application_metadata,
@@ -202,7 +206,7 @@ class MockVuforiaWebServicesAPI:
         path_pattern=f"/targets/{_TARGET_ID_PATTERN}",
         http_methods={HTTPMethod.DELETE},
     )
-    def delete_target(self, request: "Request", context: "Context") -> str:
+    def delete_target(self, request: PreparedRequest) -> Response:
         """
         Delete a target.
 
@@ -214,7 +218,7 @@ class MockVuforiaWebServicesAPI:
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
                 request_method=request.method,
-                request_path=request.path,
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
@@ -227,7 +231,7 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
 
@@ -269,19 +273,20 @@ class MockVuforiaWebServicesAPI:
         return body_json
 
     @route(path_pattern="/summary", http_methods={HTTPMethod.GET})
-    def database_summary(self, request: "Request", context: "Context") -> str:
+    def database_summary(self, request: "Request") -> str:
         """
         Get a database summary report.
 
         Fake implementation of
         https://developer.vuforia.com/library/web-api/cloud-targets-web-services-api#summary-report
         """
+        breakpoint()
         try:
             run_services_validators(
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
                 request_method=request.method,
-                request_path=request.path,
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
@@ -295,7 +300,7 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
 
@@ -335,7 +340,7 @@ class MockVuforiaWebServicesAPI:
         return body_json
 
     @route(path_pattern="/targets", http_methods={HTTPMethod.GET})
-    def target_list(self, request: "Request", context: "Context") -> str:
+    def target_list(self, request: PreparedRequest) -> Response:
         """
         Get a list of all targets.
 
@@ -347,7 +352,7 @@ class MockVuforiaWebServicesAPI:
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
                 request_method=request.method,
-                request_path=request.path,
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
@@ -359,7 +364,7 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
 
@@ -395,7 +400,7 @@ class MockVuforiaWebServicesAPI:
         path_pattern=f"/targets/{_TARGET_ID_PATTERN}",
         http_methods={HTTPMethod.GET},
     )
-    def get_target(self, request: "Request", context: "Context") -> str:
+    def get_target(self, request: PreparedRequest) -> Response:
         """
         Get details of a target.
 
@@ -407,7 +412,7 @@ class MockVuforiaWebServicesAPI:
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
                 request_method=request.method,
-                request_path=request.path,
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
@@ -419,7 +424,7 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
         target_id = request.path.split(sep="/")[-1]
@@ -463,7 +468,7 @@ class MockVuforiaWebServicesAPI:
         path_pattern=f"/duplicates/{_TARGET_ID_PATTERN}",
         http_methods={HTTPMethod.GET},
     )
-    def get_duplicates(self, request: "Request", context: "Context") -> str:
+    def get_duplicates(self, request: PreparedRequest) -> Response:
         """
         Get targets which may be considered duplicates of a given target.
 
@@ -475,7 +480,7 @@ class MockVuforiaWebServicesAPI:
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
                 request_method=request.method,
-                request_path=request.path,
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
@@ -487,7 +492,7 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
         target_id = request.path.split(sep="/")[-1]
@@ -537,7 +542,7 @@ class MockVuforiaWebServicesAPI:
         path_pattern=f"/targets/{_TARGET_ID_PATTERN}",
         http_methods={HTTPMethod.PUT},
     )
-    def update_target(self, request: "Request", context: "Context") -> str:
+    def update_target(self, request: PreparedRequest) -> Response:
         """
         Update a target.
 
@@ -548,12 +553,12 @@ class MockVuforiaWebServicesAPI:
             run_services_validators(
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
-                request_method=request.method,
-                request_path=request.path,
+                request_method=request.method or "",
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
-            context.headers = exc.headers
+            request.headers = exc.headers
             context.status_code = exc.status_code
             return exc.response_text
 
@@ -561,7 +566,7 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
 
@@ -581,26 +586,27 @@ class MockVuforiaWebServicesAPI:
             context.status_code = exception.status_code
             return exception.response_text
 
-        width = request.json().get("width", target.width)
-        name = request.json().get("name", target.name)
-        active_flag = request.json().get("active_flag", target.active_flag)
-        application_metadata = request.json().get(
+        request_json: dict[str, Any] = json.loads(s=request.body or b"")
+        width = request_json.get("width", target.width)
+        name = request_json.get("name", target.name)
+        active_flag = request_json.get("active_flag", target.active_flag)
+        application_metadata = request_json.get(
             "application_metadata",
             target.application_metadata,
         )
 
         image_value = target.image_value
-        if "image" in request.json():
-            image_value = base64.b64decode(s=request.json()["image"])
+        if "image" in request_json:
+            image_value = base64.b64decode(s=request_json["image"])
 
-        if "active_flag" in request.json() and active_flag is None:
+        if "active_flag" in request_json and active_flag is None:
             fail_exception = FailError(status_code=HTTPStatus.BAD_REQUEST)
             context.headers = fail_exception.headers
             context.status_code = fail_exception.status_code
             return fail_exception.response_text
 
         if (
-            "application_metadata" in request.json()
+            "application_metadata" in request_json
             and application_metadata is None
         ):
             fail_exception = FailError(status_code=HTTPStatus.BAD_REQUEST)
@@ -646,7 +652,7 @@ class MockVuforiaWebServicesAPI:
         path_pattern=f"/summary/{_TARGET_ID_PATTERN}",
         http_methods={HTTPMethod.GET},
     )
-    def target_summary(self, request: "Request", context: "Context") -> str:
+    def target_summary(self, request: PreparedRequest) -> Response:
         """
         Get a summary report for a target.
 
@@ -658,7 +664,7 @@ class MockVuforiaWebServicesAPI:
                 request_headers=request.headers,
                 request_body=_body_bytes(request=request),
                 request_method=request.method,
-                request_path=request.path,
+                request_path=request.path_url,
                 databases=self._target_manager.databases,
             )
         except ValidatorError as exc:
@@ -670,7 +676,7 @@ class MockVuforiaWebServicesAPI:
             request_headers=request.headers,
             request_body=_body_bytes(request=request),
             request_method=request.method,
-            request_path=request.path,
+            request_path=request.path_url,
             databases=self._target_manager.databases,
         )
         target_id = request.path.split(sep="/")[-1]

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -12,7 +12,7 @@ import email.utils
 import uuid
 from collections.abc import Callable
 from http import HTTPMethod, HTTPStatus
-from typing import TYPE_CHECKING, SupportsFloat
+from typing import SupportsFloat
 from zoneinfo import ZoneInfo
 
 from mock_vws._constants import ResultCodes, TargetStatuses
@@ -29,11 +29,6 @@ from mock_vws.image_matchers import ImageMatcher
 from mock_vws.target import Target
 from mock_vws.target_manager import TargetManager
 from mock_vws.target_raters import TargetTrackingRater
-
-if TYPE_CHECKING:
-    from requests_mock.request import Request
-    from requests_mock.response import Context
-
 
 _TARGET_ID_PATTERN = "[A-Za-z0-9]+"
 
@@ -78,7 +73,7 @@ def route(
     return decorator
 
 
-def _body_bytes(request: "Request") -> bytes:
+def _body_bytes(request: Request) -> bytes:
     """
     Return the body of a request as bytes.
     """
@@ -96,7 +91,7 @@ class MockVuforiaWebServicesAPI:
     """
     A fake implementation of the Vuforia Web Services API.
 
-    This implementation is tied to the implementation of `requests_mock`.
+    This implementation is tied to the implementation of ``responses``.
     """
 
     def __init__(

--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -131,7 +131,7 @@ def _enable_use_docker_in_memory(
         value=target_manager_base_url,
     )
 
-    with responses.RequestsMock() as mock:
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as mock:
         add_flask_app_to_mock(
             mock_obj=mock,
             flask_app=VWS_FLASK_APP,

--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -9,7 +9,7 @@ from enum import Enum
 
 import pytest
 import requests
-import requests_mock
+import responses
 from requests_mock_flask import add_flask_app_to_mock
 from vws import VWS
 from vws.exceptions.vws_exceptions import (
@@ -131,7 +131,7 @@ def _enable_use_docker_in_memory(
         value=target_manager_base_url,
     )
 
-    with requests_mock.Mocker(real_http=False) as mock:
+    with responses.RequestsMock() as mock:
         add_flask_app_to_mock(
             mock_obj=mock,
             flask_app=VWS_FLASK_APP,

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -8,8 +8,8 @@ from http import HTTPStatus
 
 import pytest
 import requests
+import responses
 from PIL import Image
-from requests_mock import Mocker
 from requests_mock_flask import add_flask_app_to_mock
 from vws import VWS, CloudRecoService
 
@@ -25,24 +25,25 @@ _EXAMPLE_URL_FOR_TARGET_MANAGER = "http://" + uuid.uuid4().hex + ".com"
 
 
 @pytest.fixture(autouse=True)
-def _(monkeypatch: pytest.MonkeyPatch, requests_mock: Mocker) -> None:
+@responses.activate
+def _(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Enable a mock service backed by the Flask applications.
     """
     add_flask_app_to_mock(
-        mock_obj=requests_mock,
+        mock_obj=responses,
         flask_app=VWS_FLASK_APP,
         base_url="https://vws.vuforia.com",
     )
 
     add_flask_app_to_mock(
-        mock_obj=requests_mock,
+        mock_obj=responses,
         flask_app=CLOUDRECO_FLASK_APP,
         base_url="https://cloudreco.vuforia.com",
     )
 
     add_flask_app_to_mock(
-        mock_obj=requests_mock,
+        mock_obj=responses,
         flask_app=TARGET_MANAGER_FLASK_APP,
         base_url=_EXAMPLE_URL_FOR_TARGET_MANAGER,
     )

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -81,7 +81,9 @@ class TestRealHTTP:
         non-Vuforia addresses, but not to mocked Vuforia endpoints.
         """
         with MockVWS():
-            with pytest.raises(expected_exception=NoMockAddress):
+            with pytest.raises(
+                expected_exception=requests.exceptions.ConnectionError
+            ):
                 request_unmocked_address()
 
             # No exception is raised when making a request to a mocked

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -80,7 +80,7 @@ class TestRealHTTP:
         By default, the mock stops any requests made with `requests` to
         non-Vuforia addresses, but not to mocked Vuforia endpoints.
         """
-        with MockVWS() as mock:
+        with MockVWS():
             with pytest.raises(
                 expected_exception=requests.exceptions.ConnectionError
             ):

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -80,7 +80,7 @@ class TestRealHTTP:
         By default, the mock stops any requests made with `requests` to
         non-Vuforia addresses, but not to mocked Vuforia endpoints.
         """
-        with MockVWS():
+        with MockVWS() as mock:
             with pytest.raises(
                 expected_exception=requests.exceptions.ConnectionError
             ):

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -14,7 +14,6 @@ import requests
 from freezegun import freeze_time
 from PIL import Image
 from requests.exceptions import MissingSchema
-from requests_mock.exceptions import NoMockAddress
 from vws import VWS, CloudRecoService
 from vws_auth_tools import rfc_1123_date
 
@@ -43,8 +42,8 @@ def request_unmocked_address() -> None:
     Raises:
         requests.exceptions.ConnectionError: This is expected as there is
             nothing to connect to.
-        requests_mock.exceptions.NoMockAddress: This request is being made in
-            the context of a `requests_mock` mock which does not mock local
+        requests.exceptions.ConnectionError: This request is being made in the
+            context of a ``responses`` mock which does not mock local
             addresses.
     """
     sock = socket.socket()
@@ -192,7 +191,9 @@ class TestCustomBaseURLs:
             base_vws_url="https://vuforia.vws.example.com",
             real_http=False,
         ):
-            with pytest.raises(expected_exception=NoMockAddress):
+            with pytest.raises(
+                expected_exception=requests.exceptions.ConnectionError
+            ):
                 requests.get(url="https://vws.vuforia.com/summary", timeout=30)
 
             requests.get(
@@ -213,7 +214,9 @@ class TestCustomBaseURLs:
             base_vwq_url="https://vuforia.vwq.example.com",
             real_http=False,
         ):
-            with pytest.raises(expected_exception=NoMockAddress):
+            with pytest.raises(
+                expected_exception=requests.exceptions.ConnectionError
+            ):
                 requests.post(
                     url="https://cloudreco.vuforia.com/v1/query",
                     timeout=30,


### PR DESCRIPTION
* Responses seems more actively maintained
* `requests_mock` isn't compatible with runtime type checking (some types are in the `.pyi` only)