### PR TITLE
Enforce keyword-only arguments in test helper

### DIFF
--- a/tests/mock_vws/fixtures/prepared_requests.py
+++ b/tests/mock_vws/fixtures/prepared_requests.py
@@ -23,7 +23,7 @@ VWQ_HOST = "https://cloudreco.vuforia.com"
 
 
 @RETRY_ON_TOO_MANY_REQUESTS
-def _wait_for_target_processed(vws_client: VWS, target_id: str) -> None:
+def _wait_for_target_processed(*, vws_client: VWS, target_id: str) -> None:
     """Wait for a target to be processed.
 
     We retry here because pytest-retry does not retry on exceptions


### PR DESCRIPTION
## Summary
- Add `*` to `_wait_for_target_processed` in `tests/mock_vws/fixtures/prepared_requests.py` to enforce keyword-only arguments, preventing accidental positional usage
- All existing call sites already use keyword arguments, so this is a non-breaking change

## Test plan
- [ ] Verify existing tests pass (all callers already use keyword args)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny signature tightening in test-only code; all current call sites already use keywords so impact should be minimal.
> 
> **Overview**
> Enforces keyword-only arguments for the test helper `_wait_for_target_processed` in `tests/mock_vws/fixtures/prepared_requests.py` by adding `*` to its signature, preventing accidental positional calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92378dacaf849c56564ace4eaa19330fca12bd67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->