### PR TITLE
Rename database methods and endpoints to cloud_databases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ This requires Python |minimum-python-version|\+.
 
     with MockVWS() as mock:
         database = CloudDatabase()
-        mock.add_database(database=database)
+        mock.add_cloud_database(cloud_database=database)
         # This will use the Vuforia mock.
         requests.get(url="https://vws.vuforia.com/summary", timeout=30)
 

--- a/docs/source/basic-example.rst
+++ b/docs/source/basic-example.rst
@@ -11,7 +11,7 @@ Using the mock redirects requests to Vuforia made with `requests`_ to an in-memo
 
     with MockVWS() as mock:
         database = CloudDatabase()
-        mock.add_database(database=database)
+        mock.add_cloud_database(cloud_database=database)
         # This will use the Vuforia mock.
         requests.get(url="https://vws.vuforia.com/summary", timeout=30)
 

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -63,7 +63,7 @@ For example, with the containers set up as in :ref:`creating-containers`, use ``
    $ curl --request POST \
        --header "Content-Type: application/json" \
        --data '{}' \
-       '127.0.0.1:5005/databases'
+       '127.0.0.1:5005/cloud_databases'
    {
        "client_access_key": "2d61c1d17bb94694bee77c1f1f41e5d9",
        "client_secret_key": "b73f8170cf7d42728fa8ce66221ad147",
@@ -80,7 +80,7 @@ Deleting a database
 To delete a database use the following endpoint:
 
 .. autoflask:: mock_vws._flask_server.target_manager:TARGET_MANAGER_FLASK_APP
-   :endpoints: delete_database
+   :endpoints: delete_cloud_database
 
 
 .. _Target Manager: https://developer.vuforia.com/target-manager

--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -58,14 +58,14 @@ class TargetManagerSettings(BaseSettings):
 
 
 @TARGET_MANAGER_FLASK_APP.route(
-    rule="/databases/<string:database_name>",
+    rule="/cloud_databases/<string:database_name>",
     methods=[HTTPMethod.DELETE],
 )
 @beartype
-def delete_database(database_name: str) -> Response:
-    """Delete a database.
+def delete_cloud_database(database_name: str) -> Response:
+    """Delete a cloud database.
 
-    :status 200: The database has been deleted.
+    :status 200: The cloud database has been deleted.
     """
     try:
         (matching_database,) = {
@@ -76,14 +76,16 @@ def delete_database(database_name: str) -> Response:
     except ValueError:
         return Response(response="", status=HTTPStatus.NOT_FOUND)
 
-    TARGET_MANAGER.remove_database(database=matching_database)
+    TARGET_MANAGER.remove_cloud_database(cloud_database=matching_database)
     return Response(response="", status=HTTPStatus.OK)
 
 
-@TARGET_MANAGER_FLASK_APP.route(rule="/databases", methods=[HTTPMethod.GET])
+@TARGET_MANAGER_FLASK_APP.route(
+    rule="/cloud_databases", methods=[HTTPMethod.GET]
+)
 @beartype
 def get_cloud_databases() -> Response:
-    """Return a list of all databases."""
+    """Return a list of all cloud databases."""
     databases = [
         database.to_dict() for database in TARGET_MANAGER.cloud_databases
     ]
@@ -93,47 +95,53 @@ def get_cloud_databases() -> Response:
     )
 
 
-@TARGET_MANAGER_FLASK_APP.route(rule="/databases", methods=[HTTPMethod.POST])
+@TARGET_MANAGER_FLASK_APP.route(
+    rule="/cloud_databases", methods=[HTTPMethod.POST]
+)
 @beartype
 def create_cloud_database() -> Response:
-    """Create a new database.
+    """Create a new cloud database.
 
     :reqheader Content-Type: application/json
     :resheader Content-Type: application/json
 
     :reqjson string client_access_key: (Optional) The client access key for the
-      database.
+      cloud database.
 
     :reqjson string client_secret_key: (Optional) The client secret key for the
-      database.
+      cloud database.
 
-    :reqjson string database_name: (Optional) The name of the database.
+    :reqjson string database_name: (Optional) The name of the cloud database.
 
     :reqjson string server_access_key: (Optional) The server access key for the
-      database.
+      cloud database.
 
     :reqjson string server_secret_key: (Optional) The server secret key for the
+      cloud database.
+
+    :reqjson string state_name: (Optional) The state of the cloud database.
+     This can be "WORKING" or "PROJECT_INACTIVE". This defaults to "WORKING".
+
+    :resjson string client_access_key: The client access key for the cloud
       database.
 
-    :reqjson string state_name: (Optional) The state of the database. This can
-     be "WORKING" or "PROJECT_INACTIVE". This defaults to "WORKING".
+    :resjson string client_secret_key: The client secret key for the cloud
+      database.
 
-    :resjson string client_access_key: The client access key for the database.
+    :resjson string database_name: The cloud database name.
 
-    :resjson string client_secret_key: The client secret key for the database.
+    :resjson string server_access_key: The server access key for the cloud
+      database.
 
-    :resjson string database_name: The database name.
+    :resjson string server_secret_key: The server secret key for the cloud
+      database.
 
-    :resjson string server_access_key: The server access key for the database.
+    :resjson string state_name: The cloud database state. This will be
+      "WORKING" or "PROJECT_INACTIVE".
 
-    :resjson string server_secret_key: The server secret key for the database.
+    :reqjsonarr targets: The targets in the cloud database.
 
-    :resjson string state_name: The database state. This will be "WORKING" or
-      "PROJECT_INACTIVE".
-
-    :reqjsonarr targets: The targets in the database.
-
-    :status 201: The database has been successfully created.
+    :status 201: The cloud database has been successfully created.
     """
     random_database = CloudDatabase()
     request_json = json.loads(s=request.data)
@@ -173,7 +181,7 @@ def create_cloud_database() -> Response:
         state=state,
     )
     try:
