### PR TITLE
Switch from pre-commit to prek

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,9 +34,9 @@ jobs:
 
       - name: Lint
         run: |
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage manual --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
+          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ ci:
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-default_install_hook_types: [pre-commit, pre-push, commit-msg]
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: meta

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -31,7 +31,7 @@ Install ``pre-commit`` hooks:
 
 .. code-block:: console
 
-   $ pre-commit install
+   $ prek install
 
 Linting
 -------
@@ -40,9 +40,9 @@ Run lint tools either by committing, or with:
 
 .. code-block:: console
 
-   $ pre-commit run --all-files --hook-stage pre-commit --verbose
-   $ pre-commit run --all-files --hook-stage pre-push --verbose
-   $ pre-commit run --all-files --hook-stage manual --verbose
+   $ prek run --all-files --hook-stage pre-commit --verbose
+   $ prek run --all-files --hook-stage pre-push --verbose
+   $ prek run --all-files --hook-stage manual --verbose
 
 .. _Homebrew: https://brew.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2025.4.3",
-    "pre-commit==4.5.1",
+    "prek==0.2.25",
     "pydocstyle==6.3",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",


### PR DESCRIPTION
Replace pre-commit with prek for running hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates hook runner from `pre-commit` to `prek`.
> 
> - Update GitHub Actions `lint.yml` to invoke `prek run` for `pre-commit`, `pre-push`, and `manual` stages
> - Replace dev dependency `pre-commit` with `prek` in `pyproject.toml`
> - Update documentation commands to use `prek install` and `prek run`
> - Adjust `.pre-commit-config.yaml` `default_install_hook_types` to `[pre-commit, pre-push]` (remove `commit-msg`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee90e81f7c4836a557a4248c2090535135670dd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->