### PR TITLE
Unquote type annotations in create_secrets_files

### DIFF
--- a/admin/create_secrets_files.py
+++ b/admin/create_secrets_files.py
@@ -8,15 +8,11 @@ import os
 import sys
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import vws_web_tools
 from selenium.common.exceptions import TimeoutException
-
-if TYPE_CHECKING:
-    from selenium.webdriver.remote.webdriver import WebDriver
-    from vws_web_tools import DatabaseDict, VuMarkDatabaseDict
-
+from selenium.webdriver.remote.webdriver import WebDriver
+from vws_web_tools import DatabaseDict, VuMarkDatabaseDict
 
 VUMARK_TEMPLATE_SVG_FILE_PATH = Path(__file__).with_name(
     name="vumark_template.svg",
@@ -24,12 +20,12 @@ VUMARK_TEMPLATE_SVG_FILE_PATH = Path(__file__).with_name(
 
 
 def _create_and_get_cloud_database_details(
-    driver: "WebDriver",
+    driver: WebDriver,
     email_address: str,
     password: str,
     cloud_license_name: str,
     cloud_database_name: str,
-) -> "DatabaseDict":
+) -> DatabaseDict:
     """Create a cloud database and get its details.
 
     Returns database details.
@@ -57,9 +53,9 @@ def _create_and_get_cloud_database_details(
 
 
 def _create_and_get_vumark_details(
-    driver: "WebDriver",
+    driver: WebDriver,
     vumark_database_name: str,
-) -> "VuMarkDatabaseDict":
+) -> VuMarkDatabaseDict:
     """Create a VuMark database and get its details.
 
     Returns VuMark database details.
@@ -76,10 +72,10 @@ def _create_and_get_vumark_details(
 
 
 def _generate_secrets_file_content(
-    cloud_database_details: "DatabaseDict",
-    vumark_details: "VuMarkDatabaseDict",
-    inactive_database_details: "DatabaseDict",
-    inactive_vumark_details: "VuMarkDatabaseDict",
+    cloud_database_details: DatabaseDict,
+    vumark_details: VuMarkDatabaseDict,
+    inactive_database_details: DatabaseDict,
+    inactive_vumark_details: VuMarkDatabaseDict,
     vumark_target_id: str,
 ) -> str:
     """Generate the content of a secrets file."""
@@ -110,7 +106,7 @@ def _generate_secrets_file_content(
 
 
 def _create_and_get_vumark_target_id(
-    driver: "WebDriver",
+    driver: WebDriver,
     vumark_database_name: str,
     vumark_template_name: str,
 ) -> str:
@@ -130,12 +126,12 @@ def _create_and_get_vumark_target_id(
 
 
 def _create_and_get_inactive_database_details(
-    driver: "WebDriver",
+    driver: WebDriver,
     email_address: str,
     password: str,
     cloud_license_name: str,
     cloud_database_name: str,
-) -> "DatabaseDict":
+) -> DatabaseDict:
     """Create a cloud database, get its details, then delete the license to
     make it inactive.
     """
@@ -164,12 +160,12 @@ def _create_and_get_inactive_database_details(
 
 
 def _create_and_get_inactive_vumark_details(
-    driver: "WebDriver",
+    driver: WebDriver,
     email_address: str,
     password: str,
     vumark_license_name: str,
     vumark_database_name: str,
-) -> "VuMarkDatabaseDict":
+) -> VuMarkDatabaseDict:
     """Create a VuMark database, get its details, then delete the license
     to
     make it inactive.


### PR DESCRIPTION
Move the `WebDriver`, `DatabaseDict`, and `VuMarkDatabaseDict` imports out of the `TYPE_CHECKING` block so the annotations in `admin/create_secrets_files.py` no longer need to be string-quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a typing-only refactor that changes imports and annotations without altering runtime behavior or test data flow.
> 
> **Overview**
> Removes the `TYPE_CHECKING`-guarded imports in `admin/create_secrets_files.py` and imports `WebDriver`, `DatabaseDict`, and `VuMarkDatabaseDict` at runtime.
> 
> Updates function signatures to use direct type annotations (no string quotes) for driver parameters and database-detail return/argument types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6f286f4343d56f8e8c87680d70a4ce0d6e97e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->