### PR TITLE
Use bash shell for Lint step to ensure early failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,9 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
 
       - name: Lint
+        # Use bash to ensure the step fails if any command fails.
+        # PowerShell does not fail on intermediate command failures by default.
+        shell: bash
         run: |
           uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
           uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose


### PR DESCRIPTION
PowerShell does not fail on intermediate command failures by default. By using bash shell, we ensure that any failing command causes the step to fail immediately.

See https://github.com/adamtheturtle/doccmd/pull/720 for the original learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow update**
> 
> - In `.github/workflows/lint.yml`, the `Lint` step now runs with `shell: bash` (with comments explaining failure behavior) to ensure the step fails on any command error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9111ce2c9f0c41476fce717b57f483e891beb3be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->