### PR TITLE
Make test_tests_collected_once actually verify coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,11 +113,15 @@ jobs:
           - tests/mock_vws/test_update_target.py::TestWidth
           - tests/mock_vws/test_update_target.py::TestInactiveProject
           - tests/mock_vws/test_requests_mock_usage.py
+          - tests/mock_vws/test_respx_mock_usage.py
           - tests/mock_vws/test_flask_app_usage.py
           - tests/mock_vws/test_vumark_generation_api.py
+          - tests/mock_vws/test_target_validators.py
           - tests/mock_vws/test_docker.py
+          - ci/test_custom_linters.py
           - README.rst
           - docs/source/basic-example.rst
+          - docs/source/httpx-example.rst
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,8 @@ jobs:
           - tests/mock_vws/test_target_validators.py
           - tests/mock_vws/test_docker.py
           - ci/test_custom_linters.py
-          - '**/*.rst'
+          - README.rst
+          - docs/
 
     steps:
       - uses: actions/checkout@v6
@@ -161,7 +162,6 @@ jobs:
 
       - name: Run tests
         run: |
-          shopt -s globstar
           uv run --extra=dev \
             coverage run -m pytest \
               -s \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,9 +119,7 @@ jobs:
           - tests/mock_vws/test_target_validators.py
           - tests/mock_vws/test_docker.py
           - ci/test_custom_linters.py
-          - README.rst
-          - docs/source/basic-example.rst
-          - docs/source/httpx-example.rst
+          - '**/*.rst'
 
     steps:
       - uses: actions/checkout@v6
@@ -163,6 +161,7 @@ jobs:
 
       - name: Run tests
         run: |
+          shopt -s globstar
           uv run --extra=dev \
             coverage run -m pytest \
               -s \

--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -8,6 +8,23 @@ from beartype import beartype
 
 
 @beartype
+def _expand_pattern(*, ci_pattern: str) -> list[str]:
+    """Expand a CI pattern, treating shell-style globs as recursive globs.
+
+    Hidden directories (such as ``.venv``) are skipped to match bash's
+    default globbing behaviour. Patterns without glob metacharacters are
+    returned unchanged.
+    """
+    if not any(char in ci_pattern for char in "*?["):
+        return [ci_pattern]
+    return [
+        path.as_posix()
+        for path in Path().glob(pattern=ci_pattern)
+        if not any(part.startswith(".") for part in path.parts)
+    ]
+
+
+@beartype
 def _ci_patterns(*, repository_root: Path) -> set[str]:
     """Return the CI patterns given in the CI configuration file."""
     ci_file = repository_root / ".github" / "workflows" / "test.yml"
@@ -52,7 +69,7 @@ def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
             # Unknown config option: retry_delay
             # ```
             "--disable-warnings",
-            ci_pattern,
+            *_expand_pattern(ci_pattern=ci_pattern),
         ],
         plugins=[plugin],
     )
@@ -71,7 +88,7 @@ def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
         collect_only_result = pytest.main(
             args=[
                 "--collect-only",
-                ci_pattern,
+                *_expand_pattern(ci_pattern=ci_pattern),
                 # Disable pytest-retry to avoid:
                 # ```
                 # ValueError: no option named 'filtered_exceptions'

--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -8,23 +8,6 @@ from beartype import beartype
 
 
 @beartype
-def _expand_pattern(*, ci_pattern: str) -> list[str]:
-    """Expand a CI pattern, treating shell-style globs as recursive globs.
-
-    Hidden directories (such as ``.venv``) are skipped to match bash's
-    default globbing behaviour. Patterns without glob metacharacters are
-    returned unchanged.
-    """
-    if not any(char in ci_pattern for char in "*?["):
-        return [ci_pattern]
-    return [
-        path.as_posix()
-        for path in Path().glob(pattern=ci_pattern)
-        if not any(part.startswith(".") for part in path.parts)
-    ]
-
-
-@beartype
 def _ci_patterns(*, repository_root: Path) -> set[str]:
     """Return the CI patterns given in the CI configuration file."""
     ci_file = repository_root / ".github" / "workflows" / "test.yml"
@@ -69,7 +52,7 @@ def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
             # Unknown config option: retry_delay
             # ```
             "--disable-warnings",
-            *_expand_pattern(ci_pattern=ci_pattern),
+            ci_pattern,
         ],
         plugins=[plugin],
     )
