### PR TITLE
[codex] Use assert_never for enum fallbacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -385,6 +385,7 @@ run.patch = [ "subprocess" ]
 run.relative_files = true
 run.source = [ "ci/", "src/", "tests/" ]
 report.exclude_also = [
+    "case _ as unreachable:\n\\s*assert_never\\(",
     "class .*\\bProtocol\\):",
     "if TYPE_CHECKING:",
 ]

--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -6,6 +6,7 @@ import datetime
 import json
 from enum import StrEnum, auto
 from http import HTTPMethod, HTTPStatus
+from typing import assert_never
 from zoneinfo import ZoneInfo
 
 from beartype import beartype
@@ -37,17 +38,19 @@ class _TargetRaterChoice(StrEnum):
     PERFECT = auto()
     RANDOM = auto()
 
-    def to_target_rater(self) -> TargetTrackingRater:
+    def to_target_rater(
+        self: _TargetRaterChoice,
+    ) -> TargetTrackingRater:
         """Get the target rater."""
         match self:
-            case self.BRISQUE:
+            case _TargetRaterChoice.BRISQUE:
                 return BrisqueTargetTrackingRater()
-            case self.PERFECT:
+            case _TargetRaterChoice.PERFECT:
                 return HardcodedTargetTrackingRater(rating=5)
-            case self.RANDOM:
+            case _TargetRaterChoice.RANDOM:
                 return RandomTargetTrackingRater()
-            case _:  # pragma: no cover
-                raise ValueError
+            case _ as unreachable:
+                assert_never(unreachable)
 
 
 @beartype

--- a/src/mock_vws/_flask_server/vwq.py
+++ b/src/mock_vws/_flask_server/vwq.py
@@ -8,6 +8,7 @@ import email.utils
 import time
 from enum import StrEnum, auto
 from http import HTTPMethod, HTTPStatus
+from typing import assert_never
 
 import requests
 from beartype import beartype
@@ -39,15 +40,15 @@ class _ImageMatcherChoice(StrEnum):
     EXACT = auto()
     STRUCTURAL_SIMILARITY = auto()
 
-    def to_image_matcher(self) -> ImageMatcher:
+    def to_image_matcher(self: _ImageMatcherChoice) -> ImageMatcher:
         """Get the image matcher."""
         match self:
-            case self.EXACT:
+            case _ImageMatcherChoice.EXACT:
                 return ExactMatcher()
-            case self.STRUCTURAL_SIMILARITY:
+            case _ImageMatcherChoice.STRUCTURAL_SIMILARITY:
                 return StructuralSimilarityMatcher()
-            case _:  # pragma: no cover
-                raise ValueError
+            case _ as unreachable:
+                assert_never(unreachable)
 
 
 @beartype

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from enum import StrEnum, auto
 from http import HTTPMethod, HTTPStatus
+from typing import assert_never
 
 import requests
 from beartype import beartype
@@ -62,15 +63,15 @@ class _ImageMatcherChoice(StrEnum):
     EXACT = auto()
     STRUCTURAL_SIMILARITY = auto()
 
-    def to_image_matcher(self) -> ImageMatcher:
+    def to_image_matcher(self: _ImageMatcherChoice) -> ImageMatcher:
         """Get the image matcher."""
         match self:
-            case self.EXACT:
+            case _ImageMatcherChoice.EXACT:
                 return ExactMatcher()
-            case self.STRUCTURAL_SIMILARITY:
+            case _ImageMatcherChoice.STRUCTURAL_SIMILARITY:
                 return StructuralSimilarityMatcher()
-            case _:  # pragma: no cover
-                raise ValueError
+            case _ as unreachable:
+                assert_never(unreachable)
 
 
 @beartype


### PR DESCRIPTION
Replaces the enum fallback `case _` pragmas in the Flask VWS, VWQ, and target-manager settings helpers with exhaustive `assert_never` branches. The enum match arms now use qualified enum members and explicit receiver annotations so strict match checkers can prove the fallback is unreachable. Adds a coverage exclusion for that `assert_never` pattern, matching the sibling-repo convention. Validated via commit and push hooks, including ruff, mypy, pyright, ty, and pyrefly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to enum-to-implementation helper methods and coverage configuration, with no behavioral changes expected unless an impossible enum value is encountered.
> 
> **Overview**
> Updates the Flask mock servers’ enum helper methods (image matcher and target rater selection) to use *exhaustive* `match` statements: arms now reference qualified enum members, add explicit `self` annotations, and replace the prior fallback `case _`/`ValueError` with `case _ as unreachable: assert_never(unreachable)`.
> 
> Adjusts `coverage` config to exclude the new `assert_never` unreachable-branch pattern from coverage reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb4d7f0d516a5532afa8c39fc8c9bad6d9bd22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->