### PR TITLE
Refactor request handling with library-agnostic RequestData

### DIFF
--- a/src/mock_vws/_mock_common.py
+++ b/src/mock_vws/_mock_common.py
@@ -1,11 +1,28 @@
 """Common utilities for creating mock routes."""
 
 import json
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
 from beartype import beartype
+
+
+@dataclass(frozen=True)
+class RequestData:
+    """A library-agnostic representation of an HTTP request.
+
+    Args:
+        method: The HTTP method of the request.
+        path: The path of the request.
+        headers: The headers sent with the request.
+        body: The body of the request.
+    """
+
+    method: str
+    path: str
+    headers: Mapping[str, str]
+    body: bytes
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Introduce RequestData dataclass as a frozen, library-agnostic representation of HTTP requests, replacing the requests library's PreparedRequest in the handler layer.

**Changes:**
- Add RequestData dataclass with method, path, headers, body fields
- Update all handler signatures to accept RequestData instead of PreparedRequest
- Move body normalization (None/str/bytes handling) to adapter boundary in decorators.py
- Remove duplicate _body_bytes() helpers from both API modules
- Decouple core business logic from requests library dependency

This enables future adapter support (respx, httpx, etc) and eliminates type-checking conflicts between mypy, pyrefly, and ruff.

Fixes #2974

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core interface between the `responses` adapter and all mock route handlers, so incorrect request normalization (body/path/headers) could break request validation or JSON parsing across endpoints.
> 
> **Overview**
> Refactors the mock request handling layer to use a new frozen `RequestData` dataclass (`method`, `path`, `headers`, `body`) instead of `requests.PreparedRequest`.
> 
> `MockVWS._wrap_callback` now converts a `PreparedRequest` into `RequestData` (including normalizing body to bytes) before invoking route handlers, and both Web Services and Web Query API handlers are updated to consume `RequestData`, removing duplicated body-parsing helpers and switching from `path_url` to `path`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit def934d74b38c06ff38f2462b4e368949ce3d5fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->