### PR TITLE
Bump pyright to 1.1.410 and drop now-unnecessary ignore comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ optional-dependencies.dev = [
     "pylint-per-file-ignores==3.2.1",
     "pyproject-fmt==2.23.0",
     "pyrefly==1.0.0",
-    "pyright==1.1.409",
+    "pyright==1.1.410",
     "pyroma==5.0.1",
     "pytest==9.0.3",
     "pytest-beartype-tests==2026.4.26",

--- a/src/mock_vws/image_matchers.py
+++ b/src/mock_vws/image_matchers.py
@@ -81,12 +81,7 @@ class StructuralSimilarityMatcher:
             second_image_resized = second_image.resize(size=target_size)
 
         first_image_np = np.array(object=first_image_resized, dtype=np.float32)
-        first_image_tensor = (
-            torch.tensor(  # pyright: ignore[reportPrivateImportUsage]
-                data=first_image_np,
-            ).float()
-            / 255
-        )
+        first_image_tensor = torch.tensor(data=first_image_np).float() / 255
         first_image_tensor = first_image_tensor.view(
             first_image_resized.size[1],
             first_image_resized.size[0],
@@ -97,12 +92,7 @@ class StructuralSimilarityMatcher:
             object=second_image_resized,
             dtype=np.float32,
         )
-        second_image_tensor = (
-            torch.tensor(  # pyright: ignore[reportPrivateImportUsage]
-                data=second_image_np,
-            ).float()
-            / 255
-        )
+        second_image_tensor = torch.tensor(data=second_image_np).float() / 255
         second_image_tensor = second_image_tensor.view(
             second_image_resized.size[1],
             second_image_resized.size[0],

--- a/src/mock_vws/target_raters.py
+++ b/src/mock_vws/target_raters.py
@@ -28,12 +28,7 @@ def _get_brisque_target_tracking_rating(*, image_content: bytes) -> int:
     image_file = io.BytesIO(initial_bytes=image_content)
     with Image.open(fp=image_file) as image:
         image_np = np.array(object=image, dtype=np.float32)
-        image_tensor = (
-            torch.tensor(  # pyright: ignore[reportPrivateImportUsage]
-                data=image_np,
-            ).float()
-            / 255
-        )
+        image_tensor = torch.tensor(data=image_np).float() / 255
         image_tensor = image_tensor.view(
             image.size[1],
             image.size[0],


### PR DESCRIPTION
Bumps pyright from 1.1.409 to 1.1.410. In 1.1.410 pyright no longer reports `torch.tensor` as a private import, so the three `# pyright: ignore[reportPrivateImportUsage]` suppressions on `torch.tensor(...)` calls became errors under `reportUnnecessaryTypeIgnoreComment` (the failure on PR #3213). This removes those comments and lets ruff collapse the calls to single lines. The bump and the comment removal must land together — either alone fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)