### PR TITLE
Add tenacity retries to secrets file creation

### DIFF
--- a/admin/create_secrets_files.py
+++ b/admin/create_secrets_files.py
@@ -25,21 +25,12 @@ if TYPE_CHECKING:
     from vws_web_tools import DatabaseDict, VuMarkDatabaseDict
 
 
-@retry(
+RETRY_ON_TIMEOUT = retry(
     retry=retry_if_exception_type(exception_types=TimeoutException),
     stop=stop_after_attempt(max_attempt_number=3),
     wait=wait_exponential(multiplier=2, min=5, max=30),
     reraise=True,
 )
-def _get_database_details_with_retries(
-    driver: "WebDriver",
-    database_name: str,
-) -> "DatabaseDict":
-    """Get cloud database details with retries on timeout."""
-    return vws_web_tools.get_database_details(
-        driver=driver,
-        database_name=database_name,
-    )
 
 
 def _create_and_get_database_details(
@@ -67,7 +58,7 @@ def _create_and_get_database_details(
         license_name=license_name,
     )
 
-    return _get_database_details_with_retries(
+    return RETRY_ON_TIMEOUT(vws_web_tools.get_database_details)(
         driver=driver,
         database_name=database_name,
     )
@@ -86,26 +77,9 @@ def _create_and_get_vumark_details(
         database_name=vumark_database_name,
     )
 
-    return _get_vumark_details_with_retries(
+    return RETRY_ON_TIMEOUT(vws_web_tools.get_vumark_database_details)(
         driver=driver,
         database_name=vumark_database_name,
-    )
-
-
-@retry(
-    retry=retry_if_exception_type(exception_types=TimeoutException),
-    stop=stop_after_attempt(max_attempt_number=3),
-    wait=wait_exponential(multiplier=2, min=5, max=30),
-    reraise=True,
-)
-def _get_vumark_details_with_retries(
-    driver: "WebDriver",
-    database_name: str,
-) -> "VuMarkDatabaseDict":
-    """Get VuMark database details with retries on timeout."""
-    return vws_web_tools.get_vumark_database_details(
-        driver=driver,
-        database_name=database_name,
     )
 
 


### PR DESCRIPTION
This updates admin/create_secrets_files.py to use explicit tenacity retry policies for timeout-prone Selenium operations. Database and VuMark creation/detail retrieval now raise TimeoutException and are wrapped with retries that stop after three attempts with exponential backoff. The main loop now handles exhausted retries by resetting the driver and continuing to the next attempt, preserving the existing workflow while making retry behavior bounded and clearer. The tenacity call signatures were adjusted to keyword arguments to satisfy strict mypy checks in pre-push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts retry/timeout handling in an admin Selenium script, with bounded attempts and no production-path data/auth changes.
> 
> **Overview**
> Improves robustness of `admin/create_secrets_files.py` by adding **tenacity-based retries** (3 attempts, exponential backoff) for timeout-prone Selenium calls when fetching Vuforia database and VuMark details.
> 
> Removes the previous `None`-return-on-timeout flow and instead **raises `TimeoutException` after retries**, with the main loop catching exhausted retries, resetting the Chrome driver, and continuing to the next file creation attempt.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e9ddd0307737d439df018ad93f01aa34dc2a526. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->