### PR TITLE
Fix zizmor warning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}"
+          replace: |-
+            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use YAML block scalar syntax for replace field to fix zizmor warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Workflow update**
> 
> - In `release.yml`, changes the `gha-find-replace` `replace` value to a YAML block scalar (`|-`) and adds an explicit trailing newline for the changelog insertion.
> - No application code changes; only CI configuration adjusted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed976cc84aea8987f9eb5fc6424003e58624749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->