### PR TITLE
Revert getattr workarounds to getattr with pylint disables

### DIFF
--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -160,7 +160,8 @@ class MockVWS(ContextDecorator):
             # req_kwargs is added dynamically by the responses
             # library onto PreparedRequest objects - it is not
             # in the requests type stubs.
-            req_kwargs: dict[str, Any] = request.__dict__.get(
+            req_kwargs: dict[str, Any] = getattr(  # pylint: disable=bad-builtin
+                request,
                 "req_kwargs",
                 {},
             )
@@ -224,7 +225,7 @@ class MockVWS(ContextDecorator):
                 compiled_url_pattern = re.compile(pattern=url_pattern)
 
                 for http_method in route.http_methods:
-                    original_callback = object.__getattribute__(
+                    original_callback = getattr(  # pylint: disable=bad-builtin
                         api,
                         route.route_name,
                     )

--- a/src/mock_vws/_respx_mock_server/decorators.py
+++ b/src/mock_vws/_respx_mock_server/decorators.py
@@ -161,7 +161,7 @@ def start_respx_router(
             compiled_url_pattern = re.compile(pattern=url_pattern)
 
             for http_method in route.http_methods:
-                original_callback = object.__getattribute__(
+                original_callback = getattr(  # pylint: disable=bad-builtin
                     api,
                     route.route_name,
                 )


### PR DESCRIPTION
## Summary
- Restore `getattr` instead of `request.__dict__.get` and `object.__getattribute__` introduced in #3181
- Add `# pylint: disable=bad-builtin` at each call site

## Test plan
- [ ] CI passes (pylint/ruff/mypy unchanged aside from disables)

Made with [Cursor](https://cursor.com)