### PR TITLE
Enforce keyword-only arguments

### DIFF
--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -369,6 +369,7 @@ def delete_target(database_name: str, target_id: str) -> Response:
     rule="/cloud_databases/<string:database_name>/targets/<string:target_id>",
     methods=[HTTPMethod.PUT],
 )
+@beartype
 def update_target(database_name: str, target_id: str) -> Response:
     """Update a target."""
     (database,) = (

--- a/src/mock_vws/_flask_server/vwq.py
+++ b/src/mock_vws/_flask_server/vwq.py
@@ -113,6 +113,7 @@ def add_response_delay(response: Response) -> Response:
 
 
 @CLOUDRECO_FLASK_APP.errorhandler(code_or_exception=ValidatorError)
+@beartype
 def handle_exceptions(exc: ValidatorError) -> Response:
     """Return the error response associated with the given exception."""
     response = Response(
@@ -127,6 +128,7 @@ def handle_exceptions(exc: ValidatorError) -> Response:
 
 
 @CLOUDRECO_FLASK_APP.route(rule="/v1/query", methods=[HTTPMethod.POST])
+@beartype
 def query() -> Response:
     """Perform an image recognition query."""
     settings = VWQSettings.model_validate(obj={})

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -117,6 +117,7 @@ def get_all_vumark_databases() -> set[VuMarkDatabase]:
 
 
 @VWS_FLASK_APP.before_request
+@beartype
 def set_terminate_wsgi_input() -> None:
     """We set ``wsgi.input_terminated`` to ``True`` when going through
     ``requests`` in our tests, so that requests have the given ``Content-
@@ -171,6 +172,7 @@ def add_response_delay(response: Response) -> Response:
 
 
 @VWS_FLASK_APP.errorhandler(code_or_exception=ValidatorError)
+@beartype
 def handle_exceptions(exc: ValidatorError) -> Response:
     """Return the error response associated with the given exception."""
     response = Response(
@@ -319,6 +321,7 @@ def get_target(target_id: str) -> Response:
     rule="/targets/<string:target_id>",
     methods=[HTTPMethod.DELETE],
 )
+@beartype
 def delete_target(target_id: str) -> Response:
     """Delete a target.
 
@@ -499,6 +502,7 @@ def database_summary() -> Response:
     rule="/summary/<string:target_id>",
     methods=[HTTPMethod.GET],
 )
+@beartype
 def target_summary(target_id: str) -> Response:
     """Get a summary report for a target.
 
@@ -616,6 +620,7 @@ def get_duplicates(target_id: str) -> Response:
 
 
 @VWS_FLASK_APP.route(rule="/targets", methods=[HTTPMethod.GET])
+@beartype
 def target_list() -> Response:
     """Get a list of all targets.
 
@@ -658,6 +663,7 @@ def target_list() -> Response:
 @VWS_FLASK_APP.route(
     rule="/targets/<string:target_id>", methods=[HTTPMethod.PUT]
 )
+@beartype
 def update_target(target_id: str) -> Response:
     """Update a target.
 

--- a/src/mock_vws/_mock_common.py
+++ b/src/mock_vws/_mock_common.py
@@ -8,6 +8,7 @@ from typing import Any
 from beartype import beartype
 
 
+@beartype
 @dataclass(frozen=True)
 class RequestData:
     """A library-agnostic representation of an HTTP request.
@@ -25,6 +26,7 @@ class RequestData:
     body: bytes
 
 
+@beartype
 @dataclass(frozen=True)
 class Route:
     """A representation of a VWS route.

--- a/src/mock_vws/_query_validators/content_type_validators.py
+++ b/src/mock_vws/_query_validators/content_type_validators.py
@@ -18,6 +18,7 @@ _LOGGER = logging.getLogger(name=__name__)
 
 @beartype
 def validate_content_type_header(
+    *,
     request_headers: Mapping[str, str],
     request_body: bytes,
 ) -> None:

--- a/src/mock_vws/_query_validators/date_validators.py
+++ b/src/mock_vws/_query_validators/date_validators.py
@@ -34,6 +34,7 @@ def validate_date_header_given(*, request_headers: Mapping[str, str]) -> None:
     raise DateHeaderNotGivenError
 
 
+@beartype
 def _accepted_date_formats() -> set[str]:
     """Return all known accepted date formats.
 

--- a/src/mock_vws/_query_validators/image_validators.py
+++ b/src/mock_vws/_query_validators/image_validators.py
@@ -171,6 +171,7 @@ def validate_image_format(
 
 @beartype
 def validate_image_is_image(
+    *,
     request_headers: Mapping[str, str],
     request_body: bytes,
 ) -> None:

--- a/src/mock_vws/_query_validators/include_target_data_validators.py
+++ b/src/mock_vws/_query_validators/include_target_data_validators.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(name=__name__)
 
 @beartype
 def validate_include_target_data(
+    *,
     request_headers: Mapping[str, str],
     request_body: bytes,
 ) -> None:

--- a/src/mock_vws/_query_validators/project_state_validators.py
+++ b/src/mock_vws/_query_validators/project_state_validators.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(name=__name__)
 
 @beartype
 def validate_project_state(
+    *,
     request_path: str,
     request_headers: Mapping[str, str],
     request_body: bytes,

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -35,6 +35,7 @@ _STRUCTURAL_SIMILARITY_MATCHER = StructuralSimilarityMatcher()
 _BRISQUE_TRACKING_RATER = BrisqueTargetTrackingRater()
 
 
+@beartype
 class MissingSchemeError(Exception):
     """Raised when a URL is missing a schema."""
 

--- a/src/mock_vws/_requests_mock_server/mock_web_query_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_query_api.py
@@ -41,6 +41,7 @@ class _RouteMethod(Protocol[_P]):
 
 @beartype
 def route(
+    *,
     path_pattern: str,
     http_methods: Iterable[str],
 ) -> Callable[[_RouteMethod[_P]], _RouteMethod[_P]]:

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -67,6 +67,7 @@ class _RouteMethod(Protocol[_P]):
 
 @beartype
 def route(
+    *,
     path_pattern: str,
     http_methods: Iterable[HTTPMethod],
 ) -> Callable[[_RouteMethod[_P]], _RouteMethod[_P]]:

--- a/src/mock_vws/_services_validators/__init__.py
+++ b/src/mock_vws/_services_validators/__init__.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Iterable, Mapping
 
+from beartype import beartype
+
 from mock_vws._database_matchers import AnyDatabase
 
 from .active_flag_validators import validate_active_flag
@@ -50,7 +52,9 @@ from .target_validators import validate_target_id_exists
 from .width_validators import validate_width
 
 
+@beartype
 def run_services_validators(
+    *,
     request_path: str,
     request_headers: Mapping[str, str],
     request_body: bytes,

--- a/src/mock_vws/_services_validators/key_validators.py
+++ b/src/mock_vws/_services_validators/key_validators.py
@@ -14,6 +14,7 @@ from .exceptions import FailError
 _LOGGER = logging.getLogger(name=__name__)
 
 
+@beartype
 @dataclass
 class _Route:
     """A representation of a VWS route.


### PR DESCRIPTION
## Summary
- Add * separator to enforce keyword-only arguments in functions with 2+ parameters
- Update all call sites to use keyword arguments
- Applies to validator functions and route decorators

## Test plan
- [ ] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because tightening function signatures and adding runtime type enforcement can break downstream callers or raise new exceptions at runtime if any call sites/types are mismatched.
> 
> **Overview**
> Enforces **keyword-only arguments** on several multi-parameter functions (notably query/service validators and the `route` decorators) by adding `*`, requiring call sites to pass explicit keywords.
> 
> Expands runtime type checking by adding `@beartype` to additional Flask handlers (`vws.py`, `vwq.py`, `target_manager.py`) and to shared utility types (`RequestData`, `Route`, `_Route`, `MissingSchemeError`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f7859b358d4eb83c029557a94d431db9451d4aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->