### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,15 +12,6 @@ from sybil.parsers.rest import (
 
 from tests.mock_vws.utils.retries import RETRY_EXCEPTIONS
 
-
-@beartype
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)
-
-
 pytest_collect_file = Sybil(
     parsers=[
         DocTestParser(optionflags=ELLIPSIS),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests",
     "pytest-retry==1.7.0",
     "pytest-xdist==3.8.0",
     "pyyaml==6.0.3",
@@ -145,6 +145,7 @@ fallback_version = "0.0.0"
 version_scheme = "post-release"
 
 [tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 sources.torch = { index = "pytorch-cpu" }
 sources.torchvision = { index = "pytorch-cpu" }
 index = [ { name = "pytorch-cpu", url = "https://download.pytorch.org/whl/cpu", explicit = true } ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-retry==1.7.0",
     "pytest-xdist==3.8.0",
     "pyyaml==6.0.3",
@@ -113,6 +114,9 @@ optional-dependencies.dev = [
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-python-mock/"
 urls.Source = "https://github.com/VWS-Python/vws-python-mock"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` wiring from conftest where it duplicated the plugin.

The dependency is pinned to [git `bc81d99`](https://github.com/adamtheturtle/pytest-beartype-tests/commit/bc81d99) via `[tool.uv.sources]` until a PyPI release includes the Sybil-safe plugin fix.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low impact on production code, but it changes the test collection/runtime behavior and introduces a git-pinned pytest plugin dependency, which could affect CI stability and reproducibility.
> 
> **Overview**
> Shifts `beartype` enforcement for tests from a custom `pytest_collection_modifyitems` hook in `conftest.py` to the external `pytest-beartype-tests` plugin (removing the redundant collection-time wrapping).
> 
> Adds `pytest-beartype-tests` to dev dependencies and configures `uv` to install it from a specific git revision (`bc81d99`), plus introduces an empty `[dependency-groups]`/`dev` group entry in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b5b5186daeb6df89ce20a736d50adf0c983d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->