### PR TITLE
Avoid static folder serving in Flask apps

### DIFF
--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -24,7 +24,7 @@ from mock_vws.target_raters import (
     TargetTrackingRater,
 )
 
-TARGET_MANAGER_FLASK_APP = Flask(__name__)
+TARGET_MANAGER_FLASK_APP = Flask(import_name=__name__, static_folder=None)
 
 TARGET_MANAGER = TargetManager()
 

--- a/src/mock_vws/_flask_server/vwq.py
+++ b/src/mock_vws/_flask_server/vwq.py
@@ -27,7 +27,7 @@ from mock_vws.image_matchers import (
     StructuralSimilarityMatcher,
 )
 
-CLOUDRECO_FLASK_APP = Flask(import_name=__name__)
+CLOUDRECO_FLASK_APP = Flask(import_name=__name__, static_folder=None)
 CLOUDRECO_FLASK_APP.config["PROPAGATE_EXCEPTIONS"] = True
 
 

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -38,7 +38,7 @@ from mock_vws.target_raters import (
     HardcodedTargetTrackingRater,
 )
 
-VWS_FLASK_APP = Flask(import_name=__name__)
+VWS_FLASK_APP = Flask(import_name=__name__, static_folder=None)
 VWS_FLASK_APP.config["PROPAGATE_EXCEPTIONS"] = True
 
 


### PR DESCRIPTION
This makes debugging easier as we have to trawl through fewer URLs in a list when a request is not matched.