### PR TITLE
Use RELEASE_PAT to bypass ruleset in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
           # Credentials need to persist for stefanzweifel/git-auto-commit-action.
           # zizmor: ignore[artipacked]
           persist-credentials: true
+          # Use a PAT so that the push from git-auto-commit-action
+          # can bypass repository ruleset required status checks.
+          # The default GITHUB_TOKEN cannot bypass rulesets.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
The release workflow fails because `git-auto-commit-action` cannot push the CHANGELOG bump commit directly to `main` — the repository ruleset requires 3 status checks to pass, and the default `GITHUB_TOKEN` cannot bypass rulesets.

Use the existing `RELEASE_PAT` organization secret (a PAT with admin bypass privileges) in the checkout step so that the push succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the credentials used by the release pipeline to an elevated PAT; misconfiguration or leakage could increase repository write access, though the change is small and isolated to the workflow.
> 
> **Overview**
> Updates the `Release` GitHub Actions workflow to checkout with a dedicated `RELEASE_PAT` (instead of the default `GITHUB_TOKEN`) so the `git-auto-commit-action` changelog bump commit can push to `main` even when repository rulesets require status checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35b3e9f976973ada72b7031b507c0c543e2a5308. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->