### PR TITLE
Matrix lint workflow by hook stage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         python-version: ['3.13']
         platform: [ubuntu-latest, windows-latest]
+        hook-stage: [pre-commit, pre-push, manual]
 
     runs-on: ${{ matrix.platform }}
 
@@ -38,10 +39,8 @@ jobs:
         # Use bash to ensure the step fails if any command fails.
         # PowerShell does not fail on intermediate command failures by default.
         shell: bash
-        run: |
-          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
+        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
+          --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
Refactor the lint workflow to parallelize hook stage execution by adding `hook-stage` to the build matrix. This runs all three hook stages (pre-commit, pre-push, manual) in parallel across each platform instead of sequentially.

## Changes
- Added `hook-stage: [pre-commit, pre-push, manual]` to the build matrix
- Replaced three sequential `prek run` commands with a single parameterized command using `${{ matrix.hook-stage }}`

This expands the matrix from 2 jobs (2 platforms) to 6 jobs (2 platforms × 3 hook stages) running in parallel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow refactor that changes job fan-out/ordering but not application/runtime code; main risk is longer queue time or unexpected matrix execution behavior.
> 
> **Overview**
> Parallelizes the `Lint` GitHub Actions workflow by adding `hook-stage` to the build matrix, running `pre-commit`, `pre-push`, and `manual` as separate matrix jobs per platform.
> 
> Replaces three sequential `prek run` invocations with a single parameterized command using `${{ matrix.hook-stage }}`, expanding the matrix from 2 to 6 jobs and improving failure isolation/throughput.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 205acc292e0575524c82d994bf8ae79abca34429. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->