### PR TITLE
More flexible Windows checks

### DIFF
--- a/tests/mock_vws/test_docker.py
+++ b/tests/mock_vws/test_docker.py
@@ -121,9 +121,16 @@ def test_build_and_run(
         full_log = "\n".join(
             [item["stream"] for item in exc.build_log if "stream" in item],
         )
+        windows_message_substrings = (
+            "no matching manifest for windows/amd64",
+            "no matching manifest for windows(10.0.26100)/amd64",
+        )
         # If this assertion fails, it may be useful to look at the other
         # properties of ``exc``.
-        if "no matching manifest for windows/amd64" not in exc.msg:
+        if not any(
+            windows_message_substring in exc.msg
+            for windows_message_substring in windows_message_substrings
+        ):
             raise AssertionError(full_log) from exc
         pytest.skip(
             reason="We do not currently support using Windows containers."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that broadens a skip condition based on error-message matching; low impact outside Windows CI behavior.
> 
> **Overview**
> Updates `tests/mock_vws/test_docker.py` to treat additional Docker `BuildError` messages as Windows-container unsupported cases by checking `exc.msg` against a small set of known "no matching manifest" substrings before skipping the test, instead of requiring an exact single message match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5d69e23e6bf7fe405cea4e25f98f49be946496f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->