### PR TITLE
Add zizmor for GitHub Actions security linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ ci:
     - vulture
     - vulture-docs
     - yamlfix
+    - zizmor
     - pyrefly
     - pyrefly-docs
 
@@ -380,6 +381,15 @@ repos:
         name: pyproject-fmt
         entry: uv run --extra=dev yamlfix
         language: python
+        types_or: [yaml]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: zizmor
+        name: zizmor
+        entry: uv run --extra=dev zizmor .github
+        language: python
+        pass_filenames: false
         types_or: [yaml]
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ optional-dependencies.dev = [
     "vws-test-fixtures==2023.3.5",
     "vws-web-tools==2024.10.6.1",
     "yamlfix==1.19.1",
+    "zizmor==1.19.0",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-python-mock/"


### PR DESCRIPTION
Add zizmor to dev dependencies and pre-commit config for GitHub Actions workflow security linting.

## Changes
- Add `zizmor==1.19.0` to dev dependencies in pyproject.toml
- Add zizmor pre-commit hook (runs on YAML files in .github directory)
- Add zizmor to ci.skip list (where applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces GitHub Actions security linting via `zizmor` and wires it into local hooks.
> 
> - Adds `zizmor==1.19.0` to dev dependencies in `pyproject.toml`
> - New pre-commit hook: `uv run --extra=dev zizmor .github` (YAML, pre-commit, no filenames)
> - Adds `zizmor` to `ci.skip` in `.pre-commit-config.yaml` to avoid running in pre-commit CI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0bdc3d1a8016b83d070d4326543a5c94458a72b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->