### PR TITLE
chore: bump uv to 0.11.7 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 fail_fast: true
 
-.uv_version: &uv_version uv==0.9.5
+.uv_version: &uv_version uv==0.11.7
 
 # We use system Python, with required dependencies specified in pyproject.toml.
 # We therefore cannot use those dependencies in pre-commit CI.


### PR DESCRIPTION
Bumps the uv pin in `.pre-commit-config.yaml` (`.uv_version` YAML anchor) to **uv 0.11.7**, matching the current [astral-sh/uv](https://github.com/astral-sh/uv) release used for pre-commit local hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only updates the pinned `uv` version used by pre-commit hook environments; the main impact is potential tooling behavior differences during local/CI hook runs.
> 
> **Overview**
> Updates `.pre-commit-config.yaml` to bump the pinned `uv` version (YAML anchor `.uv_version`) from `0.9.5` to `0.11.7`, affecting which `uv` release is installed for hooks that depend on `*uv_version`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f96525947ebfe10e53ed501f9f98034c06c3db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->