### PR TITLE
Ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ secrets.tar
 src/*/_setuptools_scm_version.txt
 
 uv.lock
+
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Adds `.claude/scheduled_tasks.lock` to `.gitignore` so the scheduled-tasks lock file is not tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to stop tracking a generated lock file, with no runtime or behavior changes.
> 
> **Overview**
> Prevents the Claude scheduled-tasks lockfile from being committed by adding `.claude/scheduled_tasks.lock` to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ab9e863e2fb3f780b10b365d335483fe857846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->