### PR TITLE
Fix test isolation in Flask app database tests

### DIFF
--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -60,10 +60,10 @@ def _(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
         yield
 
-    for database in TARGET_MANAGER.cloud_databases:
-        TARGET_MANAGER.remove_cloud_database(cloud_database=database)
-    for database in TARGET_MANAGER.vumark_databases:
-        TARGET_MANAGER.remove_vumark_database(vumark_database=database)
+    for cloud_database in TARGET_MANAGER.cloud_databases:
+        TARGET_MANAGER.remove_cloud_database(cloud_database=cloud_database)
+    for vumark_database in TARGET_MANAGER.vumark_databases:
+        TARGET_MANAGER.remove_vumark_database(vumark_database=vumark_database)
 
 
 class TestProcessingTime:


### PR DESCRIPTION
## Summary

Reset TARGET_MANAGER state between tests by cleaning up cloud and VuMark databases in the autouse fixture. This fixes the leaky test issue where the module-level singleton was persisting state across tests, which required workaround keys ("v1", "v2", "v3" instead of "1", "2", "3") in test_duplicate_vumark_keys.

The fix reuses the public API (remove_cloud_database/remove_vumark_database) to clean up after each test, ensuring proper test isolation.

## Changes

- Import TARGET_MANAGER in test_flask_app_usage.py
- Add cleanup code in the autouse fixture to remove all databases after each test
- Revert test keys from "v1"/"v2"/"v3" back to "1"/"2"/"3" since the underlying test leakiness is now fixed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that improve isolation by cleaning up shared singleton state; low risk aside from potential flakiness if cleanup interacts with concurrent tests.
> 
> **Overview**
> Ensures `tests/mock_vws/test_flask_app_usage.py` no longer leaks state between tests by importing the singleton `TARGET_MANAGER` and clearing all cloud and VuMark databases in the autouse fixture teardown via `remove_cloud_database`/`remove_vumark_database`.
> 
> Updates the duplicate VuMark key test to use simple key values again ("1"/"2"/"3") now that prior test-created databases are reliably cleaned up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bdd91ed60556f3625913acdf449f04a86600fa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->