### PR TITLE
Add view and edit buttons to Sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,6 +74,7 @@ html_show_sphinx = False
 html_show_sourcelink = False
 html_theme_options = {
     "sidebar_hide_name": False,
+    "top_of_page_buttons": ["view", "edit"],
 }
 
 # Retry link checking to avoid transient network errors.


### PR DESCRIPTION
Add top_of_page_buttons configuration to Furo theme to enable view and edit buttons on documentation pages.