### PR TITLE
Revert "Bump sphinx from 8.2.3 to 9.1.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ optional-dependencies.dev = [
     "coverage==7.13.1",
     "deptry==0.24.0",
     "dirty-equals==0.11",
-    "doc8==2.0.0",
+    "doc8==1.1.1",
     "doccmd==2026.1.12",
     "docformatter==1.7.7",
     "docker==7.1.0",
@@ -85,7 +85,7 @@ optional-dependencies.dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
-    "sphinx==9.1.0",
+    "sphinx==8.2.3",
     "sphinx-copybutton==0.5.2",
     "sphinx-lint==1.0.2",
     "sphinx-paramlinks==0.6",


### PR DESCRIPTION
Reverts VWS-Python/vws-python-mock#2820

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts recent documentation tooling upgrades to restore previous versions in `pyproject.toml`.
> 
> - Set `sphinx` from `9.1.0` back to `8.2.3`
> - Set `doc8` from `2.0.0` back to `1.1.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4df6581c985a05d768b6d12d0ae1016b361e177. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->