### PR TITLE
Use native pytest TOML configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,7 +340,7 @@ markers = [
 # Options for pytest-retry.
 retries = "10"
 retry_delay = "10"
-cumulative_timing = "false"
+cumulative_timing = false
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
## Summary
- Remove `ini_options.` prefix from pytest configuration keys under `[tool.pytest]`
- Uses the native TOML configuration format supported since pytest 9.0
- See: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change limited to pytest settings; risk is mainly tests behaving differently if pytest 9+/plugins interpret the TOML values (notably the stringified retry settings) unexpectedly.
> 
> **Overview**
> Updates `[tool.pytest]` in `pyproject.toml` to use native pytest TOML configuration (e.g., `xfail_strict`, `log_cli`, `addopts`, `markers`) instead of `ini_options.*`.
> 
> Also converts the `pytest-retry` options (`retries`, `retry_delay`) to TOML string values to match the new configuration style; behavior should remain the same but depends on pytest/plugin parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 222ae78aa5ff76d3770268466b7a208dece96dde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->