### PR TITLE
Parallelize Docker image builds in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,19 @@ jobs:
           verbose: true
 
   docker:
-    name: Publish Docker images
+    name: Publish Docker image (${{ matrix.image.target }})
     needs: release
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image:
+          - target: target-manager
+            repo: adamtheturtle/vuforia-target-manager-mock
+          - target: vws
+            repo: adamtheturtle/vuforia-vws-mock
+          - target: vwq
+            repo: adamtheturtle/vuforia-vwq-mock
 
     permissions: {}
 
@@ -159,35 +169,13 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Build and push target manager Docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6.19.2
         with:
           file: src/mock_vws/_flask_server/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          target: target-manager
-          tags: |
-            adamtheturtle/vuforia-target-manager-mock:latest
-            adamtheturtle/vuforia-target-manager-mock:${{ needs.release.outputs.version }}
-
-      - name: Build and push VWS Docker image
-        uses: docker/build-push-action@v6.19.2
-        with:
-          file: src/mock_vws/_flask_server/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: vws
-          tags: |
-            adamtheturtle/vuforia-vws-mock:latest
-            adamtheturtle/vuforia-vws-mock:${{ needs.release.outputs.version }}
-
-      - name: Build and push VWQ Docker image
-        uses: docker/build-push-action@v6.19.2
-        with:
-          file: src/mock_vws/_flask_server/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          target: vwq
+          target: ${{ matrix.image.target }}
           tags: |-
-            adamtheturtle/vuforia-vwq-mock:latest
-            adamtheturtle/vuforia-vwq-mock:${{ needs.release.outputs.version }}
+            ${{ matrix.image.repo }}:latest
+            ${{ matrix.image.repo }}:${{ needs.release.outputs.version }}


### PR DESCRIPTION
Use a matrix strategy for the Docker job in the release workflow so that the three images (target-manager, vws, vwq) build in parallel instead of sequentially.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only refactor that should preserve outputs; main risk is misconfigured matrix values causing an image to be tagged/published incorrectly or not at all.
> 
> **Overview**
> Switches the `docker` job in `.github/workflows/release.yml` from three sequential `docker/build-push-action` steps to a **matrix strategy** that runs one job per image (`target-manager`, `vws`, `vwq`).
> 
> The build step now parameterizes the Docker target and repository name from the matrix while keeping the same multi-arch build (`linux/amd64,linux/arm64`) and version/latest tagging scheme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6631301e0cc08aad6358e75fe827887e20cf4e80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->