### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
     "release",
 ]


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

This removes deprecation warnings; the old key may be removed in a future deptry release.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change: updates the deptry setting key to the new name to avoid deprecation warnings, with no runtime code impact.
> 
> **Overview**
> Updates `pyproject.toml` deptry configuration to replace deprecated `pep621_dev_dependency_groups` with `optional_dependencies_dev_groups` while keeping the same `dev`/`release` groups, eliminating deptry 0.25+ deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f89faa11fff6188e61f965fd7ea9ffdb41f7245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->