### PR TITLE
Fix block scalar newline interpretation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}"
+          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n"
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
The previous fix used a YAML block scalar (`|-`) which doesn't interpret `\n` as newlines, causing literal `\n` to appear in CHANGELOG.rst. This fix uses a double-quoted string on a single line which correctly interprets escape sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `CHANGELOG.rst` is formatted correctly during releases.
> 
> - In `release.yml`, updates the `Update changelog` step to use a double-quoted `replace` string with escaped newlines and an explicit trailing newline so inserted version headers and underlines render properly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f17f95fd11f88ee7feef593f922015f7f992865. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->