### PR TITLE
Enforce keyword-only arguments in `make_image_file`

### DIFF
--- a/tests/mock_vws/utils/__init__.py
+++ b/tests/mock_vws/utils/__init__.py
@@ -85,6 +85,7 @@ class Endpoint:
 
 @beartype
 def make_image_file(
+    *,
     file_format: str,
     color_space: Literal["RGB", "CMYK"],
     width: int,


### PR DESCRIPTION
## Summary
- Add `*` to `make_image_file` in `tests/mock_vws/utils/__init__.py` to enforce keyword-only arguments, consistent with the project's conventions.
- All existing call sites already use keyword arguments, so no other changes are needed.

## Test plan
- All pre-commit hooks pass.
- Existing tests are unaffected since all callers already use keyword arguments.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, test-only API tightening; risk is limited to breaking any unseen positional call sites.
> 
> **Overview**
> Updates the test helper `make_image_file` to enforce **keyword-only** parameters by adding a `*` to its signature, preventing positional-argument usage and aligning with project conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd70bfafbaa43734fefe0128bb8aeb137ed9b092. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->