### PR TITLE
Bump mypy to 2.0.0 and enable parallel checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -174,7 +174,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -185,7 +185,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ optional-dependencies.dev = [
     "freezegun==1.5.5",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.11",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
## Summary
- Bump `mypy[faster-cache]` from 1.20.2 to 2.0.0 in dev dependencies.
- Pass `--num-workers=4` to the `mypy` and `mypy-docs` pre-commit hooks to use mypy 2.0's new parallel type-checking.

## Test plan
- [ ] Pre-push hooks pass (mypy + mypy-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates dev tooling and pre-push hooks, but mypy 2.0 may introduce new/changed type-checking errors that could block contributors’ pre-push workflow.
> 
> **Overview**
> Upgrades dev dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0`.
> 
> Updates the `mypy` and `mypy-docs` pre-push hooks to pass `--num-workers=4`, enabling mypy’s parallel type-checking for faster runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62678e7eae55b2ea58339bd39b1a06c1738fb39b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->