### PR TITLE
[codex] Disable unsafe Pylint extension loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,7 @@ MASTER.load-plugins = [
     "pylint.extensions.set_membership",
     "pylint.extensions.typing",
 ]
+MASTER.unsafe-load-any-extension = false
 # We ignore invalid names because:
 # - We want to use generated module names, which may not be valid, but are never seen.
 # - We want to use global variables in documentation, which may not be uppercase


### PR DESCRIPTION
## Summary

Adds `MASTER.unsafe-load-any-extension = false` to the Pylint configuration in `pyproject.toml`.

## Impact

This keeps Pylint from loading arbitrary C extensions while preserving the existing configured plugin list.

## Validation

- `python3.12 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("pyproject.toml").read_text())'`
- Commit hooks: `check toml`, `pyproject-fmt`, and other configured pre-commit checks passed
- Push hooks: `mypy`, `check-manifest`, `pyright`, `ty`, and `pyrefly` passed