### PR TITLE
Include ci/ in coverage source for 100% requirement

### DIFF
--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -103,10 +103,7 @@ def test_tests_collected_once(request: pytest.FixtureRequest) -> None:
     for pattern in ci_patterns:
         tests = _tests_from_pattern(ci_pattern=pattern)
         for test in tests:
-            if test in tests_to_patterns:
-                tests_to_patterns[test].add(pattern)
-            else:
-                tests_to_patterns[test] = {pattern}
+            tests_to_patterns.setdefault(test, set()).add(pattern)
 
     for test_name, patterns in tests_to_patterns.items():
         message = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,7 +374,7 @@ run.omit = [
     "src/mock_vws/_flask_server/healthcheck.py",
 ]
 run.parallel = true
-run.source = [ "src/", "tests/" ]
+run.source = [ "ci/", "src/", "tests/" ]
 report.exclude_also = [
     "class .*\\bProtocol\\):",
     "if TYPE_CHECKING:",


### PR DESCRIPTION
## Summary
- Add `ci/` to `tool.coverage.run.source` so `ci/test_custom_linters.py` is included in the 100% coverage requirement enforced by the `coverage` job.

## Test plan
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change that expands coverage measurement to include `ci/`, which may cause CI to fail if those files are not fully exercised.
> 
> **Overview**
> Coverage collection is expanded by adding `ci/` to `tool.coverage.run.source`, making CI helper tests (e.g. `ci/test_custom_linters.py`) part of the 100% coverage gate.
> 
> `test_tests_collected_once` is slightly refactored to use `dict.setdefault(...).add(...)` when building the `tests_to_patterns` map (no functional change intended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3326f05f44c1dc1022d5352880f6cca1f9fab9bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->