### PR TITLE
[codex] Use assert in Docker build test

### DIFF
--- a/tests/mock_vws/test_docker.py
+++ b/tests/mock_vws/test_docker.py
@@ -153,11 +153,11 @@ def test_build_and_run(
         )
         # If this assertion fails, it may be useful to look at the other
         # properties of ``exc``.
-        if not any(
+        is_windows_container_error = any(
             windows_message_substring in exc.msg
             for windows_message_substring in windows_message_substrings
-        ):
-            raise AssertionError(full_log) from exc  # pragma: no cover
+        )
+        assert is_windows_container_error, full_log
         pytest.skip(
             reason="We do not currently support using Windows containers."
         )


### PR DESCRIPTION
## Summary

Replace the explicit `raise AssertionError(full_log) from exc` in the Docker build test with an `assert` that still reports the full build log.
This keeps the unsupported Windows container skip behavior while making the assertion style simpler.

## Checks

Pre-commit and pre-push hooks passed, including Ruff, mypy, pyright, ty, and pyrefly.
Also ran the Docker test under coverage successfully; the scoped coverage report for this single file remains 93% because the `BuildError` handler is not exercised on macOS after removing the pragma.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test failure/skip logic in the Docker build test, without changing runtime code paths.
> 
> **Overview**
> Simplifies the Docker image build failure handling in `tests/mock_vws/test_docker.py` by replacing a manual `raise AssertionError(...)` with an `assert` that includes the full build log.
> 
> The test still *skips* when the `BuildError` matches known Windows-container manifest errors, but now fails with a standard assertion (and clearer log output) for unexpected build failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126d1520f89a86664cb65c78c5b8ad9ca45585ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->