### PR TITLE
Refactor timeout and body handling to use match statements

### DIFF
--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -167,23 +167,25 @@ class MockVWS(ContextDecorator):
             # requests allows timeout as a (connect, read)
             # tuple. The delay simulates server response
             # time, so compare against the read timeout.
-            if isinstance(timeout, tuple):
-                timeout = timeout[1]
-            effective: float | None = None
-            if isinstance(timeout, (int, float)):
-                effective = float(timeout)
+            match timeout:
+                case tuple():
+                    effective: float | None = float(timeout[1])
+                case int() | float():
+                    effective = float(timeout)
+                case _:
+                    effective = None
 
             if effective is not None and delay_seconds > effective:
                 sleep_fn(effective)
                 raise requests.exceptions.Timeout
 
-            raw_body = request.body
-            if raw_body is None:
-                body_bytes = b""
-            elif isinstance(raw_body, str):
-                body_bytes = raw_body.encode(encoding="utf-8")
-            else:
-                body_bytes = raw_body
+            match request.body:
+                case None:
+                    body_bytes = b""
+                case str() as raw_body:
+                    body_bytes = raw_body.encode(encoding="utf-8")
+                case bytes() as raw_body:
+                    body_bytes = raw_body
 
             path = request.path_url
             if base_path and path.startswith(base_path):

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -184,8 +184,8 @@ class MockVWS(ContextDecorator):
                     body_bytes = b""
                 case str() as raw_body:
                     body_bytes = raw_body.encode(encoding="utf-8")
-                case bytes() as raw_body:
-                    body_bytes = raw_body
+                case _:
+                    body_bytes = request.body
 
             path = request.path_url
             if base_path and path.startswith(base_path):

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -168,8 +168,8 @@ class MockVWS(ContextDecorator):
             # tuple. The delay simulates server response
             # time, so compare against the read timeout.
             match timeout:
-                case tuple():
-                    effective: float | None = float(timeout[1])
+                case (_, int() | float() as read_timeout):
+                    effective: float | None = float(read_timeout)
                 case int() | float():
                     effective = float(timeout)
                 case _:


### PR DESCRIPTION
## Summary
- Replace `isinstance` chains with `match`/`case` for timeout normalization and request body → bytes conversion in `_wrap_callback`

Closes #3110

## Test plan
- [x] All pre-commit hooks pass
- [ ] Existing tests pass (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of request timeout and body parsing in the mock callback wrapper; low risk aside from potential edge-case differences when `timeout` tuples or unusual body types are passed.
> 
> **Overview**
> Refactors `_wrap_callback` in `src/mock_vws/_requests_mock_server/decorators.py` to replace `isinstance` chains with `match`/`case` for (1) normalizing `requests` `timeout` values (including `(connect, read)` tuples) into an effective read-timeout and (2) converting `request.body` into `bytes`.
> 
> Behavior is intended to stay the same, but tuple handling is now pattern-matched (only treating `(…, number)` as a read timeout) and body handling is expressed via explicit `None`/`str` cases with a fallback to the original body value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d57724cd9bb86e2dcba56154c2c00b31c8f69ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->