### PR TITLE
Document VuMark instance image differences from real Vuforia

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -103,6 +103,13 @@ These are:
 
 When the given ``Content-Length`` header does not match the length of the given data, the mock server (written with Flask) will not behave as the real Vuforia Web Services behaves.
 
+VuMark instance images
+----------------------
+
+The mock returns a fixed minimal image in the requested format.
+The ``instance_id`` value is not encoded into the response image.
+Real Vuforia encodes the instance ID into the VuMark pattern.
+
 Header cases
 ------------
 


### PR DESCRIPTION
## Summary

- Adds a "VuMark instance images" section to `differences-to-vws.rst` noting that the mock returns a fixed minimal PNG image and does not encode the `instance_id` into the image (unlike real Vuforia)

This is extracted from the docs portion of #2954, which is applicable regardless of that PR's other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that does not affect runtime behavior.
> 
> **Overview**
> Documents a known discrepancy for VuMark instance image responses: the mock returns a fixed minimal image in the requested format and does not encode the requested `instance_id`, unlike real Vuforia.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22cae1eb429442ebdc7450a7afe13e783a6faf1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->