### PR TITLE
Enable coverage report.show_missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,8 +345,8 @@ report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
 report.fail_under = 100
-
 report.show_missing = true
+
 [tool.mypy]
 strict = true
 files = [ "." ]


### PR DESCRIPTION
## Summary
- set \ \ in \

## Testing
- not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change that affects test reporting output but not runtime behavior or application logic.
> 
> **Overview**
> Enables `coverage.py` reporting of uncovered lines by setting `tool.coverage.report.show_missing = true` in `pyproject.toml`, improving visibility into what code is not covered while keeping the existing `fail_under = 100` threshold.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91693d89fa1222a210945d1de5f4584ce292e47a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->