### PR TITLE
Remove --example-workers 0 from mypy-docs hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,6 +171,7 @@ repos:
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
 
+      # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]


### PR DESCRIPTION
This removes `--example-workers 0` only from the `mypy-docs` hook due to a mypy race condition bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Pre-commit config update**
> 
> - Adjusts `mypy-docs` hook in `.pre-commit-config.yaml` to remove `--example-workers 0` from `doccmd` invocation due to a mypy race condition (see `python/mypy#18283`)
> - Adds a clarifying comment above the hook; no other hooks or commands changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c4ea9e7de77b50f953242f88799f8abd87a7434. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->