### PR TITLE
Fix branch coverage in timeout handling

### DIFF
--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -154,15 +154,16 @@ class MockVWS(ContextDecorator):
             # library onto PreparedRequest objects - it is not
             # in the requests type stubs.
             req_kwargs: dict[str, Any] = getattr(request, "req_kwargs", {})
-            timeout = req_kwargs.get("timeout")
+            timeout: tuple[float, float] | float | int | None = req_kwargs.get(
+                "timeout"
+            )
             # requests allows timeout as a (connect, read)
             # tuple. The delay simulates server response
             # time, so compare against the read timeout.
-            effective: float | None = None
             if isinstance(timeout, tuple):
-                if isinstance(timeout[1], (int, float)):
-                    effective = float(timeout[1])
-            elif isinstance(timeout, (int, float)):
+                timeout = timeout[1]
+            effective: float | None = None
+            if isinstance(timeout, (int, float)):
                 effective = float(timeout)
 
             if effective is not None and delay_seconds > effective:


### PR DESCRIPTION
## Summary
- Annotate the `timeout` variable with explicit types so pyright can narrow through tuple element access without needing `type: ignore` or `cast`
- Flatten the nested `isinstance` checks into two sequential `if` statements, which eliminates the uncoverable false branch (the inner `isinstance(timeout[1], (int, float))` was always true when reached)

## Test plan
- [x] All 6 `TestResponseDelay` tests pass
- [x] All pre-commit and pre-push hooks pass (pyright, mypy, ruff, vulture, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in mock response-delay timeout logic; behavior should be equivalent aside from clearer tuple timeout handling and is covered by existing timeout tests.
> 
> **Overview**
> Adjusts `_wrap_callback` timeout handling in `src/mock_vws/_requests_mock_server/decorators.py` to improve type narrowing and remove an effectively dead branch.
> 
> `timeout` is now explicitly typed, tuple timeouts are flattened by extracting the read-timeout element first, and the effective timeout is computed via a single `isinstance` check before potentially sleeping and raising `requests.exceptions.Timeout`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358652437e2b27ed22b13a061150bca09068cd3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->