### PR TITLE
Add tenacity retries to secrets file creation

### DIFF
--- a/admin/create_secrets_files.py
+++ b/admin/create_secrets_files.py
@@ -25,21 +25,12 @@ if TYPE_CHECKING:
     from vws_web_tools import DatabaseDict, VuMarkDatabaseDict
 
 
-@retry(
+RETRY_ON_TIMEOUT = retry(
     retry=retry_if_exception_type(exception_types=TimeoutException),
     stop=stop_after_attempt(max_attempt_number=3),
     wait=wait_exponential(multiplier=2, min=5, max=30),
     reraise=True,
 )
-def _get_database_details_with_retries(
-    driver: "WebDriver",
-    database_name: str,
-) -> "DatabaseDict":
-    """Get cloud database details with retries on timeout."""
-    return vws_web_tools.get_database_details(
-        driver=driver,
-        database_name=database_name,
-    )
 
 
 def _create_and_get_database_details(
@@ -67,7 +58,7 @@ def _create_and_get_database_details(
         license_name=license_name,
     )
 
-    return _get_database_details_with_retries(
+    return RETRY_ON_TIMEOUT(vws_web_tools.get_database_details)(
         driver=driver,
         database_name=database_name,
     )
@@ -86,26 +77,9 @@ def _create_and_get_vumark_details(
         database_name=vumark_database_name,
     )
 
-    return _get_vumark_details_with_retries(
+    return RETRY_ON_TIMEOUT(vws_web_tools.get_vumark_database_details)(
         driver=driver,
         database_name=vumark_database_name,
-    )
-
-
-@retry(
-    retry=retry_if_exception_type(exception_types=TimeoutException),
-    stop=stop_after_attempt(max_attempt_number=3),
-    wait=wait_exponential(multiplier=2, min=5, max=30),
-    reraise=True,
-)
-def _get_vumark_details_with_retries(
-    driver: "WebDriver",
-    database_name: str,
-) -> "VuMarkDatabaseDict":
-    """Get VuMark database details with retries on timeout."""
-    return vws_web_tools.get_vumark_database_details(
-        driver=driver,
-        database_name=database_name,
     )
 
 


### PR DESCRIPTION
This updates admin/create_secrets_files.py to use explicit tenacity retry policies for timeout-prone Selenium operations. Database and VuMark creation/detail retrieval now raise TimeoutException and are wrapped with retries that stop after three attempts with exponential backoff. The main loop now handles exhausted retries by resetting the driver and continuing to the next attempt, preserving the existing workflow while making retry behavior bounded and clearer. The tenacity call signatures were adjusted to keyword arguments to satisfy strict mypy checks in pre-push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to an admin script and mainly adjust timeout handling by retrying and failing fast after bounded attempts.
> 
> **Overview**
> Makes secrets-file generation more resilient to flaky Selenium timeouts by introducing a shared tenacity `RETRY_ON_TIMEOUT` policy (3 attempts with exponential backoff) around database/VuMark detail retrieval.
> 
> Refactors helper functions to always return details (no `None`) and lets `TimeoutException` propagate after retries; the main loop now catches exhausted timeouts, logs a clearer error, resets the web driver, and continues to the next file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7604f0fd1b5abd4f01da67bb2e41bbccabf6b18e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->