### PR TITLE
Add ty to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,8 @@ ci:
     - pyright
     - pyright-docs
     - pyright-verifytypes
+    - ty
+    - ty-docs
     - pyroma
     - ruff-check-fix
     - ruff-check-fix-docs
@@ -206,6 +208,24 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty
+        name: ty
+        stages: [pre-push]
+        entry: uv run --extra=dev ty check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty-docs
+        name: ty-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="ty check"
+        language: python
+        types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
 
       - id: vulture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ optional-dependencies.dev = [
     "sphinxcontrib-spelling==8.0.2",
     "sybil==9.3.0",
     "tenacity==9.1.2",
+    "ty==0.0.1a34",
     "types-docker==7.1.0.20251202",
     "types-pyyaml==6.0.12.20250915",
     "types-requests==2.32.4.20250913",


### PR DESCRIPTION
Add ty and ty-docs hooks to pre-commit configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ty`/`ty-docs` pre-push hooks and includes `ty` in dev dependencies.
> 
> - **Pre-commit**:
>   - Add `ty` hook (`uv run --extra=dev ty check`) and `ty-docs` hook (via `doccmd` running `ty check`) at `pre-push`.
>   - Update CI skip list to include `ty` and `ty-docs`.
> - **Dependencies**:
>   - Add `ty==0.0.1a34` to `optional-dependencies.dev` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c26243281c59db8f76caa42e42f3f9d1901a795b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->