### PR TITLE
Update pyproject-fmt to 2.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,17 +334,17 @@ ini_options.retry_delay = 10
 ini_options.cumulative_timing = false
 
 [tool.coverage]
-report.exclude_also = [
-    "if TYPE_CHECKING:",
-    "class .*\\bProtocol\\):",
-]
-report.fail_under = 100
 run.branch = true
 run.omit = [
     "src/mock_vws/_flask_server/healthcheck.py",
 ]
 run.parallel = true
 run.source = [ "src/", "tests/" ]
+report.exclude_also = [
+    "class .*\\bProtocol\\):",
+    "if TYPE_CHECKING:",
+]
+report.fail_under = 100
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
Update pyproject-fmt to 2.15.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only reordering with identical coverage settings; low risk aside from potential CI differences if tooling relies on exact TOML key order.
> 
> **Overview**
> Updates `pyproject.toml` formatting consistent with `pyproject-fmt` changes by reordering the `[tool.coverage]` `report.*` keys (`exclude_also`/`fail_under`) to come after the `run.*` settings, without changing their values.
> 
> No runtime code changes; this only affects configuration file ordering/formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef8894698b3613f56a5bac4297157cea7a99b510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->