### PR TITLE
Dump container logs and health probes on healthcheck failure

### DIFF
--- a/tests/mock_vws/test_docker.py
+++ b/tests/mock_vws/test_docker.py
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
     reraise=True,
 )
 @beartype
-def wait_for_health_check(container: Container) -> None:
-    """Wait for a container to pass its health check."""
+def _poll_health_check(container: Container) -> None:
+    """Poll a container until it reports a healthy status."""
     container.reload()
     health_status = container.attrs["State"]["Health"]["Status"]
     # In theory this might not be hit by coverage.
@@ -45,6 +45,35 @@ def wait_for_health_check(container: Container) -> None:
             f"Container {container.name} is not healthy: {health_status}"
         )
         raise ValueError(error_message)
+
+
+@beartype
+def wait_for_health_check(container: Container) -> None:
+    """Wait for a container to pass its health check.
+
+    On failure, augment the error with the container's logs and the
+    Docker healthcheck probe history so CI failures are diagnosable.
+    """
+    try:
+        _poll_health_check(container=container)
+    except ValueError as exc:  # pragma: no cover
+        container.reload()
+        logs = container.logs().decode(errors="replace")
+        health_log = container.attrs["State"]["Health"].get("Log", [])
+        probes = "\n".join(
+            f"  exit={entry.get('ExitCode')!r} "
+            f"start={entry.get('Start')!r} end={entry.get('End')!r}\n"
+            f"  output={entry.get('Output')!r}"
+            for entry in health_log
+        )
+        error_message = (
+            f"{exc}\n"
+            f"--- container logs ({container.name}) ---\n"
+            f"{logs}\n"
+            f"--- healthcheck probes ({container.name}) ---\n"
+            f"{probes}"
+        )
+        raise ValueError(error_message) from exc
 
 
 @pytest.fixture(name="custom_bridge_network")

--- a/tests/mock_vws/test_docker.py
+++ b/tests/mock_vws/test_docker.py
@@ -52,7 +52,7 @@ def wait_for_health_check(container: Container) -> None:
     """Wait for a container to pass its health check.
 
     On failure, augment the error with the container's logs and the
-    Docker healthcheck probe history so CI failures are diagnosable.
+    Docker health check probe history so CI failures are diagnosable.
     """
     try:
         _poll_health_check(container=container)


### PR DESCRIPTION
## Summary
- Closes #3147. When `wait_for_health_check` exhausts its retries in `tests/mock_vws/test_docker.py`, it now augments the raised `ValueError` with the container's logs and Docker's `State.Health.Log` probe history so CI failures are diagnosable rather than just reporting `unhealthy`.

## Test plan
- [ ] Existing `test_build_and_run` still passes locally / in CI
- [ ] On a forced failure, the error message includes container logs and probe entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that augments failure diagnostics without altering production behavior; main risk is noisier CI output or unexpected decode/attr edge cases when containers lack health log data.
> 
> **Overview**
> When `wait_for_health_check` exhausts retries in `tests/mock_vws/test_docker.py`, it now re-raises with **additional diagnostics**: the container’s logs and Docker `State.Health.Log` probe history.
> 
> The retrying poll logic is split into `_poll_health_check` (tenacity-decorated) plus a wrapper that formats and chains the enriched `ValueError` for easier CI debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1fda3854c1e75b010a9f594072d04d95d1af67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->