### PR TITLE
Fix vacuous CI matrix meta-test and add missing entries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,11 +113,15 @@ jobs:
           - tests/mock_vws/test_update_target.py::TestWidth
           - tests/mock_vws/test_update_target.py::TestInactiveProject
           - tests/mock_vws/test_requests_mock_usage.py
+          - tests/mock_vws/test_respx_mock_usage.py
+          - tests/mock_vws/test_target_validators.py
           - tests/mock_vws/test_flask_app_usage.py
           - tests/mock_vws/test_vumark_generation_api.py
           - tests/mock_vws/test_docker.py
           - README.rst
           - docs/source/basic-example.rst
+          - docs/source/httpx-example.rst
+          - ci/
 
     steps:
       - uses: actions/checkout@v6

--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -34,9 +34,9 @@ class _CollectPlugin:
         self.nodeids.update(item.nodeid for item in items)
 
 
-@beartype
-def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
-    """From a CI pattern, get all tests ``pytest`` would collect.
+@pytest.fixture(scope="module")
+def all_tests() -> frozenset[str]:
+    """Collect every test node ID in the suite, exactly once.
 
     Uses a collection-hook plugin instead of parsing stdout: an in-process
     ``pytest.main()`` installs its own output capture, so reading from
@@ -57,14 +57,36 @@ def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
             # Unknown config option: retry_delay
             # ```
             "--disable-warnings",
-            ci_pattern,
+            ".",
         ],
         plugins=[plugin],
     )
-    return plugin.nodeids
+    return frozenset(plugin.nodeids)
 
 
-def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
+@beartype
+def _matches(*, nodeid: str, ci_pattern: str) -> bool:
+    """Whether ``pytest <ci_pattern>`` would have collected ``nodeid``.
+
+    The patterns in the CI matrix are all of the form ``path[/]`` or
+    ``path::Class[::method]``. A node ID matches if it equals the pattern,
+    is a directory child of a pattern ending with ``/``, or extends the
+    pattern at a ``::`` (sub-item), ``/`` (path), or ``[`` (parametrize)
+    boundary.
+    """
+    if nodeid == ci_pattern:
+        return True
+    if not nodeid.startswith(ci_pattern):
+        return False
+    if ci_pattern.endswith("/"):
+        return True
+    return nodeid[len(ci_pattern)] in {":", "/", "["}
+
+
+def test_ci_patterns_valid(
+    request: pytest.FixtureRequest,
+    all_tests: frozenset[str],
+) -> None:
     """
     All of the CI patterns in the CI configuration match at least one
     test in
@@ -73,14 +95,17 @@ def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
     ci_patterns = _ci_patterns(repository_root=request.config.rootpath)
 
     for ci_pattern in ci_patterns:
-        tests = _tests_from_pattern(ci_pattern=ci_pattern)
+        matched = {
+            n for n in all_tests if _matches(nodeid=n, ci_pattern=ci_pattern)
+        }
         message = f'"{ci_pattern}" does not match any tests.'
-        assert tests, message
+        assert matched, message
 
 
 def test_tests_collected_once(
     *,
     request: pytest.FixtureRequest,
+    all_tests: frozenset[str],
 ) -> None:
     """Each test in the test suite is collected exactly once.
 
