### PR TITLE
Use literal block scalar for changelog replace string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,12 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: |-
-            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
+          replace: |
+            Next
+            ----
+
+            ${{ steps.calver.outputs.release }}
+            ${{ steps.changelog_underline.outputs.underline }}
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use literal block scalar (`|`) with actual newlines instead of escape sequences in the release workflow. This fixes zizmor warnings while being compatible with yamlfix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the GitHub Actions release workflow to use a YAML literal block scalar for the `replace` value in the `jacobtomlinson/gha-find-replace` step, replacing escaped newlines with actual newlines.
> 
> - Adjusts `.github/workflows/release.yml` so the `replace` content for updating `CHANGELOG.rst` is written as a multi-line block (`|`) with real line breaks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5baf0eed63c275cccdc4df54fea3f560d06bb19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->