### PR TITLE
Bump vws-web-tools to 2026.2.17 and drop local retries

### DIFF
--- a/admin/create_secrets_files.py
+++ b/admin/create_secrets_files.py
@@ -13,24 +13,10 @@ from typing import TYPE_CHECKING
 import vws_web_tools
 from dotenv import load_dotenv
 from selenium.common.exceptions import TimeoutException
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
 
 if TYPE_CHECKING:
     from selenium.webdriver.remote.webdriver import WebDriver
     from vws_web_tools import DatabaseDict, VuMarkDatabaseDict
-
-
-RETRY_ON_TIMEOUT = retry(
-    retry=retry_if_exception_type(exception_types=TimeoutException),
-    stop=stop_after_attempt(max_attempt_number=3),
-    wait=wait_exponential(multiplier=2, min=5, max=30),
-    reraise=True,
-)
 
 
 def _create_and_get_database_details(
@@ -58,7 +44,7 @@ def _create_and_get_database_details(
         license_name=license_name,
     )
 
-    return RETRY_ON_TIMEOUT(vws_web_tools.get_database_details)(
+    return vws_web_tools.get_database_details(
         driver=driver,
         database_name=database_name,
     )
@@ -77,7 +63,7 @@ def _create_and_get_vumark_details(
         database_name=vumark_database_name,
     )
 
-    return RETRY_ON_TIMEOUT(vws_web_tools.get_vumark_database_details)(
+    return vws_web_tools.get_vumark_database_details(
         driver=driver,
         database_name=vumark_database_name,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ optional-dependencies.dev = [
     "vulture==2.14",
     "vws-python==2026.2.15",
     "vws-test-fixtures==2023.3.5",
-    "vws-web-tools==2026.2.16.1",
+    "vws-web-tools==2026.2.17",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]


### PR DESCRIPTION
This bumps vws-web-tools to 2026.2.17 in dev dependencies. In admin/create_secrets_files.py, it removes the local tenacity retry wrapper and calls get_database_details/get_vumark_database_details directly because retry behavior now lives in vws-web-tools. No other workspace-diff changes are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a dev dependency bump and an admin-only secrets generation script; behavior should remain similar but now depends on `vws-web-tools` for retries/timeouts.
> 
> **Overview**
> **Delegates timeout retry behavior to `vws-web-tools`.** `admin/create_secrets_files.py` removes the local Tenacity `RETRY_ON_TIMEOUT` wrapper and calls `get_database_details`/`get_vumark_database_details` directly.
> 
> **Bumps tooling dependency.** Updates the dev dependency `vws-web-tools` from `2026.2.16.1` to `2026.2.17` to pick up the moved retry logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b181c991939537f705e465dac73a33910deda3df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->