### PR TITLE
Use keyword-only parameters in tests

### DIFF
--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -83,6 +83,7 @@ def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
 
 
 def test_tests_collected_once(
+    *,
     capsys: pytest.CaptureFixture[str],
     request: pytest.FixtureRequest,
 ) -> None:

--- a/tests/mock_vws/test_add_target.py
+++ b/tests/mock_vws/test_add_target.py
@@ -103,6 +103,7 @@ class TestContentTypes:
         ],
     )
     def test_content_types(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
         content_type: str,
@@ -129,6 +130,7 @@ class TestContentTypes:
 
     @staticmethod
     def test_empty_content_type(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -174,6 +176,7 @@ class TestMissingData:
         argvalues=["name", "width", "image"],
     )
     def test_missing_data(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
         data_to_remove: str,
@@ -212,6 +215,7 @@ class TestWidth:
         ids=["Negative", "Wrong Type", "None", "Zero"],
     )
     def test_width_invalid(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
         width: int | str | None,
@@ -239,6 +243,7 @@ class TestWidth:
 
     @staticmethod
     def test_width_valid(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -273,6 +278,7 @@ class TestTargetName:
         ids=["Short name", "Max char value", "Long name"],
     )
     def test_name_valid(
+        *,
         name: str,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
@@ -310,6 +316,7 @@ class TestTargetName:
         ],
     )
     def test_name_invalid(
+        *,
         name: str | int | None,
         image_file_failed_state: io.BytesIO,
         status_code: int,
@@ -349,6 +356,7 @@ class TestTargetName:
 
     @staticmethod
     def test_existing_target_name(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -378,6 +386,7 @@ class TestTargetName:
 
     @staticmethod
     def test_deleted_existing_target_name(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -411,6 +420,7 @@ class TestImage:
 
     @staticmethod
     def test_image_valid(
+        *,
         vws_client: VWS,
         image_files_failed_state: io.BytesIO,
     ) -> None:
@@ -428,6 +438,7 @@ class TestImage:
 
     @staticmethod
     def test_bad_image_format_or_color_space(
+        *,
         bad_image_file: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -454,6 +465,7 @@ class TestImage:
 
     @staticmethod
     def test_corrupted(
+        *,
         corrupted_image_file: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -543,6 +555,7 @@ class TestImage:
 
     @staticmethod
     def test_not_base64_encoded_processable(
+        *,
         vws_client: VWS,
         not_base64_encoded_processable: str,
     ) -> None:
@@ -570,6 +583,7 @@ class TestImage:
 
     @staticmethod
     def test_not_base64_encoded_not_processable(
+        *,
         vws_client: VWS,
         not_base64_encoded_not_processable: str,
     ) -> None:
@@ -622,6 +636,7 @@ class TestImage:
         argvalues=[1, None],
     )
     def test_invalid_type(
+        *,
         invalid_type_image: int | None,
         vws_client: VWS,
     ) -> None:
@@ -681,6 +696,7 @@ class TestActiveFlag:
 
     @staticmethod
     def test_invalid(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -717,6 +733,7 @@ class TestActiveFlag:
 
     @staticmethod
     def test_not_set(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -740,6 +757,7 @@ class TestActiveFlag:
 
     @staticmethod
     def test_set_to_none(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -773,6 +791,7 @@ class TestUnexpectedData:
 
     @staticmethod
     def test_invalid_extra_data(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -816,6 +835,7 @@ class TestApplicationMetadata:
         ids=["Short", "Max length"],
     )
     def test_base64_encoded(
+        *,
         image_file_failed_state: io.BytesIO,
         metadata: bytes,
         vws_client: VWS,
@@ -835,6 +855,7 @@ class TestApplicationMetadata:
 
     @staticmethod
     def test_null(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -860,6 +881,7 @@ class TestApplicationMetadata:
 
     @staticmethod
     def test_invalid_type(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -890,6 +912,7 @@ class TestApplicationMetadata:
 
     @staticmethod
     def test_not_base64_encoded_processable(
+        *,
         high_quality_image: io.BytesIO,
         not_base64_encoded_processable: str,
         vws_client: VWS,
@@ -909,6 +932,7 @@ class TestApplicationMetadata:
 
     @staticmethod
     def test_not_base64_encoded_not_processable(
+        *,
         high_quality_image: io.BytesIO,
         not_base64_encoded_not_processable: str,
         vws_client: VWS,
@@ -935,6 +959,7 @@ class TestApplicationMetadata:
 
     @staticmethod
     def test_metadata_too_large(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -970,6 +995,7 @@ class TestInactiveProject:
 
     @staticmethod
     def test_inactive_project(
+        *,
         image_file_failed_state: io.BytesIO,
         inactive_vws_client: VWS,
     ) -> None:

--- a/tests/mock_vws/test_authorization_header.py
+++ b/tests/mock_vws/test_authorization_header.py
@@ -265,6 +265,7 @@ class TestBadKey:
 
     @staticmethod
     def test_bad_access_key_query(
+        *,
         vuforia_database: CloudDatabase,
         high_quality_image: io.BytesIO,
     ) -> None:
@@ -328,6 +329,7 @@ class TestBadKey:
 
     @staticmethod
     def test_bad_secret_key_query(
+        *,
         vuforia_database: CloudDatabase,
         high_quality_image: io.BytesIO,
     ) -> None:

--- a/tests/mock_vws/test_database_summary.py
+++ b/tests/mock_vws/test_database_summary.py
@@ -94,6 +94,7 @@ class TestDatabaseSummary:
 
     @staticmethod
     def test_success(
+        *,
         vuforia_database: CloudDatabase,
         vws_client: VWS,
     ) -> None:
@@ -110,7 +111,7 @@ class TestDatabaseSummary:
         )
 
     @staticmethod
-    def test_active_images(vws_client: VWS, target_id: str) -> None:
+    def test_active_images(*, vws_client: VWS, target_id: str) -> None:
         """The number of images in the active state is returned."""
         vws_client.wait_for_target_processed(target_id=target_id)
 
@@ -124,6 +125,7 @@ class TestDatabaseSummary:
 
     @staticmethod
     def test_failed_images(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -148,6 +150,7 @@ class TestDatabaseSummary:
 
     @staticmethod
     def test_inactive_images(
+        *,
         vws_client: VWS,
         image_file_success_state_low_rating: io.BytesIO,
     ) -> None:
@@ -176,6 +179,7 @@ class TestDatabaseSummary:
 
     @staticmethod
     def test_inactive_failed(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -200,6 +204,7 @@ class TestDatabaseSummary:
 
     @staticmethod
     def test_deleted(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -289,6 +294,7 @@ class TestRecos:
 
     @staticmethod
     def test_query_request(
+        *,
         cloud_reco_client: CloudRecoService,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
@@ -344,6 +350,7 @@ class TestRequestUsage:
 
     @staticmethod
     def test_bad_target_request(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -372,6 +379,7 @@ class TestRequestUsage:
 
     @staticmethod
     def test_query_request(
+        *,
         cloud_reco_client: CloudRecoService,
         high_quality_image: io.BytesIO,
         vws_client: VWS,

--- a/tests/mock_vws/test_delete_target.py
+++ b/tests/mock_vws/test_delete_target.py
@@ -19,7 +19,7 @@ class TestDelete:
     """Tests for deleting targets."""
 
     @staticmethod
-    def test_no_wait(target_id: str, vws_client: VWS) -> None:
+    def test_no_wait(*, target_id: str, vws_client: VWS) -> None:
         """When attempting to delete a target immediately after creating
         it, a
         `FORBIDDEN` response is returned.
@@ -41,7 +41,7 @@ class TestDelete:
         )
 
     @staticmethod
-    def test_processed(target_id: str, vws_client: VWS) -> None:
+    def test_processed(*, target_id: str, vws_client: VWS) -> None:
         """When a target has finished processing, it can be deleted."""
         vws_client.wait_for_target_processed(target_id=target_id)
         vws_client.delete_target(target_id=target_id)

--- a/tests/mock_vws/test_docker.py
+++ b/tests/mock_vws/test_docker.py
@@ -88,6 +88,7 @@ def fixture_custom_bridge_network() -> Iterator[Network]:
 
 @pytest.mark.requires_docker_build
 def test_build_and_run(
+    *,
     high_quality_image: io.BytesIO,
     custom_bridge_network: Network,
     request: pytest.FixtureRequest,

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -92,6 +92,7 @@ class TestProcessingTime:
 
     def test_custom(
         self,
+        *,
         image_file_failed_state: io.BytesIO,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -323,6 +324,7 @@ class TestQueryImageMatchers:
 
     @staticmethod
     def test_exact_match(
+        *,
         high_quality_image: io.BytesIO,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -366,6 +368,7 @@ class TestQueryImageMatchers:
 
     @staticmethod
     def test_structural_similarity_matcher(
+        *,
         high_quality_image: io.BytesIO,
         different_high_quality_image: io.BytesIO,
         monkeypatch: pytest.MonkeyPatch,
@@ -421,6 +424,7 @@ class TestDuplicatesImageMatchers:
 
     @staticmethod
     def test_exact_match(
+        *,
         high_quality_image: io.BytesIO,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -470,6 +474,7 @@ class TestDuplicatesImageMatchers:
 
     @staticmethod
     def test_structural_similarity_matcher(
+        *,
         high_quality_image: io.BytesIO,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -516,6 +521,7 @@ class TestTargetRaters:
 
     @staticmethod
     def test_default(
+        *,
         image_file_success_state_low_rating: io.BytesIO,
         high_quality_image: io.BytesIO,
     ) -> None:
@@ -564,6 +570,7 @@ class TestTargetRaters:
 
     @staticmethod
     def test_brisque(
+        *,
         monkeypatch: pytest.MonkeyPatch,
         image_file_success_state_low_rating: io.BytesIO,
         high_quality_image: io.BytesIO,
@@ -615,6 +622,7 @@ class TestTargetRaters:
 
     @staticmethod
     def test_perfect(
+        *,
         monkeypatch: pytest.MonkeyPatch,
         high_quality_image: io.BytesIO,
     ) -> None:
@@ -654,6 +662,7 @@ class TestTargetRaters:
 
     @staticmethod
     def test_random(
+        *,
         monkeypatch: pytest.MonkeyPatch,
         high_quality_image: io.BytesIO,
     ) -> None:

--- a/tests/mock_vws/test_get_duplicates.py
+++ b/tests/mock_vws/test_get_duplicates.py
@@ -17,6 +17,7 @@ class TestDuplicates:
 
     @staticmethod
     def test_duplicates(
+        *,
         high_quality_image: io.BytesIO,
         image_file_success_state_low_rating: io.BytesIO,
         vws_client: VWS,
@@ -61,6 +62,7 @@ class TestDuplicates:
 
     @staticmethod
     def test_duplicates_not_same(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -100,6 +102,7 @@ class TestDuplicates:
 
     @staticmethod
     def test_status(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -141,6 +144,7 @@ class TestActiveFlag:
 
     @staticmethod
     def test_active_flag(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -194,6 +198,7 @@ class TestProcessing:
 
     @staticmethod
     def test_processing(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
     ) -> None:

--- a/tests/mock_vws/test_get_target.py
+++ b/tests/mock_vws/test_get_target.py
@@ -18,6 +18,7 @@ class TestGetRecord:
 
     @staticmethod
     def test_get_vws_target(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -53,6 +54,7 @@ class TestGetRecord:
 
     @staticmethod
     def test_fail_status(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -77,6 +79,7 @@ class TestGetRecord:
 
     @staticmethod
     def test_success_status(
+        *,
         image_file_success_state_low_rating: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -139,6 +142,7 @@ class TestTargetTrackingRating:
 
     @staticmethod
     def test_target_quality(
+        *,
         vws_client: VWS,
         high_quality_image: io.BytesIO,
         image_file_success_state_low_rating: io.BytesIO,

--- a/tests/mock_vws/test_invalid_given_id.py
+++ b/tests/mock_vws/test_invalid_given_id.py
@@ -25,6 +25,7 @@ class TestInvalidGivenID:
 
     @staticmethod
     def test_not_real_id(
+        *,
         vws_client: VWS,
         endpoint: Endpoint,
         target_id: str,

--- a/tests/mock_vws/test_query.py
+++ b/tests/mock_vws/test_query.py
@@ -273,6 +273,7 @@ class TestContentType:
 
     @staticmethod
     def test_incorrect_with_boundary(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
     ) -> None:
@@ -351,6 +352,7 @@ class TestContentType:
         ],
     )
     def test_no_boundary(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         content_type: str,
@@ -415,6 +417,7 @@ class TestContentType:
 
     @staticmethod
     def test_bogus_boundary(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
     ) -> None:
@@ -477,6 +480,7 @@ class TestContentType:
 
     @staticmethod
     def test_extra_section(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
     ) -> None:
@@ -540,6 +544,7 @@ class TestSuccess:
 
     @staticmethod
     def test_no_results(
+        *,
         high_quality_image: io.BytesIO,
         cloud_reco_client: CloudRecoService,
     ) -> None:
@@ -553,6 +558,7 @@ class TestSuccess:
 
     @staticmethod
     def test_match_exact(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         vws_client: VWS,
@@ -603,6 +609,7 @@ class TestSuccess:
 
     @staticmethod
     def test_low_quality_image(
+        *,
         image_file_success_state_low_rating: io.BytesIO,
         cloud_reco_client: CloudRecoService,
         vws_client: VWS,
@@ -631,6 +638,7 @@ class TestSuccess:
 
     @staticmethod
     def test_match_similar(
+        *,
         high_quality_image: io.BytesIO,
         different_high_quality_image: io.BytesIO,
         vws_client: VWS,
@@ -681,6 +689,7 @@ class TestSuccess:
 
     @staticmethod
     def test_not_base64_encoded_processable(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
         not_base64_encoded_processable: str,
@@ -753,6 +762,7 @@ class TestIncorrectFields:
 
     @staticmethod
     def test_extra_fields(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
     ) -> None:
@@ -810,6 +820,7 @@ class TestMaxNumResults:
 
     @staticmethod
     def test_default(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         vws_client: VWS,
@@ -847,6 +858,7 @@ class TestMaxNumResults:
     @staticmethod
     @pytest.mark.parametrize(argnames="num_results", argvalues=[1, b"1", 50])
     def test_valid_accepted(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         num_results: int | bytes,
@@ -877,6 +889,7 @@ class TestMaxNumResults:
 
     @staticmethod
     def test_valid_works(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
@@ -899,6 +912,7 @@ class TestMaxNumResults:
     @staticmethod
     @pytest.mark.parametrize(argnames="num_results", argvalues=[-1, 0, 51])
     def test_out_of_range(
+        *,
         high_quality_image: io.BytesIO,
         num_results: int,
         cloud_reco_client: CloudRecoService,
@@ -940,6 +954,7 @@ class TestMaxNumResults:
         argvalues=[b"0.1", b"1.1", b"a", b"2147483648"],
     )
     def test_invalid_type(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         num_results: bytes,
@@ -1002,6 +1017,7 @@ class TestIncludeTargetData:
 
     @staticmethod
     def test_default(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
         vuforia_database: CloudDatabase,
@@ -1032,6 +1048,7 @@ class TestIncludeTargetData:
         argvalues=["top", "TOP"],
     )
     def test_top(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         include_target_data: str,
@@ -1068,6 +1085,7 @@ class TestIncludeTargetData:
         argvalues=["none", "NONE"],
     )
     def test_none(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         include_target_data: str,
@@ -1104,6 +1122,7 @@ class TestIncludeTargetData:
         argvalues=["all", "ALL"],
     )
     def test_all(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         include_target_data: str,
@@ -1189,6 +1208,7 @@ class TestAcceptHeader:
         ],
     )
     def test_valid(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         extra_headers: dict[str, str],
@@ -1245,6 +1265,7 @@ class TestAcceptHeader:
 
     @staticmethod
     def test_invalid(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
     ) -> None:
@@ -1315,6 +1336,7 @@ class TestActiveFlag:
 
     @staticmethod
     def test_inactive(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
@@ -1339,6 +1361,7 @@ class TestBadImage:
 
     @staticmethod
     def test_corrupted(
+        *,
         corrupted_image_file: io.BytesIO,
         cloud_reco_client: CloudRecoService,
     ) -> None:
@@ -1667,6 +1690,7 @@ class TestImageFormats:
     @staticmethod
     @pytest.mark.parametrize(argnames="file_format", argvalues=["png", "jpeg"])
     def test_supported(
+        *,
         high_quality_image: io.BytesIO,
         file_format: str,
         cloud_reco_client: CloudRecoService,
@@ -1683,6 +1707,7 @@ class TestImageFormats:
 
     @staticmethod
     def test_unsupported(
+        *,
         high_quality_image: io.BytesIO,
         cloud_reco_client: CloudRecoService,
     ) -> None:
@@ -1729,10 +1754,10 @@ class TestProcessing:
     @staticmethod
     @pytest.mark.parametrize(argnames="active_flag", argvalues=[True, False])
     def test_processing(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
-        *,
         active_flag: bool,
     ) -> None:
         """
@@ -1773,6 +1798,7 @@ class TestUpdate:
 
     @staticmethod
     def test_updated_target(
+        *,
         high_quality_image: io.BytesIO,
         different_high_quality_image: io.BytesIO,
         vws_client: VWS,
@@ -1850,6 +1876,7 @@ class TestDeleted:
 
     @staticmethod
     def test_deleted_active(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
@@ -1886,6 +1913,7 @@ class TestDeleted:
 
     @staticmethod
     def test_deleted_inactive(
+        *,
         high_quality_image: io.BytesIO,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
@@ -1914,6 +1942,7 @@ class TestTargetStatusFailed:
 
     @staticmethod
     def test_status_failed(
+        *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
@@ -1959,10 +1988,10 @@ class TestDateFormats:
     )
     @pytest.mark.parametrize(argnames="include_tz", argvalues=[True, False])
     def test_date_formats(
+        *,
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
         datetime_format: str,
-        *,
         include_tz: bool,
     ) -> None:
         """Test various date formats which are known to be accepted.
@@ -2030,6 +2059,7 @@ class TestInactiveProject:
 
     @staticmethod
     def test_inactive_project(
+        *,
         high_quality_image: io.BytesIO,
         inactive_cloud_reco_client: CloudRecoService,
     ) -> None:

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -684,6 +684,7 @@ class TestQueryImageMatchers:
 
     @staticmethod
     def test_structural_similarity_matcher(
+        *,
         high_quality_image: io.BytesIO,
         different_high_quality_image: io.BytesIO,
     ) -> None:

--- a/tests/mock_vws/test_target_list.py
+++ b/tests/mock_vws/test_target_list.py
@@ -10,6 +10,7 @@ class TestTargetList:
 
     @staticmethod
     def test_includes_targets(
+        *,
         vws_client: VWS,
         target_id: str,
     ) -> None:
@@ -18,6 +19,7 @@ class TestTargetList:
 
     @staticmethod
     def test_deleted(
+        *,
         vws_client: VWS,
         target_id: str,
     ) -> None:

--- a/tests/mock_vws/test_target_summary.py
+++ b/tests/mock_vws/test_target_summary.py
@@ -20,10 +20,10 @@ class TestTargetSummary:
     @staticmethod
     @pytest.mark.parametrize(argnames="active_flag", argvalues=[True, False])
     def test_target_summary(
+        *,
         vws_client: VWS,
         vuforia_database: CloudDatabase,
         image_file_failed_state: io.BytesIO,
-        *,
         active_flag: bool,
     ) -> None:
         """A target summary is returned."""
@@ -70,6 +70,7 @@ class TestTargetSummary:
         ],
     )
     def test_after_processing(
+        *,
         vws_client: VWS,
         request: pytest.FixtureRequest,
         image_fixture_name: str,
@@ -121,6 +122,7 @@ class TestRecognitionCounts:
 
     @staticmethod
     def test_recognition(
+        *,
         vws_client: VWS,
         cloud_reco_client: CloudRecoService,
         high_quality_image: io.BytesIO,

--- a/tests/mock_vws/test_update_target.py
+++ b/tests/mock_vws/test_update_target.py
@@ -77,6 +77,7 @@ class TestUpdate:
         ids=["Documented Content-Type", "Undocumented Content-Type"],
     )
     def test_content_types(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
         content_type: str,
@@ -113,6 +114,7 @@ class TestUpdate:
 
     @staticmethod
     def test_empty_content_type(
+        *,
         vws_client: VWS,
         image_file_failed_state: io.BytesIO,
     ) -> None:
@@ -147,6 +149,7 @@ class TestUpdate:
 
     @staticmethod
     def test_no_fields_given(
+        *,
         vws_client: VWS,
         target_id: str,
     ) -> None:
@@ -185,6 +188,7 @@ class TestUnexpectedData:
 
     @staticmethod
     def test_invalid_extra_data(
+        *,
         vws_client: VWS,
         target_id: str,
     ) -> None:
@@ -219,6 +223,7 @@ class TestWidth:
         ids=["Negative", "Wrong Type", "None", "Zero"],
     )
     def test_width_invalid(
+        *,
         vws_client: VWS,
         width: int | str | None,
         target_id: str,
@@ -246,7 +251,7 @@ class TestWidth:
         assert target_details.target_record.width == original_width
 
     @staticmethod
-    def test_width_valid(vws_client: VWS, target_id: str) -> None:
+    def test_width_valid(*, vws_client: VWS, target_id: str) -> None:
         """Positive numbers are valid widths."""
         vws_client.wait_for_target_processed(target_id=target_id)
 
@@ -270,9 +275,9 @@ class TestActiveFlag:
         argvalues=[True, False],
     )
     def test_active_flag(
+        *,
         vws_client: VWS,
         image_file_success_state_low_rating: io.BytesIO,
-        *,
         initial_active_flag: bool,
         desired_active_flag: bool,
     ) -> None:
@@ -300,6 +305,7 @@ class TestActiveFlag:
         argvalues=["string", None],
     )
     def test_invalid(
+        *,
         vws_client: VWS,
         target_id: str,
         desired_active_flag: str | None,
@@ -338,6 +344,7 @@ class TestApplicationMetadata:
         ids=["Short", "Max length"],
     )
     def test_base64_encoded(
+        *,
         target_id: str,
         metadata: bytes,
         vws_client: VWS,
@@ -355,6 +362,7 @@ class TestApplicationMetadata:
     @staticmethod
     @pytest.mark.parametrize(argnames="invalid_metadata", argvalues=[1, None])
     def test_invalid_type(
+        *,
         vws_client: VWS,
         target_id: str,
         invalid_metadata: int | None,
@@ -377,6 +385,7 @@ class TestApplicationMetadata:
 
     @staticmethod
     def test_not_base64_encoded_processable(
+        *,
         vws_client: VWS,
         target_id: str,
         not_base64_encoded_processable: str,
@@ -395,6 +404,7 @@ class TestApplicationMetadata:
 
     @staticmethod
     def test_not_base64_encoded_not_processable(
+        *,
         vws_client: VWS,
         target_id: str,
         not_base64_encoded_not_processable: str,
@@ -419,7 +429,7 @@ class TestApplicationMetadata:
         )
 
     @staticmethod
-    def test_metadata_too_large(vws_client: VWS, target_id: str) -> None:
+    def test_metadata_too_large(*, vws_client: VWS, target_id: str) -> None:
         """
         A base64 encoded string of greater than 1024 * 1024 bytes is too
         large
@@ -465,6 +475,7 @@ class TestTargetName:
         ids=["Short name", "Max char value", "Long name"],
     )
     def test_name_valid(
+        *,
         name: str,
         target_id: str,
         vws_client: VWS,
@@ -512,6 +523,7 @@ class TestTargetName:
         ],
     )
     def test_name_invalid(
+        *,
         name: str | int | None,
         target_id: str,
         vws_client: VWS,
@@ -536,6 +548,7 @@ class TestTargetName:
 
     @staticmethod
     def test_existing_target_name(
+        *,
         image_file_success_state_low_rating: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -576,6 +589,7 @@ class TestTargetName:
 
     @staticmethod
     def test_same_name_given(
+        *,
         image_file_success_state_low_rating: io.BytesIO,
         vws_client: VWS,
     ) -> None:
@@ -606,6 +620,7 @@ class TestImage:
 
     @staticmethod
     def test_image_valid(
+        *,
         image_files_failed_state: io.BytesIO,
         target_id: str,
         vws_client: VWS,
@@ -623,6 +638,7 @@ class TestImage:
 
     @staticmethod
     def test_bad_image_format_or_color_space(
+        *,
         bad_image_file: io.BytesIO,
         target_id: str,
         vws_client: VWS,
@@ -643,6 +659,7 @@ class TestImage:
 
     @staticmethod
     def test_corrupted(
+        *,
         vws_client: VWS,
         corrupted_image_file: io.BytesIO,
         target_id: str,
@@ -662,7 +679,7 @@ class TestImage:
         )
 
     @staticmethod
-    def test_image_too_large(target_id: str, vws_client: VWS) -> None:
+    def test_image_too_large(*, target_id: str, vws_client: VWS) -> None:
         """
         An `ImageTooLargeError` result is returned if the image is above
         a
@@ -723,6 +740,7 @@ class TestImage:
 
     @staticmethod
     def test_not_base64_encoded_processable(
+        *,
         vws_client: VWS,
         target_id: str,
         not_base64_encoded_processable: str,
@@ -751,6 +769,7 @@ class TestImage:
 
     @staticmethod
     def test_not_base64_encoded_not_processable(
+        *,
         vws_client: VWS,
         target_id: str,
         not_base64_encoded_not_processable: str,
@@ -777,7 +796,7 @@ class TestImage:
         )
 
     @staticmethod
-    def test_not_image(target_id: str, vws_client: VWS) -> None:
+    def test_not_image(*, target_id: str, vws_client: VWS) -> None:
         """
         If the given image is not an image file then a `BadImageError`
         result
@@ -803,6 +822,7 @@ class TestImage:
         argvalues=[1, None],
     )
     def test_invalid_type(
+        *,
         invalid_type_image: int | None,
         target_id: str,
         vws_client: VWS,
@@ -825,6 +845,7 @@ class TestImage:
 
     @staticmethod
     def test_rating_can_change(
+        *,
         image_file_success_state_low_rating: io.BytesIO,
         high_quality_image: io.BytesIO,
         vws_client: VWS,

--- a/tests/mock_vws/test_vumark_generation_api.py
+++ b/tests/mock_vws/test_vumark_generation_api.py
@@ -103,6 +103,7 @@ class TestGenerateInstance:
     )
     @staticmethod
     def test_generate_instance_format(
+        *,
         accept: VuMarkAccept,
         expected_signature: bytes,
         vumark_vuforia_database: VuMarkCloudDatabase,
@@ -131,6 +132,7 @@ class TestGenerateInstance:
     )
     @staticmethod
     def test_generate_instance_content_type_header(
+        *,
         accept: str,
         expected_content_type: str,
         vumark_vuforia_database: VuMarkCloudDatabase,


### PR DESCRIPTION
## Summary
- Enforce keyword-only arguments (using `*`) in test functions that accept multiple parameters
- This improves call-site clarity and prevents accidental positional argument errors

## Test plan
- [ ] Verify tests still pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical test-signature change only; risk is limited to potential pytest collection/parametrization edge cases if any test relies on positional arguments.
> 
> **Overview**
> This PR changes many pytest test functions (and one CI linter test) to enforce **keyword-only parameters** by adding `*` to function signatures.
> 
> No runtime behavior is intentionally changed; the update is a broad signature/style adjustment across the mock VWS test suite to make argument passing explicit and reduce accidental positional ordering mistakes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e311e6f5d87a988ae23e4b17420ab237ebe3174. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->