### PR TITLE
Add --no-write-to-file flag for read-only doccmd commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,8 +133,8 @@ repos:
       - id: shellcheck-docs
         name: shellcheck-docs
         # We exclude SC2215 as it is a false positive for an unknown reason on Windows.
-        entry: uv run --extra=dev doccmd --language=shell --language=console --command="shellcheck
-          --shell=bash --exclude=SC2215"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=shell --language=console
+          --command="shellcheck --shell=bash --exclude=SC2215"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -169,7 +169,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
 
@@ -193,7 +193,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --language=python --command="pyright"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyright"
         language: python
         types_or: [markdown, rst]
 
@@ -217,7 +217,7 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry: uv run --extra=dev doccmd --language=python --command="vulture"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="vulture"
         language: python
         types_or: [python]
         pass_filenames: false
@@ -251,7 +251,7 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry: uv run --extra=dev doccmd --language=python --command="pylint"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pylint"
         language: python
         stages: [manual]
         types_or: [markdown, rst]
@@ -307,7 +307,7 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry: uv run --extra=dev doccmd --language=python --command="interrogate"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
## Summary
- Add `--no-write-to-file` flag to doccmd invocations that use read-only tools (shellcheck, mypy, pyright, vulture, pylint, interrogate)
- Tools that write to files (shfmt --write, ruff check --fix, ruff format) are intentionally not changed

## Test plan
- Pre-commit hooks pass
- Read-only checks work correctly with the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)