@@ -88,7 +71,7 @@ def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
         collect_only_result = pytest.main(
             args=[
                 "--collect-only",
-                *_expand_pattern(ci_pattern=ci_pattern),
+                ci_pattern,
                 # Disable pytest-retry to avoid:
                 # ```
                 # ValueError: no option named 'filtered_exceptions'

--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -1,14 +1,10 @@
 """Custom lint tests."""
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 from beartype import beartype
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 @beartype
@@ -23,32 +19,44 @@ def _ci_patterns(*, repository_root: Path) -> set[str]:
     return ci_patterns
 
 
+class _CollectPlugin:
+    """Pytest plugin that records the node IDs of collected items."""
+
+    def __init__(self) -> None:
+        """Start with an empty set of collected node IDs."""
+        self.collected: set[str] = set()
+
+    def pytest_itemcollected(self, item: pytest.Item) -> None:
+        """Record each collected item's node ID."""
+        self.collected.add(item.nodeid)
+
+
 @beartype
-def _tests_from_pattern(
-    *,
-    ci_pattern: str,
-    capsys: pytest.CaptureFixture[str],
-) -> set[str]:
+def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
     """From a CI pattern, get all tests ``pytest`` would collect."""
-    # Clear the captured output.
-    capsys.readouterr()
-    tests: Iterable[str] = set()
+    plugin = _CollectPlugin()
     pytest.main(
         args=[
             "-q",
             "--collect-only",
-            # If there are any warnings, these obscure the output.
+            # Disable pytest-retry to avoid:
+            # ```
+            # ValueError: no option named 'filtered_exceptions'
+            # ```
+            # which causes the nested run to exit with INTERNAL_ERROR
+            # before any items are collected.
+            "-p",
+            "no:pytest-retry",
+            # Disable warnings to avoid many instances of:
+            # ```
+            # Unknown config option: retry_delay
+            # ```
             "--disable-warnings",
             ci_pattern,
         ],
+        plugins=[plugin],
     )
-    data = capsys.readouterr().out
-    for line in data.splitlines():
-        # We filter empty lines and lines which look like
-        # "9 tests collected in 0.01s".
-        if line and "collected in" not in line:
-            tests = {*tests, line}
-    return set(tests)
+    return plugin.collected
 
 
 def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
@@ -82,20 +90,18 @@ def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
         assert collect_only_result == 0, message
 
 
-def test_tests_collected_once(
-    *,
-    capsys: pytest.CaptureFixture[str],
-    request: pytest.FixtureRequest,
-) -> None:
+def test_tests_collected_once(request: pytest.FixtureRequest) -> None:
     """Each test in the test suite is collected exactly once.
 
     This does not necessarily mean that they are run - they may be skipped.
     """
     ci_patterns = _ci_patterns(repository_root=request.config.rootpath)
+    all_tests = _tests_from_pattern(ci_pattern=".")
+    assert all_tests
     tests_to_patterns: dict[str, set[str]] = {}
 
     for pattern in ci_patterns:
-        tests = _tests_from_pattern(ci_pattern=pattern, capsys=capsys)
+        tests = _tests_from_pattern(ci_pattern=pattern)
         for test in tests:
             if test in tests_to_patterns:
                 tests_to_patterns[test].add(pattern)
@@ -110,6 +116,5 @@ def test_tests_collected_once(
         )
         assert len(patterns) == 1, message
 
-    all_tests = _tests_from_pattern(ci_pattern=".", capsys=capsys)
     assert tests_to_patterns.keys() - all_tests == set()
     assert all_tests - tests_to_patterns.keys() == set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -417,6 +417,7 @@ ignore_names = [
     # pytest configuration
     "pytest_collect_file",
     "pytest_collection_modifyitems",
+    "pytest_itemcollected",
     "pytest_plugins",
     "pytest_set_filtered_exceptions",
     "pytest_addoption",


### PR DESCRIPTION
## Summary
- The custom linter test \`test_tests_collected_once\` was passing vacuously: \`capsys\` could not see the inner \`pytest.main\` output, and the nested run was also exiting with \`INTERNAL_ERROR\` because of \`pytest-retry\`, so 0 items were ever collected. Replaced the stdout-parsing approach with a small pytest plugin that records collected node IDs directly, and disabled \`pytest-retry\` in the nested run (matching the existing workaround in \`test_ci_patterns_valid\`). Removed a stray \`breakpoint()\` and added \`assert all_tests\` as a sanity check.
- Added the missing test files and docs (\`ci/test_custom_linters.py\`, \`tests/mock_vws/test_respx_mock_usage.py\`, \`tests/mock_vws/test_target_validators.py\`, \`docs/source/httpx-example.rst\`) to the CI matrix in \`.github/workflows/test.yml\` — these were the real coverage gaps the now-working linter test surfaced.

## Test plan
- [x] \`uv run pytest ci/test_custom_linters.py\` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI configuration and a custom linter test that validates pytest collection patterns; main risk is CI runtime/flake if pytest plugin interactions differ across environments.
> 
> **Overview**
> **Fixes the custom CI linter so it actually validates test coverage across the CI matrix.** `ci/test_custom_linters.py` now collects tests via a lightweight pytest plugin (`pytest_itemcollected`) instead of parsing captured stdout, disables `pytest-retry` in the nested `pytest.main` run to avoid internal errors, and adds a sanity `assert all_tests`.
> 
> **Closes CI coverage gaps.** The workflow matrix in `.github/workflows/test.yml` is updated to include previously-missed patterns (additional mock VWS tests, `ci/test_custom_linters.py`, and the `docs/` tree), and `pyproject.toml` adds `pytest_itemcollected` to Vulture’s ignore list to avoid false positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413ab1a5901ef5cf14114f1f9cdf623c329f0c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->