### PR TITLE
Fix PytestAssertRewriteWarning for credentials fixture module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,12 @@ from vws import VWS, CloudRecoService
 from mock_vws.database import CloudDatabase
 from tests.mock_vws.utils import Endpoint
 
+# `credentials` must be listed before modules that import from it.
+# If listed later, those imports happen before pytest can register it for
+# assertion rewriting, causing a PytestAssertRewriteWarning.
 pytest_plugins = [
-    "tests.mock_vws.fixtures.prepared_requests",
     "tests.mock_vws.fixtures.credentials",
+    "tests.mock_vws.fixtures.prepared_requests",
     "tests.mock_vws.fixtures.vuforia_backends",
 ]
 


### PR DESCRIPTION
Move `tests.mock_vws.fixtures.credentials` first in `pytest_plugins` so pytest registers it for assertion rewriting before other fixture modules (`prepared_requests`, `vuforia_backends`) import it as a side effect, which was causing a `PytestAssertRewriteWarning`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts plugin import order and adds comments; low risk aside from potential fixture import-order assumptions.
> 
> **Overview**
> Reorders `pytest_plugins` in `tests/conftest.py` so `tests.mock_vws.fixtures.credentials` is loaded before other fixture modules, and documents the reason.
> 
> This prevents a `PytestAssertRewriteWarning` by ensuring pytest registers `credentials` for assertion rewriting before it is imported as a side effect elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d295efafbb3b7ff48dd7b89ee0931d56af23d8a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->