### PR TITLE
Add clarifying comment and test for unknown target in VuMark

### DIFF
--- a/tests/mock_vws/test_invalid_given_id.py
+++ b/tests/mock_vws/test_invalid_given_id.py
@@ -34,6 +34,9 @@ class TestInvalidGivenID:
         target ID
         of a target which does not exist.
         """
+        # This shared check only covers endpoints that end in target_id,
+        # such as /targets/{target_id}. Endpoints with trailing segments
+        # are covered by endpoint-specific tests.
         if not endpoint.path_url.endswith(target_id):
             return
 

--- a/tests/mock_vws/test_vumark_generation_api.py
+++ b/tests/mock_vws/test_vumark_generation_api.py
@@ -196,6 +196,23 @@ class TestGenerateInstance:
         )
 
     @staticmethod
+    def test_unknown_target(
+        vumark_vuforia_database: VuMarkCloudDatabase,
+    ) -> None:
+        """An unknown target_id returns UnknownTarget."""
+        response = _make_vumark_request(
+            server_access_key=vumark_vuforia_database.server_access_key,
+            server_secret_key=vumark_vuforia_database.server_secret_key,
+            target_id=uuid4().hex,
+            instance_id=uuid4().hex,
+            accept=VuMarkAccept.PNG,
+        )
+
+        assert response.status_code == HTTPStatus.NOT_FOUND
+        response_json = response.json()
+        assert response_json["result_code"] == ResultCodes.UNKNOWN_TARGET.value
+
+    @staticmethod
     def test_non_vumark_database(
         vuforia_database: CloudDatabase,
     ) -> None:


### PR DESCRIPTION
Add clarifying comment in test_invalid_given_id explaining that the shared check only covers endpoints ending in target_id, with endpoint-specific tests covering trailing segments. Add test_unknown_target to verify that the VuMark generation API correctly returns UnknownTarget for non-existent targets.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (comment + new assertion coverage) with no production logic modifications.
> 
> **Overview**
> Clarifies in `test_invalid_given_id` that the shared invalid-ID check only applies to endpoints whose paths end with `{target_id}`, leaving trailing-segment endpoints to their own tests.
> 
> Adds a new VuMark generation API test (`test_unknown_target`) that requests an instance for a non-existent `target_id` and asserts a `404 NOT_FOUND` with `ResultCodes.UNKNOWN_TARGET`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cab8193e95c0e5309ea07058ef333d444f1a690. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->