### PR TITLE
Add @beartype to test helper functions

### DIFF
--- a/tests/mock_vws/fixtures/prepared_requests.py
+++ b/tests/mock_vws/fixtures/prepared_requests.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from beartype import beartype
 from urllib3.filepost import encode_multipart_formdata
 from vws import VWS
 from vws_auth_tools import authorization_header, rfc_1123_date
@@ -22,6 +23,7 @@ VWS_HOST = "https://vws.vuforia.com"
 VWQ_HOST = "https://cloudreco.vuforia.com"
 
 
+@beartype
 @RETRY_ON_TOO_MANY_REQUESTS
 def _wait_for_target_processed(vws_client: VWS, target_id: str) -> None:
     """Wait for a target to be processed.

--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger(name=__name__)
 LOGGER.setLevel(level=logging.DEBUG)
 
 
+@beartype
 @RETRY_ON_TOO_MANY_REQUESTS
 def _delete_all_targets(*, database_keys: CloudDatabase) -> None:
     """Delete all targets.

--- a/tests/mock_vws/utils/__init__.py
+++ b/tests/mock_vws/utils/__init__.py
@@ -8,6 +8,7 @@ from typing import Literal
 from urllib.parse import urljoin
 
 import requests
+from beartype import beartype
 from PIL import Image
 from requests.structures import CaseInsensitiveDict
 from vws.response import Response
@@ -52,6 +53,7 @@ class Endpoint:
     access_key: str
     secret_key: str
 
+    @beartype
     def send(self) -> Response:
         """Send the request."""
         request = requests.Request(
@@ -81,6 +83,7 @@ class Endpoint:
         return full_content_type.split(sep=";")[0]
 
 
+@beartype
 def make_image_file(
     file_format: str,
     color_space: Literal["RGB", "CMYK"],

--- a/tests/mock_vws/utils/assertions.py
+++ b/tests/mock_vws/utils/assertions.py
@@ -219,6 +219,7 @@ def assert_query_success(*, response: Response) -> None:
     )
 
 
+@beartype
 def assert_vwq_failure(
     *,
     response: Response,

--- a/tests/mock_vws/utils/usage_test_helpers.py
+++ b/tests/mock_vws/utils/usage_test_helpers.py
@@ -3,12 +3,14 @@
 import datetime
 import io
 
+from beartype import beartype
 from vws import VWS
 from vws.reports import TargetStatuses
 
 from mock_vws.database import CloudDatabase
 
 
+@beartype
 def processing_time_seconds(
     *,
     vuforia_database: CloudDatabase,


### PR DESCRIPTION
## Summary
- Add `@beartype` decorator to non-fixture test helper functions that were missing runtime type checking
- Affected helpers: `processing_time_seconds`, `make_image_file`, `Endpoint.send`, `assert_vwq_failure`, `_wait_for_target_processed`, `_delete_all_targets`

## Test plan
- [ ] CI passes with existing tests

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add runtime type validation; main risk is newly raised type errors causing previously-passing tests to fail.
> 
> **Overview**
> Adds `@beartype` runtime type checking to several test-only helper functions (`_wait_for_target_processed`, `_delete_all_targets`, `Endpoint.send`, `make_image_file`, `assert_vwq_failure`, `processing_time_seconds`) and updates imports accordingly.
> 
> This tightens test validation by surfacing incorrect argument/return types earlier during test execution without changing production code paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76dbaa1a4d69c82fcb725028d23d8ffa45544e44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->