### PR TITLE
Disable pytest-beartype-tests in nested collection runs to fix Python 3.14

### DIFF
--- a/ci/test_custom_linters.py
+++ b/ci/test_custom_linters.py
@@ -47,6 +47,14 @@ def _tests_from_pattern(*, ci_pattern: str) -> set[str]:
             # before any items are collected.
             "-p",
             "no:pytest-retry",
+            # Disable pytest-beartype-tests to avoid
+            # https://github.com/beartype/beartype/issues/637 — wrapping
+            # collected items with @beartype installs a buggy
+            # __annotate_beartype__ closure on the underlying test
+            # function, which crashes a subsequent nested collection on
+            # Python 3.14.
+            "-p",
+            "no:pytest_beartype_tests",
             # Disable warnings to avoid many instances of:
             # ```
             # Unknown config option: retry_delay
@@ -78,6 +86,14 @@ def test_ci_patterns_valid(request: pytest.FixtureRequest) -> None:
                 # ````
                 "-p",
                 "no:pytest-retry",
+                # Disable pytest-beartype-tests to avoid
+                # https://github.com/beartype/beartype/issues/637 —
+                # wrapping collected items with @beartype installs a
+                # buggy __annotate_beartype__ closure on the underlying
+                # test function, which crashes a subsequent nested
+                # collection on Python 3.14.
+                "-p",
+                "no:pytest_beartype_tests",
                 # Disable warnings to avoid many instances of:
                 # ```
                 # Unknown config option: retry_delay


### PR DESCRIPTION
## Summary

- The custom CI linter (`ci/test_custom_linters.py`) calls `pytest.main(--collect-only)` in a loop. On Python 3.14 this crashed with `TypeError: Cannot stringify annotation containing string formatting` due to an upstream beartype bug (https://github.com/beartype/beartype/issues/637) where the `pytest-beartype-tests` plugin installs a buggy `__annotate_beartype__` closure on test functions, which a subsequent nested collection then trips over via `inspect.signature(..., annotation_format=Format.STRING)`.
- Worked around by passing `-p no:pytest_beartype_tests` to both nested `pytest.main` invocations — type-checking adds no value for `--collect-only` runs anyway.

## Test plan

- [x] `uv run --python=3.14 --all-extras pytest ci/test_custom_linters.py` passes (both linter tests, ~2.5 min)
- [ ] CI passes on Python 3.13 and 3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CI linter test invocation flags to work around an upstream pytest plugin crash on Python 3.14, without changing production/runtime logic.
> 
> **Overview**
> Updates `ci/test_custom_linters.py` to disable the `pytest-beartype-tests` plugin (`-p no:pytest_beartype_tests`) in both nested `pytest.main(--collect-only)` runs.
> 
> This prevents Python 3.14 nested test collection crashes caused by an upstream beartype/pytest plugin bug, while keeping the linter’s collection-only behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba140bb2e4d5491aab07b1102cda654fa0844f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->