@@ -90,12 +115,9 @@ def test_tests_collected_once(
     tests_to_patterns: dict[str, set[str]] = {}
 
     for pattern in ci_patterns:
-        tests = _tests_from_pattern(ci_pattern=pattern)
-        for test in tests:
-            if test in tests_to_patterns:
-                tests_to_patterns[test].add(pattern)
-            else:
-                tests_to_patterns[test] = {pattern}
+        for test in all_tests:
+            if _matches(nodeid=test, ci_pattern=pattern):
+                tests_to_patterns.setdefault(test, set()).add(pattern)
 
     for test_name, patterns in tests_to_patterns.items():
         message = (
@@ -105,6 +127,5 @@ def test_tests_collected_once(
         )
         assert len(patterns) == 1, message
 
-    all_tests = _tests_from_pattern(ci_pattern=".")
     assert tests_to_patterns.keys() - all_tests == set()
     assert all_tests - tests_to_patterns.keys() == set()

--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -1,14 +1,10 @@
 """Custom lint tests."""
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 from beartype import beartype
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 @beartype
@@ -23,32 +19,49 @@ def _ci_patterns(*, repository_root: Path) -> set[str]:
     return ci_patterns
 
 
+class _CollectPlugin:
+    """Pytest plugin that records collected node IDs."""
+
+    def __init__(self) -> None:
+        """Initialize an empty set of collected node IDs."""
+        self.nodeids: set[str] = set()
+
+    def pytest_collection_modifyitems(
+        self,
+        items: list[pytest.Item],
+    ) -> None:
+        """Record the node IDs of all collected items."""
+        self.nodeids.update(item.nodeid for item in items)
+
+
 @beartype
-def _tests_from_pattern(
-    *,
-    ci_pattern: str,
-    capsys: pytest.CaptureFixture[str],
-) -> set[str]:
-    """From a CI pattern, get all tests ``pytest`` would collect."""
-    # Clear the captured output.
-    capsys.readouterr()
-    tests: Iterable[str] = set()
+def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
+    """From a CI pattern, get all tests ``pytest`` would collect.
+
+    Uses a collection-hook plugin instead of parsing stdout: an in-process
+    ``pytest.main()`` installs its own output capture, so reading from
+    ``capsys`` would see an empty string and the test would pass vacuously.
+    """
+    plugin = _CollectPlugin()
     pytest.main(
         args=[
-            "-q",
             "--collect-only",
-            # If there are any warnings, these obscure the output.
+            # Disable pytest-retry to avoid:
+            # ```
+            # ValueError: no option named 'filtered_exceptions'
+            # ```
+            "-p",
+            "no:pytest-retry",
+            # Disable warnings to avoid many instances of:
+            # ```
+            # Unknown config option: retry_delay
+            # ```
             "--disable-warnings",
             ci_pattern,
         ],
+        plugins=[plugin],
     )
-    data = capsys.readouterr().out
-    for line in data.splitlines():
-        # We filter empty lines and lines which look like
-        # "9 tests collected in 0.01s".
-        if line and "collected in" not in line:
-            tests = {*tests, line}
-    return set(tests)
+    return plugin.nodeids
 
 
 def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
@@ -60,31 +73,13 @@ def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
     ci_patterns = _ci_patterns(repository_root=request.config.rootpath)
 
     for ci_pattern in ci_patterns:
-        collect_only_result = pytest.main(
-            args=[
-                "--collect-only",
-                ci_pattern,
-                # Disable pytest-retry to avoid:
-                # ```
-                # ValueError: no option named 'filtered_exceptions'
-                # ````
-                "-p",
-                "no:pytest-retry",
-                # Disable warnings to avoid many instances of:
-                # ```
-                # Unknown config option: retry_delay
-                # ```
-                "--disable-warnings",
-            ],
-        )
-
+        tests = _tests_from_pattern(ci_pattern=ci_pattern)
         message = f'"{ci_pattern}" does not match any tests.'
-        assert collect_only_result == 0, message
+        assert tests, message
 
 
 def test_tests_collected_once(
     *,
-    capsys: pytest.CaptureFixture[str],
     request: pytest.FixtureRequest,
 ) -> None:
     """Each test in the test suite is collected exactly once.
@@ -95,7 +90,7 @@ def test_tests_collected_once(
     tests_to_patterns: dict[str, set[str]] = {}
 
     for pattern in ci_patterns:
-        tests = _tests_from_pattern(ci_pattern=pattern, capsys=capsys)
+        tests = _tests_from_pattern(ci_pattern=pattern)
         for test in tests:
             if test in tests_to_patterns:
                 tests_to_patterns[test].add(pattern)
@@ -110,6 +105,6 @@ def test_tests_collected_once(
         )
         assert len(patterns) == 1, message
 
-    all_tests = _tests_from_pattern(ci_pattern=".", capsys=capsys)
+    all_tests = _tests_from_pattern(ci_pattern=".")
     assert tests_to_patterns.keys() - all_tests == set()
     assert all_tests - tests_to_patterns.keys() == set()

--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -43,7 +43,7 @@ def all_tests() -> frozenset[str]:
     ``capsys`` would see an empty string and the test would pass vacuously.
     """
     plugin = _CollectPlugin()
-    pytest.main(
+    exit_code = pytest.main(
         args=[
             "--collect-only",
             # Disable pytest-retry to avoid:
@@ -60,6 +60,12 @@ def all_tests() -> frozenset[str]:
             ".",
         ],
         plugins=[plugin],
+    )
+    # Fail loudly on collection errors (import failures, syntax errors, etc.)
+    # rather than silently using whatever items were captured before the
+    # crash.
+    assert exit_code == pytest.ExitCode.OK, (
+        f"Collection failed with exit code {exit_code}."
     )
     return frozenset(plugin.nodeids)
 

--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -34,9 +34,9 @@ class _CollectPlugin:
         self.nodeids.update(item.nodeid for item in items)
 
 
-@pytest.fixture(scope="module")
-def all_tests() -> frozenset[str]:
-    """Collect every test node ID in the suite, exactly once.
+@beartype
+def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
+    """From a CI pattern, get all tests ``pytest`` would collect.
 
     Uses a collection-hook plugin instead of parsing stdout: an in-process
     ``pytest.main()`` installs its own output capture, so reading from
@@ -57,7 +57,7 @@ def all_tests() -> frozenset[str]:
             # Unknown config option: retry_delay
             # ```
             "--disable-warnings",
-            ".",
+            ci_pattern,
         ],
         plugins=[plugin],
     )
@@ -65,34 +65,12 @@ def all_tests() -> frozenset[str]:
     # rather than silently using whatever items were captured before the
     # crash.
     assert exit_code == pytest.ExitCode.OK, (
-        f"Collection failed with exit code {exit_code}."
+        f"Collection for {ci_pattern!r} failed with exit code {exit_code}."
     )
-    return frozenset(plugin.nodeids)
+    return plugin.nodeids
 
 
-@beartype
-def _matches(*, nodeid: str, ci_pattern: str) -> bool:
-    """Whether ``pytest <ci_pattern>`` would have collected ``nodeid``.
-
-    The patterns in the CI matrix are all of the form ``path[/]`` or
-    ``path::Class[::method]``. A node ID matches if it equals the pattern,
-    is a directory child of a pattern ending with ``/``, or extends the
-    pattern at a ``::`` (sub-item), ``/`` (path), or ``[`` (parametrize)
-    boundary.
-    """
-    if nodeid == ci_pattern:
-        return True
-    if not nodeid.startswith(ci_pattern):
-        return False
-    if ci_pattern.endswith("/"):
-        return True
-    return nodeid[len(ci_pattern)] in {":", "/", "["}
-
-
-def test_ci_patterns_valid(
-    request: pytest.FixtureRequest,
-    all_tests: frozenset[str],
-) -> None:
+def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
     """
     All of the CI patterns in the CI configuration match at least one
     test in
@@ -101,17 +79,14 @@ def test_ci_patterns_valid(
     ci_patterns = _ci_patterns(repository_root=request.config.rootpath)
 
     for ci_pattern in ci_patterns:
-        matched = {
-            n for n in all_tests if _matches(nodeid=n, ci_pattern=ci_pattern)
-        }
+        tests = _tests_from_pattern(ci_pattern=ci_pattern)
         message = f'"{ci_pattern}" does not match any tests.'
-        assert matched, message
+        assert tests, message
 
 
 def test_tests_collected_once(
     *,
     request: pytest.FixtureRequest,
-    all_tests: frozenset[str],
 ) -> None:
     """Each test in the test suite is collected exactly once.
 
@@ -121,9 +96,9 @@ def test_tests_collected_once(
     tests_to_patterns: dict[str, set[str]] = {}
 
     for pattern in ci_patterns:
-        for test in all_tests:
-            if _matches(nodeid=test, ci_pattern=pattern):
-                tests_to_patterns.setdefault(test, set()).add(pattern)
+        tests = _tests_from_pattern(ci_pattern=pattern)
+        for test in tests:
+            tests_to_patterns.setdefault(test, set()).add(pattern)
 
     for test_name, patterns in tests_to_patterns.items():
         message = (
@@ -133,5 +108,6 @@ def test_tests_collected_once(
         )
         assert len(patterns) == 1, message
 
+    all_tests = _tests_from_pattern(ci_pattern=".")
     assert tests_to_patterns.keys() - all_tests == set()
     assert all_tests - tests_to_patterns.keys() == set()


### PR DESCRIPTION
## Summary

- Fixes #3128. `ci/test_custom_linters.py::test_tests_collected_once` was passing vacuously because the in-process `pytest.main()` installed its own capture, so `capsys` returned an empty string and every pattern collected 0 tests.
- Replaces the stdout-parsing approach with a small pytest plugin that hooks `pytest_collection_modifyitems` and reads node IDs directly — still in-process (no subprocess overhead), and the meta-test now does real work (~89s vs 1.6s).
- Adds the matrix entries the now-working meta-test surfaces: `tests/mock_vws/test_respx_mock_usage.py`, `tests/mock_vws/test_target_validators.py`, `docs/source/httpx-example.rst`, and `ci/` (so the meta-tests themselves run in CI).

## Test plan

- [x] `uv run --extra=dev python -m pytest -v ci/test_custom_linters.py` — both tests pass and runtime reflects real collection work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI workflow matrix and the meta-test that validates it; risk is mainly false positives/negatives or increased CI runtime due to real collection across patterns.
> 
> **Overview**
> Fixes the `ci/test_custom_linters.py` meta-tests so they no longer pass vacuously: replaces stdout parsing/`capsys` with an in-process pytest collection plugin (`pytest_collection_modifyitems`) that records collected node IDs and asserts collection succeeds.
> 
> Updates the GitHub Actions `ci_pattern` matrix in `.github/workflows/test.yml` to include previously unlisted test/doc/`ci/` paths that the now-working meta-test detects (so all patterns are validated and the meta-tests themselves run in CI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d907796d16f5b1925d6984b3c6a1dc37097af4d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->