### PR TITLE
Cap pydantic-settings version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "numpy<2.0.0",
     "pillow",
     "piq",
-    "pydantic-settings",
+    "pydantic-settings<2.6.0",
     "requests",
     "responses",
     "torch",


### PR DESCRIPTION
See https://github.com/VWS-Python/vws-python-mock/issues/2407 for removing this cap.