### PR TITLE
Bump doc8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ optional-dependencies.dev = [
     "coverage==7.13.2",
     "deptry==0.24.0",
     "dirty-equals==0.11",
-    "doc8==1.1.1",
+    "doc8==2.0.0",
     "doccmd==2026.1.25",
     "docker==7.1.0",
     "enum-tools[sphinx]==0.13.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates development linting dependency.
> 
> - Bumps `doc8` in `pyproject.toml` dev optional dependencies from `1.1.1` to `2.0.0`
> - No production code or runtime dependencies changed; existing `[tool.doc8]` config remains the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 626a691044fabc121eee525e4f2a8c3f31a2fa2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->