-        TARGET_MANAGER.add_database(database=database)
+        TARGET_MANAGER.add_cloud_database(cloud_database=database)
     except ValueError as exc:
         return Response(
             response=str(object=exc),
@@ -187,12 +195,12 @@ def create_cloud_database() -> Response:
 
 
 @TARGET_MANAGER_FLASK_APP.route(
-    rule="/databases/<string:database_name>/targets",
+    rule="/cloud_databases/<string:database_name>/targets",
     methods=[HTTPMethod.POST],
 )
 @beartype
 def create_target(database_name: str) -> Response:
-    """Create a new target in a given database."""
+    """Create a new target in a given cloud database."""
     (database,) = (
         database
         for database in TARGET_MANAGER.cloud_databases
@@ -223,7 +231,7 @@ def create_target(database_name: str) -> Response:
 
 
 @TARGET_MANAGER_FLASK_APP.route(
-    rule="/databases/<string:database_name>/targets/<string:target_id>",
+    rule="/cloud_databases/<string:database_name>/targets/<string:target_id>",
     methods={HTTPMethod.DELETE},
 )
 @beartype
@@ -250,7 +258,7 @@ def delete_target(database_name: str, target_id: str) -> Response:
 
 
 @TARGET_MANAGER_FLASK_APP.route(
-    rule="/databases/<string:database_name>/targets/<string:target_id>",
+    rule="/cloud_databases/<string:database_name>/targets/<string:target_id>",
     methods=[HTTPMethod.PUT],
 )
 def update_target(database_name: str, target_id: str) -> Response:

--- a/src/mock_vws/_flask_server/vwq.py
+++ b/src/mock_vws/_flask_server/vwq.py
@@ -67,7 +67,7 @@ def get_all_cloud_databases() -> set[CloudDatabase]:
     """Get all database objects from the target manager back-end."""
     settings = VWQSettings.model_validate(obj={})
     response = requests.get(
-        url=f"{settings.target_manager_base_url}/databases",
+        url=f"{settings.target_manager_base_url}/cloud_databases",
         timeout=30,
     )
     return {

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -91,7 +91,7 @@ def get_all_cloud_databases() -> set[CloudDatabase]:
     settings = VWSSettings.model_validate(obj={})
     timeout_seconds = 30
     response = requests.get(
-        url=f"{settings.target_manager_base_url}/databases",
+        url=f"{settings.target_manager_base_url}/cloud_databases",
         timeout=timeout_seconds,
     )
     return {
@@ -202,7 +202,7 @@ def add_target() -> Response:
         target_tracking_rater=target_tracking_rater,
     )
 
-    databases_url = f"{settings.target_manager_base_url}/databases"
+    databases_url = f"{settings.target_manager_base_url}/cloud_databases"
     timeout_seconds = 30
     requests.post(
         url=f"{databases_url}/{database.database_name}/targets",
@@ -318,7 +318,7 @@ def delete_target(target_id: str) -> Response:
     if target.status == TargetStatuses.PROCESSING.value:
         raise TargetStatusProcessingError
 
-    databases_url = f"{settings.target_manager_base_url}/databases"
+    databases_url = f"{settings.target_manager_base_url}/cloud_databases"
     requests.delete(
         url=f"{databases_url}/{database.database_name}/targets/{target_id}",
         timeout=30,
@@ -669,7 +669,7 @@ def update_target(target_id: str) -> Response:
         update_values["image"] = image
 
     put_url = (
-        f"{settings.target_manager_base_url}/databases/"
+        f"{settings.target_manager_base_url}/cloud_databases/"
         f"{database.database_name}/targets/{target_id}"
     )
     requests.put(url=put_url, json=update_values, timeout=30)

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -126,17 +126,19 @@ class MockVWS(ContextDecorator):
             query_match_checker=query_match_checker,
         )
 
-    def add_database(self, database: CloudDatabase) -> None:
+    def add_cloud_database(self, cloud_database: CloudDatabase) -> None:
         """Add a cloud database.
 
         Args:
-            database: The database to add.
+            cloud_database: The cloud database to add.
 
         Raises:
-            ValueError: One of the given database keys matches a key for an
-                existing database.
+            ValueError: One of the given cloud database keys matches a key for
+                an existing cloud database.
         """
-        self._target_manager.add_database(database=database)
+        self._target_manager.add_cloud_database(
+            cloud_database=cloud_database,
+        )
 
     @staticmethod
     def _wrap_callback(

--- a/src/mock_vws/target_manager.py
+++ b/src/mock_vws/target_manager.py
@@ -19,59 +19,61 @@ class TargetManager:
     """
 
     def __init__(self) -> None:
-        """Create a target manager with no databases."""
-        self._databases: Iterable[CloudDatabase] = set()
+        """Create a target manager with no cloud databases."""
+        self._cloud_databases: Iterable[CloudDatabase] = set()
 
-    def remove_database(self, database: CloudDatabase) -> None:
+    def remove_cloud_database(self, cloud_database: CloudDatabase) -> None:
         """Remove a cloud database.
 
         Args:
-            database: The database to add.
+            cloud_database: The cloud database to remove.
 
         Raises:
-            KeyError: The database is not in the target manager.
+            KeyError: The cloud database is not in the target manager.
         """
-        self._databases = {db for db in self._databases if db != database}
+        self._cloud_databases = {
+            db for db in self._cloud_databases if db != cloud_database
+        }
 
-    def add_database(self, database: CloudDatabase) -> None:
+    def add_cloud_database(self, cloud_database: CloudDatabase) -> None:
         """Add a cloud database.
 
         Args:
-            database: The database to add.
+            cloud_database: The cloud database to add.
 
         Raises:
-            ValueError: One of the given database keys matches a key for an
-                existing database.
+            ValueError: One of the given cloud database keys matches a key for
+                an existing cloud database.
         """
         message_fmt = (
             "All {key_name}s must be unique. "
-            'There is already a database with the {key_name} "{value}".'
+            'There is already a cloud database with the {key_name} "{value}".'
         )
         for existing_db in self.cloud_databases:
             for existing, new, key_name in (
                 (
                     existing_db.server_access_key,
-                    database.server_access_key,
+                    cloud_database.server_access_key,
                     "server access key",
                 ),
                 (
                     existing_db.server_secret_key,
-                    database.server_secret_key,
+                    cloud_database.server_secret_key,
                     "server secret key",
                 ),
                 (
                     existing_db.client_access_key,
-                    database.client_access_key,
+                    cloud_database.client_access_key,
                     "client access key",
                 ),
                 (
                     existing_db.client_secret_key,
-                    database.client_secret_key,
+                    cloud_database.client_secret_key,
                     "client secret key",
                 ),
                 (
                     existing_db.database_name,
-                    database.database_name,
+                    cloud_database.database_name,
                     "name",
                 ),
             ):
@@ -79,9 +81,9 @@ class TargetManager:
                     message = message_fmt.format(key_name=key_name, value=new)
                     raise ValueError(message)
 
-        self._databases = {*self._databases, database}
+        self._cloud_databases = {*self._cloud_databases, cloud_database}
 
     @property
     def cloud_databases(self) -> set[CloudDatabase]:
         """All cloud databases."""
-        return set(self._databases)
+        return set(self._cloud_databases)

--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -137,9 +137,9 @@ def _enable_use_mock_vuforia(
     )
 
     with MockVWS() as mock:
-        mock.add_database(database=working_database)
-        mock.add_database(database=inactive_database)
-        mock.add_database(database=vumark_database)
+        mock.add_cloud_database(cloud_database=working_database)
+        mock.add_cloud_database(cloud_database=inactive_database)
+        mock.add_cloud_database(cloud_database=vumark_database)
         yield
 
 
@@ -196,7 +196,7 @@ def _enable_use_docker_in_memory(
             base_url=target_manager_base_url,
         )
 
-        databases_url = target_manager_base_url + "/databases"
+        databases_url = target_manager_base_url + "/cloud_databases"
         databases = requests.get(url=databases_url, timeout=30).json()
         for database in databases:
             database_name = database["database_name"]

--- a/tests/mock_vws/test_database_summary.py
+++ b/tests/mock_vws/test_database_summary.py
@@ -246,7 +246,7 @@ class TestProcessingImages:
         )
 
         with MockVWS() as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             vws_client.add_target(
                 name=uuid.uuid4().hex,
                 width=1,

--- a/tests/mock_vws/test_docker.py
+++ b/tests/mock_vws/test_docker.py
@@ -216,7 +216,7 @@ def test_build_and_run(
     )
 
     response = requests.post(
-        url=f"{base_target_manager_url}/databases",
+        url=f"{base_target_manager_url}/cloud_databases",
         json=database.to_dict(),
         timeout=30,
     )

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -71,7 +71,7 @@ class TestProcessingTime:
     ) -> None:
         """By default, targets in the mock takes 2 seconds to be processed."""
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         time_taken = processing_time_seconds(
@@ -94,7 +94,7 @@ class TestProcessingTime:
             value=str(object=seconds),
         )
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         time_taken = processing_time_seconds(
@@ -131,26 +131,26 @@ class TestAddDatabase:
 
         server_access_key_conflict_error = (
             "All server access keys must be unique. "
-            'There is already a database with the server access key "1".'
+            'There is already a cloud database with the server access key "1".'
         )
         server_secret_key_conflict_error = (
             "All server secret keys must be unique. "
-            'There is already a database with the server secret key "2".'
+            'There is already a cloud database with the server secret key "2".'
         )
         client_access_key_conflict_error = (
             "All client access keys must be unique. "
-            'There is already a database with the client access key "3".'
+            'There is already a cloud database with the client access key "3".'
         )
         client_secret_key_conflict_error = (
             "All client secret keys must be unique. "
-            'There is already a database with the client secret key "4".'
+            'There is already a cloud database with the client secret key "4".'
         )
         database_name_conflict_error = (
             "All names must be unique. "
-            'There is already a database with the name "5".'
+            'There is already a cloud database with the name "5".'
         )
 
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         for bad_database, expected_message in (
@@ -172,7 +172,7 @@ class TestAddDatabase:
     @staticmethod
     def test_give_no_details(high_quality_image: io.BytesIO) -> None:
         """It is possible to create a database without giving any data."""
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         response = requests.post(url=databases_url, json={}, timeout=30)
         assert response.status_code == HTTPStatus.CREATED
 
@@ -206,7 +206,7 @@ class TestDeleteDatabase:
         does not
         exist.
         """
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         delete_url = databases_url + "/" + "foobar"
         response = requests.delete(url=delete_url, json={}, timeout=30)
         assert response.status_code == HTTPStatus.NOT_FOUND
@@ -214,7 +214,7 @@ class TestDeleteDatabase:
     @staticmethod
     def test_delete_database() -> None:
         """It is possible to delete a database."""
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         response = requests.post(url=databases_url, json={}, timeout=30)
         assert response.status_code == HTTPStatus.CREATED
 
@@ -253,7 +253,7 @@ class TestQueryImageMatchers:
         re_exported_image = io.BytesIO()
         pil_image.save(fp=re_exported_image, format="PNG")
 
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         target_id = vws_client.add_target(
@@ -297,7 +297,7 @@ class TestQueryImageMatchers:
         pil_image = Image.open(fp=high_quality_image)
         re_exported_image = io.BytesIO()
         pil_image.save(fp=re_exported_image, format="PNG")
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         assert re_exported_image.getvalue() != high_quality_image.getvalue()
@@ -345,7 +345,7 @@ class TestDuplicatesImageMatchers:
         re_exported_image = io.BytesIO()
         pil_image.save(fp=re_exported_image, format="PNG")
 
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         target_id = vws_client.add_target(
@@ -397,7 +397,7 @@ class TestDuplicatesImageMatchers:
         re_exported_image = io.BytesIO()
         pil_image.save(fp=re_exported_image, format="PNG")
 
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         target_id = vws_client.add_target(
@@ -430,7 +430,7 @@ class TestTargetRaters:
     ) -> None:
         """By default, the BRISQUE target rater is used."""
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         vws_client = VWS(
@@ -481,7 +481,7 @@ class TestTargetRaters:
         monkeypatch.setenv(name="TARGET_RATER", value="brisque")
 
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         vws_client = VWS(
@@ -530,7 +530,7 @@ class TestTargetRaters:
         """It is possible to use the perfect target rater."""
         monkeypatch.setenv(name="TARGET_RATER", value="perfect")
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         vws_client = VWS(
@@ -570,7 +570,7 @@ class TestTargetRaters:
         monkeypatch.setenv(name="TARGET_RATER", value="random")
 
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         vws_client = VWS(
@@ -642,7 +642,7 @@ class TestResponseDelay:
     def test_default_no_delay(self) -> None:
         """By default, there is no response delay."""
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         start = time.monotonic()
@@ -660,7 +660,7 @@ class TestResponseDelay:
             value=f"{self.DELAY_SECONDS}",
         )
         database = CloudDatabase()
-        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/databases"
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
         requests.post(url=databases_url, json=database.to_dict(), timeout=30)
 
         start = time.monotonic()

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -255,7 +255,7 @@ class TestProcessingTime:
         """By default, targets in the mock takes 2 seconds to be processed."""
         database = CloudDatabase()
         with MockVWS() as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             time_taken = processing_time_seconds(
                 vuforia_database=database,
                 image=image_file_failed_state,
@@ -269,7 +269,7 @@ class TestProcessingTime:
         database = CloudDatabase()
         seconds = 5
         with MockVWS(processing_time_seconds=seconds) as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             time_taken = processing_time_seconds(
                 vuforia_database=database,
                 image=image_file_failed_state,
@@ -384,7 +384,7 @@ class TestTargets:
         )
 
         with MockVWS() as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             vws_client.add_target(
                 name="example",
                 width=1,
@@ -418,7 +418,7 @@ class TestTargets:
         )
 
         with MockVWS() as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             target_id = vws_client.add_target(
                 name="example",
                 width=1,
@@ -457,7 +457,7 @@ class TestDatabaseToDict:
 
         # We test a database with a target added.
         with MockVWS() as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             vws_client.add_target(
                 name="example",
                 width=1,
@@ -528,27 +528,27 @@ class TestAddDatabase:
 
         server_access_key_conflict_error = (
             "All server access keys must be unique. "
-            'There is already a database with the server access key "1".'
+            'There is already a cloud database with the server access key "1".'
         )
         server_secret_key_conflict_error = (
             "All server secret keys must be unique. "
-            'There is already a database with the server secret key "2".'
+            'There is already a cloud database with the server secret key "2".'
         )
         client_access_key_conflict_error = (
             "All client access keys must be unique. "
-            'There is already a database with the client access key "3".'
+            'There is already a cloud database with the client access key "3".'
         )
         client_secret_key_conflict_error = (
             "All client secret keys must be unique. "
-            'There is already a database with the client secret key "4".'
+            'There is already a cloud database with the client secret key "4".'
         )
         database_name_conflict_error = (
             "All names must be unique. "
-            'There is already a database with the name "5".'
+            'There is already a cloud database with the name "5".'
         )
 
         with MockVWS() as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             for bad_database, expected_message in (
                 (bad_server_access_key_db, server_access_key_conflict_error),
                 (bad_server_secret_key_db, server_secret_key_conflict_error),
@@ -560,7 +560,7 @@ class TestAddDatabase:
                     expected_exception=ValueError,
                     match=expected_message + "$",
                 ):
-                    mock.add_database(database=bad_database)
+                    mock.add_cloud_database(cloud_database=bad_database)
 
 
 class TestQueryImageMatchers:
@@ -584,7 +584,7 @@ class TestQueryImageMatchers:
         pil_image.save(fp=re_exported_image, format="PNG")
 
         with MockVWS(query_match_checker=ExactMatcher()) as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             target_id = vws_client.add_target(
                 name="example",
                 width=1,
@@ -620,7 +620,7 @@ class TestQueryImageMatchers:
         pil_image.save(fp=re_exported_image, format="PNG")
 
         with MockVWS(query_match_checker=_not_exact_matcher) as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             target_id = vws_client.add_target(
                 name="example",
                 width=1,
@@ -661,7 +661,7 @@ class TestQueryImageMatchers:
         with MockVWS(
             query_match_checker=StructuralSimilarityMatcher(),
         ) as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             target_id = vws_client.add_target(
                 name="example",
                 width=1,
@@ -702,7 +702,7 @@ class TestDuplicatesImageMatchers:
         pil_image.save(fp=re_exported_image, format="PNG")
 
         with MockVWS(duplicate_match_checker=ExactMatcher()) as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             target_id = vws_client.add_target(
                 name="example_0",
                 width=1,
@@ -746,7 +746,7 @@ class TestDuplicatesImageMatchers:
         pil_image.save(fp=re_exported_image, format="PNG")
 
         with MockVWS(duplicate_match_checker=_not_exact_matcher) as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             target_id = vws_client.add_target(
                 name="example_0",
                 width=1,
@@ -794,7 +794,7 @@ class TestDuplicatesImageMatchers:
         with MockVWS(
             duplicate_match_checker=StructuralSimilarityMatcher(),
         ) as mock:
-            mock.add_database(database=database)
+            mock.add_cloud_database(cloud_database=database)
             target_id = vws_client.add_target(
                 name="example",
                 width=1,


### PR DESCRIPTION
## Summary

Clarify that database-related methods, endpoints, and variables refer to cloud databases rather than generic databases. This improves code readability and lays the groundwork for supporting additional database types in the future.

## Changes

- Flask endpoints: `/databases` → `/cloud_databases` (all 5 routes)
- `TargetManager` methods: `add_database()` → `add_cloud_database()`, `remove_database()` → `remove_cloud_database()`
- `MockVWS.add_database()` → `MockVWS.add_cloud_database()`
- Updated all callers in tests, fixtures, and documentation
- Updated error messages to reference "cloud database"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a rename/refactor, but it changes public HTTP route paths and the `MockVWS`/`TargetManager` method names, which can break external consumers expecting `/databases` or `add_database`.
> 
> **Overview**
> Clarifies terminology by renaming the Target Manager HTTP API from `/databases` to `/cloud_databases` (including nested target routes) and renaming the delete handler to `delete_cloud_database`.
> 
> Renames in-memory APIs to match: `TargetManager` now stores `_cloud_databases` and exposes `add_cloud_database`/`remove_cloud_database`, while `MockVWS.add_database` becomes `MockVWS.add_cloud_database`; all upstream VWS/VWQ calls are updated to hit the new endpoints.
> 
> Updates docs, docker examples, fixtures, and tests to use the new names and adjusts conflict error messages to say *cloud database*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd2f8100255d377f7e0bb091f6f27f2d9ee922b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->