### PR TITLE
Use VuMarkService in VuMark generation API tests

### DIFF
--- a/tests/mock_vws/test_vumark_generation_api.py
+++ b/tests/mock_vws/test_vumark_generation_api.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 import requests
+from beartype import beartype
 from vws import VWS, VuMarkService
 from vws.exceptions.vws_exceptions import (
     InvalidInstanceIdError,
@@ -25,6 +26,7 @@ _PDF_SIGNATURE = b"%PDF"
 _SVG_START = b"<"
 
 
+@beartype
 def _make_vumark_service(
     *,
     server_access_key: str,
@@ -37,6 +39,7 @@ def _make_vumark_service(
     )
 
 
+@beartype
 def _make_vumark_request(
     *,
     server_access_key: str,


### PR DESCRIPTION
This updates VuMark generation API tests to use vws-python's VuMarkService and VuMarkAccept for client-level behavior checks. It converts the empty instance ID and non-VuMark target tests to assert typed vws exceptions (InvalidInstanceIdError and InvalidTargetTypeError) and inspect their responses. It keeps raw signed requests where direct protocol/header control is required and adds a dedicated test for response Content-Type across PNG/SVG/PDF formats. The PR diff is limited to tests/mock_vws/test_vumark_generation_api.py.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that primarily refactor assertions and add a header check; no production logic or security-sensitive code is modified.
> 
> **Overview**
> Updates VuMark generation API tests to exercise the `vws` client surface: generation now uses `VuMarkService.generate_vumark_instance` with typed `VuMarkAccept` values, and the format test validates returned bytes by file signature.
> 
> Error-path coverage is shifted from raw HTTP assertions to asserting `InvalidInstanceIdError`/`InvalidTargetTypeError` exceptions and inspecting their embedded HTTP responses. Raw signed requests are retained where direct header control is needed, with a new dedicated test that validates the `Content-Type` header for PNG/SVG/PDF responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c781a28d4f2c544454d9137ecd2d1f45c946748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->