### PR TITLE
Bump pyproject-fmt to 2.14.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ optional-dependencies.dev = [
     "pydocstyle==6.3",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.14.0",
+    "pyproject-fmt==2.14.2",
     "pyrefly==0.51.2",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -80,6 +80,10 @@ optional-dependencies.dev = [
     "pyyaml==6.0.3",
     "requests-mock-flask==2026.1.12",
     "ruff==0.15.0",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
+    "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx==8.2.3",
     "sphinx-copybutton==0.5.2",
@@ -101,10 +105,6 @@ optional-dependencies.dev = [
     "vws-python==2025.3.10.1",
     "vws-test-fixtures==2023.3.5",
     "vws-web-tools==2024.10.6.1",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]
@@ -144,29 +144,29 @@ lint.select = [
     "ALL",
 ]
 lint.ignore = [
+    # Ruff warns that this conflicts with the formatter.
+    "COM812",
     # Allow our chosen docstring line-style - pydocstringformatter handles formatting
     # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
+    "D212",
+    "D415",
+    # Ruff warns that this conflicts with the formatter.
+    "ISC001",
     # Ignore 'too-many-*' errors as they seem to get in the way more than
     # helping.
     "PLR0913",
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
-    # Ruff warns that this conflicts with the formatter.
-    "ISC001",
-    "D212",
-    "D415",
 ]
 lint.per-file-ignores."ci/test_custom_linters.py" = [
     # Allow asserts in tests.
     "S101",
 ]
 lint.per-file-ignores."doccmd_*.py" = [
-    # Allow asserts in docs.
-    "S101",
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
     "D200",
+    # Allow asserts in docs.
+    "S101",
 ]
 lint.per-file-ignores."tests/**" = [
     # Allow asserts in tests.


### PR DESCRIPTION
Bump pyproject-fmt from 2.14.0 to 2.14.2 and re-format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tool/dependency version bump and configuration formatting in `pyproject.toml`, with no runtime code or behavior modifications.
> 
> **Overview**
> Updates the dev dependency `pyproject-fmt` from `2.14.0` to `2.14.2` and applies the resulting `pyproject.toml` reformatting.
> 
> Also tweaks `pyproject.toml` configuration ordering/formatting for `ruff` ignores and per-file ignores, and moves the `shellcheck-py` dev dependency comment+entry within the dev dependency list (no functional code changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f7fa4c4a287d4273a4ce1e6fdf65042ea174553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->