### PR TITLE
Start Docker for Windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,23 @@ jobs:
         run: |
           cp ./vuforia_secrets.env.example ./vuforia_secrets.env
 
+      - name: Start Docker
+        shell: pwsh
+        run: |
+          $service = Get-Service docker -ErrorAction Stop
+          if ($service.Status -ne "Running") {
+            Start-Service docker
+          }
+          $deadline = (Get-Date).AddMinutes(2)
+          do {
+            docker info
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+            Start-Sleep -Seconds 5
+          } while ((Get-Date) -lt $deadline)
+          docker info
+
       - name: Run tests
         shell: bash
         run: |


### PR DESCRIPTION
Starts the Docker service in the Windows test job and waits for `docker info` before running pytest.
This addresses CI failures where the Windows worker reached Docker tests before the daemon pipe was available.
Validated with `actionlint` and the repository commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a wait-for-Docker step on Windows runners; main risk is increased job time or failures if the Docker service is unavailable.
> 
> **Overview**
> Adds a `Start Docker` step to the Windows test workflow to start the Docker Windows service if needed and poll `docker info` (with a 2-minute timeout) before executing the test suite, reducing flakiness in Docker-dependent tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e32f9fcc9743fca2b6faa315edeb764bba0d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->