### PR TITLE
Parallelize release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release.outputs.tag }}
+          # Fetch all history including tags.
+          # Needed for setuptools-scm version detection.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv


### PR DESCRIPTION
Split the single release job into three jobs:

- **release**: changelog update, commit, tag, GitHub release
- **pypi**: build and publish to PyPI (runs after release)
- **docker**: build and push Docker images (runs after release)

The `pypi` and `docker` jobs run in parallel after `release` completes, since Docker images are built from the repository source and don't depend on the PyPI package.

Permissions are scoped to only the jobs that need them:
- `contents: write` on `release` only
- `id-token: write` on `pypi` only
- `permissions: {}` on `docker`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI/CD, but it alters release ordering, checkout refs, and permissions, which could break publishing or produce releases from the wrong commit if misconfigured.
> 
> **Overview**
> Refactors `.github/workflows/release.yml` by splitting the prior single release pipeline into three jobs: **`release`** (changelog update/commit, tag/version calculation, and GitHub release creation) followed by **`pypi`** (build + publish to PyPI) and **`docker`** (build + push multi-arch Docker images) running in parallel.
> 
> The `release` job now exposes `version` and `tag` as job outputs, and downstream jobs check out the repository at the created tag instead of doing manual `git fetch/checkout`. Permissions are tightened so only `release` has `contents: write`, only `pypi` has `id-token: write`, and `docker` runs with `permissions: {}`; Docker tags now use `needs.release.outputs.version`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e0a8e8e78e1c13c7dbea71dfe055a592a204687. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->