### PR TITLE
Document CPU-only torch installation to speed up pip installs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,3 +6,29 @@ Installation
    $ pip install vws-python-mock
 
 This requires Python |minimum-python-version|\+.
+
+Faster installation
+~~~~~~~~~~~~~~~~~~~
+
+This package depends on `PyTorch`_, which pip installs from PyPI as a large CUDA-enabled build (~873 MB) even on CPU-only machines.
+To get a much smaller CPU-only build (~200 MB, no CUDA dependencies), install ``torch`` and ``torchvision`` from PyTorch's CPU index before installing this package:
+
+.. code-block:: console
+
+   $ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+   $ pip install vws-python-mock
+
+If you manage dependencies with ``uv``, add the following to your ``pyproject.toml`` instead:
+
+.. code-block:: toml
+
+   [[tool.uv.index]]
+   name = "pytorch-cpu"
+   url = "https://download.pytorch.org/whl/cpu"
+   explicit = true
+
+   [tool.uv.sources]
+   torch = { index = "pytorch-cpu" }
+   torchvision = { index = "pytorch-cpu" }
+
+.. _PyTorch: https://pytorch.org


### PR DESCRIPTION
pip users get CUDA torch from PyPI by default (~873 MB). Document how to pre-install torch and torchvision from PyTorch's CPU index (~200 MB) before installing the package, and the equivalent uv pyproject.toml configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior, APIs, or security-sensitive code paths.
> 
> **Overview**
> Updates `installation.rst` to document a *faster/smaller install path* by installing CPU-only `torch`/`torchvision` from PyTorch’s CPU wheel index before `vws-python-mock`, avoiding the default large CUDA-enabled PyPI download.
> 
> Adds equivalent `uv` `pyproject.toml` configuration for pinning `torch` and `torchvision` to the CPU index, plus a `PyTorch` reference link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99fcbf89868d7d0e40609dab6100363ef4a3a04b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->