### PR TITLE
Add injectable sleep_fn parameter to MockVWS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Next
 ----
 
+- Add ``sleep_fn`` parameter to ``MockVWS`` for injecting a custom delay strategy, enabling deterministic and fast tests without monkey-patching.
+
 2026.02.15.3
 ------------
 


### PR DESCRIPTION
## Summary

Implements issue #2919 by adding an injectable `sleep_fn` parameter to `MockVWS`. This allows callers to inject a custom delay strategy for testing timeout behavior without monkeypatching internals.

## Changes

- Add `sleep_fn: Callable[[float], None] = time.sleep` parameter to `MockVWS.__init__`
- Pass the sleep function through `_wrap_callback` for both the timeout and success code paths
- Add two comprehensive tests verifying the injected function is called correctly on both paths
- Update CHANGELOG with feature description

## Test plan

✓ All 6 existing and new response delay tests pass
✓ Custom sleep function is called with correct delay value on success path
✓ Custom sleep function is called with effective timeout on timeout path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API change limited to test/mock timing behavior; primary risk is minor backward-compatibility/typing issues for callers constructing `MockVWS`.
> 
> **Overview**
> `MockVWS` now accepts an injectable `sleep_fn` (defaulting to `time.sleep`) and threads it through the response-delay wrapper so both the *timeout* and *successful* delay paths use the provided sleep strategy instead of hardcoded sleeping.
> 
> Adds tests asserting the injected function is called with the configured delay or the effective timeout value, and documents the new parameter in `CHANGELOG.rst`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3c1cc319f44114e30b2b4985ad0afd8d7dc3daf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->