### PR TITLE
Fix beartype crash in pytest_collection_modifyitems on Windows

### DIFF
--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -295,7 +295,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 @beartype
 def pytest_collection_modifyitems(
     config: pytest.Config,
-    items: list[pytest.Function],
+    items: list[pytest.Item],
 ) -> None:
     """Skip Docker tests if requested."""
     skip_docker_build_tests_option = "--skip-docker_build_tests"


### PR DESCRIPTION
## Summary
- The `pytest_collection_modifyitems` hook in `tests/mock_vws/fixtures/vuforia_backends.py` typed `items` as `list[pytest.Function]`, but Sybil doctest items (`SybilItem`) don't inherit from `Function`
- The `@beartype` decorator enforced this at runtime, causing a `BeartypeCallHintParamViolation` that crashed the Windows CI
- Changed the type hint to `list[pytest.Item]` (matching the same hook in `conftest.py`)

## Test plan
- [x] All pre-commit hooks pass (mypy, pyright, ty, pyrefly, ruff, etc.)
- [ ] Windows CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a type-hint-only change to a pytest hook signature that affects runtime only via `beartype` and does not alter test behavior beyond avoiding collection-time crashes.
> 
> **Overview**
> Prevents a test-collection crash by widening the `pytest_collection_modifyitems` hook parameter from `list[pytest.Function]` to `list[pytest.Item]` in `tests/mock_vws/fixtures/vuforia_backends.py`, so non-function items (e.g., doctest/Sybil items) pass `@beartype` runtime checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e79e641bea191b03dc34b1ab750e40c454d9ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->