### PR TITLE
Fix release workflow: persist credentials for git-auto-commit-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ jobs:
           # Also, avoids
           # https://github.com/stefanzweifel/git-auto-commit-action/issues/99.
           fetch-depth: 0
-          persist-credentials: false
+          # Credentials need to persist for stefanzweifel/git-auto-commit-action.
+          # zizmor: ignore[artipacked]
+          persist-credentials: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
The release workflow was failing because `persist-credentials: false` on the checkout step removed authentication, causing `stefanzweifel/git-auto-commit-action` to fail when pushing the changelog bump commit.

This changes `persist-credentials` to `true` with a `zizmor: ignore[artipacked]` suppression comment, since persisted credentials are required for the auto-commit action to push.

Fixes the failure at https://github.com/VWS-Python/vws-python-mock/actions/runs/22032444453/job/63659742813

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that just adjusts GitHub checkout credential persistence; low blast radius but affects release automation behavior.
> 
> **Overview**
> Fixes the release GitHub Actions workflow by switching `actions/checkout` to `persist-credentials: true` so `stefanzweifel/git-auto-commit-action` can push the changelog bump commit.
> 
> Adds a short inline comment and a `zizmor` suppression annotation documenting why persisted credentials are required.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ac5ad29b6dff93f2ea8d9e00648b635729745aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->