### PR TITLE
Update uv to 0.10.4 in Dockerfile

### DIFF
--- a/src/mock_vws/_flask_server/Dockerfile
+++ b/src/mock_vws/_flask_server/Dockerfile
@@ -16,7 +16,7 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /app
-RUN pip install --no-cache-dir uv==0.1.44 && \
+RUN pip install --no-cache-dir uv==0.10.4 && \
     uv pip install --no-cache-dir --upgrade --editable .
 EXPOSE 5000
 ENTRYPOINT ["python"]


### PR DESCRIPTION
Updates the uv package from 0.1.44 to the latest version 0.10.4 in the Flask server Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump in a Docker build step; risk is limited to potential `uv` behavior changes affecting image builds.
> 
> **Overview**
> Updates the `src/mock_vws/_flask_server/Dockerfile` build step to install `uv` `0.10.4` instead of `0.1.44` before running `uv pip install` for the editable app install.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55a45eea79079de4f2b16ed80d4cf354ed76f536. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->