### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -174,7 +174,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -185,7 +185,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 


### PR DESCRIPTION
## Summary
- add `--num-workers=4` to the `mypy` pre-push hook entry
- update `mypy-docs` doccmd command string to run `mypy --num-workers=4`
- keep formatting aligned with repository pre-commit style

## Test plan
- [x] Run repository pre-commit hooks during commit
- [x] Verify `.pre-commit-config.yaml` includes worker flag for both hooks

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that only affects local `pre-push` type-check runs by enabling mypy parallelism.
> 
> **Overview**
> Speeds up local type-checking by enabling mypy parallel workers in the `pre-push` hooks.
> 
> Updates the `mypy` hook to run `mypy --num-workers=4`, and adjusts the `mypy-docs` `doccmd` command string to include the same flag (with formatting aligned to the YAML style).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0655228629a63a78d9b75451f614361f49770a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->