### PR TITLE
[codex] Add strict-kwargs stress fixture

### DIFF
--- a/strict_kwargs_stress/__init__.py
+++ b/strict_kwargs_stress/__init__.py
@@ -1,0 +1,1 @@
+"""Stress fixture for strict-kwargs."""

--- a/strict_kwargs_stress/main.py
+++ b/strict_kwargs_stress/main.py
@@ -1,0 +1,64 @@
+"""Call-site stress cases for strict-kwargs."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import NewType, ParamSpec, TypeAliasType, TypeVar, TypeVarTuple
+
+from strict_kwargs_stress.pkg.lib import (
+    Data,
+    Service,
+    first_party_function,
+    positional_only,
+)
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+_Ts = TypeVarTuple("_Ts")  # noqa: PYI018
+UserId = NewType("UserId", int)
+Vector = TypeAliasType("Vector", list[int])  # noqa: UP040
+_VECTOR_SAMPLE: Vector = []
+
+
+def _preserve_signature(func: Callable[_P, _T]) -> Callable[_P, _T]:  # noqa: UP047
+    """Return the given callable with its ParamSpec signature
+    preserved.
+    """
+    return func
+
+
+@_preserve_signature
+def _sample(value: int) -> int:
+    """Return a sample value for exercising the ParamSpec helper."""
+    return value
+
+
+def _accept_user_id(user_id: UserId) -> UserId:
+    """Return a sample ``NewType`` value."""
+    return user_id
+
+
+_SAMPLE_RESULT = _sample(value=1)
+_USER_ID_VALUE = UserId(1)  # type: ignore[misc]
+_USER_ID = _accept_user_id(user_id=_USER_ID_VALUE)
+
+
+type _Packed[*_Ts] = tuple[*_Ts]  # noqa: PYI047
+
+first_party_function(1, 2)  # type: ignore[misc]
+first_party_function(a=1, b=2)
+positional_only(1)
+
+Service("svc")  # type: ignore[misc]
+Service(name="svc").method(3)  # type: ignore[misc]
+service = Service(name="svc")
+service.method(7)  # type: ignore[misc]
+Service.method(Service(name="svc"), item=4)  # type: ignore[misc]
+Service.method(Service(name="svc"), 4)  # type: ignore[misc]
+Service.class_method(5)  # type: ignore[misc]
+Service.static_method(6)  # type: ignore[misc]
+Data("name")  # type: ignore[misc]
+
+sys.stdout.write("ok\n")
+str.lower("ABC")

--- a/strict_kwargs_stress/pkg/__init__.py
+++ b/strict_kwargs_stress/pkg/__init__.py
@@ -1,0 +1,1 @@
+"""Stress-test package for strict-kwargs."""

--- a/strict_kwargs_stress/pkg/lib.py
+++ b/strict_kwargs_stress/pkg/lib.py
@@ -1,0 +1,44 @@
+"""Support callables for the strict-kwargs stress fixture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def first_party_function(a: int, b: int = 0) -> int:
+    """Return the sum of two integers."""
+    return a + b
+
+
+def positional_only(value: int, /) -> int:
+    """Return the positional-only value."""
+    return value
+
+
+class Service:
+    """Service with representative method shapes."""
+
+    def __init__(self, name: str) -> None:
+        """Initialize the service."""
+        self.name = name
+
+    def method(self, item: int) -> int:
+        """Return an instance-method item."""
+        return item
+
+    @classmethod
+    def class_method(cls, item: int) -> int:
+        """Return a class-method item."""
+        return item
+
+    @staticmethod
+    def static_method(item: int) -> int:
+        """Return a static-method item."""
+        return item
+
+
+@dataclass
+class Data:
+    """Simple dataclass with a synthesized constructor."""
+
+    name: str

--- a/strict_kwargs_stress/pyproject.toml
+++ b/strict_kwargs_stress/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "strict-kwargs-stress"
+version = "0"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+
+[tool.strict_kwargs]
+ignore_names = []


### PR DESCRIPTION
Adds a standalone strict-kwargs stress fixture that exercises first-party functions, constructors, bound and unbound methods, class/static methods, dataclass construction, positional-only stdlib calls, and typing special forms.

This keeps the latest strict-kwargs main behavior easy to re-check from this repo without touching production code.

Validation: commit hooks passed; pre-push hooks passed, including custom-linters, mypy, pyright, ty, and pyrefly.
