### PR TITLE
Get the code ready for ty

### DIFF
--- a/src/mock_vws/_requests_mock_server/mock_web_query_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_query_api.py
@@ -7,7 +7,7 @@ https://developer.vuforia.com/library/web-api/vuforia-query-web-api
 import email.utils
 from collections.abc import Callable, Iterable, Mapping
 from http import HTTPMethod, HTTPStatus
-from typing import ParamSpec, Protocol
+from typing import ParamSpec, Protocol, runtime_checkable
 
 from beartype import beartype
 from requests.models import PreparedRequest
@@ -29,6 +29,7 @@ _ResponseType = tuple[int, Mapping[str, str], str]
 _P = ParamSpec("_P")
 
 
+@runtime_checkable
 class _RouteMethod(Protocol[_P]):
     """
     Callable used for routing which also exposes ``__name__``.

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -12,7 +12,7 @@ import json
 import uuid
 from collections.abc import Callable, Iterable, Mapping
 from http import HTTPMethod, HTTPStatus
-from typing import Any, ParamSpec, Protocol
+from typing import Any, ParamSpec, Protocol, runtime_checkable
 from zoneinfo import ZoneInfo
 
 from beartype import BeartypeConf, beartype
@@ -42,6 +42,7 @@ _ResponseType = tuple[int, Mapping[str, str], str]
 _P = ParamSpec("_P")
 
 
+@runtime_checkable
 class _RouteMethod(Protocol[_P]):
     """
     Callable used for routing which also exposes ``__name__``.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens typing for routing decorators using Protocol/ParamSpec and preserves method names, without changing behavior.
> 
> - **Typing/Decorators**:
>   - Introduce `_RouteMethod` `Protocol` with `ParamSpec` to ensure routed callables expose `__name__` and typed `__call__` returning `_ResponseType` in `mock_web_query_api.py` and `mock_web_services_api.py`.
>   - Update `route` decorator signatures to be generic and return the same typed callable (`Callable[[_RouteMethod[_P]], _RouteMethod[_P]]`); adjust inner `decorator` annotations accordingly.
>   - Minor import updates to include `ParamSpec`, `Protocol`, and `runtime_checkable`; no functional logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9da08cd21e2ed97ab67357480658eb5dd46c69e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->