### PR TITLE
Fix error handling in VuMark database deletion

### DIFF
--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -91,11 +91,15 @@ def delete_vumark_database(database_name: str) -> Response:
 
     :status 200: The VuMark database has been deleted.
     """
-    (matching_database,) = {
-        database
-        for database in TARGET_MANAGER.vumark_databases
-        if database_name == database.database_name
-    }
+    try:
+        (matching_database,) = {
+            database
+            for database in TARGET_MANAGER.vumark_databases
+            if database_name == database.database_name
+        }
+    except ValueError:
+        return Response(response="", status=HTTPStatus.NOT_FOUND)
+
     TARGET_MANAGER.remove_vumark_database(vumark_database=matching_database)
     return Response(response="", status=HTTPStatus.OK)
 

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -272,6 +272,33 @@ class TestDeleteDatabase:
         response = requests.delete(url=delete_url, json={}, timeout=30)
         assert response.status_code == HTTPStatus.NOT_FOUND
 
+    @staticmethod
+    def test_vumark_not_found() -> None:
+        """
+        A 404 error is returned when trying to delete a VuMark database
+        which
+        does not exist.
+        """
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/vumark_databases"
+        delete_url = databases_url + "/" + "foobar"
+        response = requests.delete(url=delete_url, json={}, timeout=30)
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+    @staticmethod
+    def test_delete_vumark_database() -> None:
+        """It is possible to delete a VuMark database."""
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/vumark_databases"
+        response = requests.post(url=databases_url, json={}, timeout=30)
+        assert response.status_code == HTTPStatus.CREATED
+
+        data = json.loads(s=response.text)
+        delete_url = databases_url + "/" + data["database_name"]
+        response = requests.delete(url=delete_url, json={}, timeout=30)
+        assert response.status_code == HTTPStatus.OK
+
+        response = requests.delete(url=delete_url, json={}, timeout=30)
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
 
 class TestQueryImageMatchers:
     """Tests for query image matchers."""


### PR DESCRIPTION
## Summary

Add error handling to the `delete_vumark_database` endpoint to return a 404 instead of crashing with a 500 error when no matching VuMark database exists. The endpoint was missing the `try/except ValueError` pattern already present in `delete_cloud_database`.

## Changes

- Fixed `delete_vumark_database` to catch `ValueError` from unpacking when no database matches the provided name
- Added test `test_vumark_not_found` to verify 404 is returned for missing databases
- Added test `test_delete_vumark_database` to verify successful deletion and subsequent 404

## Test Plan

- All existing tests pass
- New tests verify VuMark database deletion behavior matches cloud database deletion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to mock Flask endpoint error handling plus tests; behavior now matches existing cloud database deletion and should only reduce 500s.
> 
> **Overview**
> Prevents the `DELETE /vumark_databases/<database_name>` endpoint from erroring when the requested database doesn’t exist by catching the unpacking `ValueError` and returning `HTTPStatus.NOT_FOUND`.
> 
> Adds integration tests to verify VuMark deletion succeeds once and then returns 404 on subsequent deletes, and that deleting a nonexistent VuMark database returns 404.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eaacf963f914f3770870091c74df9ab8333d289. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->