### PR TITLE
Retry transient Vuforia setup failures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ from sybil.parsers.rest import (
     PythonCodeBlockParser,
 )
 
-from tests.mock_vws.utils.retries import RETRY_EXCEPTIONS
+from tests.mock_vws.utils.retries import TRANSIENT_VWS_EXCEPTIONS
 
 pytest_collect_file = Sybil(
     parsers=[
@@ -29,4 +29,4 @@ def pytest_set_filtered_exceptions() -> tuple[type[Exception], ...]:
     This is for ``pytest-retry``.
     The configuration for retries is in ``pyproject.toml``.
     """
-    return RETRY_EXCEPTIONS
+    return TRANSIENT_VWS_EXCEPTIONS

--- a/tests/mock_vws/fixtures/prepared_requests.py
+++ b/tests/mock_vws/fixtures/prepared_requests.py
@@ -17,14 +17,14 @@ from mock_vws._constants import ResultCodes
 from mock_vws.database import CloudDatabase
 from tests.mock_vws.fixtures.credentials import VuMarkCloudDatabase
 from tests.mock_vws.utils import Endpoint
-from tests.mock_vws.utils.retries import RETRY_ON_TOO_MANY_REQUESTS
+from tests.mock_vws.utils.retries import RETRY_ON_TRANSIENT_VWS_FAILURE
 
 VWS_HOST = "https://vws.vuforia.com"
 VWQ_HOST = "https://cloudreco.vuforia.com"
 
 
 @beartype
-@RETRY_ON_TOO_MANY_REQUESTS
+@RETRY_ON_TRANSIENT_VWS_FAILURE
 def _wait_for_target_processed(*, vws_client: VWS, target_id: str) -> None:
     """Wait for a target to be processed.
 

--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -26,14 +26,14 @@ from tests.mock_vws.fixtures.credentials import (
     InactiveVuMarkCloudDatabase,
     VuMarkCloudDatabase,
 )
-from tests.mock_vws.utils.retries import RETRY_ON_TOO_MANY_REQUESTS
+from tests.mock_vws.utils.retries import RETRY_ON_TRANSIENT_VWS_FAILURE
 
 LOGGER = logging.getLogger(name=__name__)
 LOGGER.setLevel(level=logging.DEBUG)
 
 
 @beartype
-@RETRY_ON_TOO_MANY_REQUESTS
+@RETRY_ON_TRANSIENT_VWS_FAILURE
 def _delete_all_targets(*, database_keys: CloudDatabase) -> None:
     """Delete all targets.
 

--- a/tests/mock_vws/utils/retries.py
+++ b/tests/mock_vws/utils/retries.py
@@ -1,20 +1,24 @@
 """Helpers for retrying requests to VWS."""
 
+from requests.exceptions import Timeout as RequestsTimeout
 from tenacity import retry
 from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 from vws.exceptions.custom_exceptions import ServerError
 from vws.exceptions.vws_exceptions import (
     TooManyRequestsError,
 )
 
-RETRY_EXCEPTIONS = (TooManyRequestsError, ServerError)
+TRANSIENT_VWS_EXCEPTIONS = (TooManyRequestsError, ServerError, RequestsTimeout)
+TRANSIENT_VWS_RETRY_ATTEMPTS = 10
 
 # We rely on pytest-retry for exceptions *during* tests.
 # We use tenacity for exceptions *before* tests.
 # See https://github.com/str0zzapreti/pytest-retry/issues/33.
-RETRY_ON_TOO_MANY_REQUESTS = retry(
-    retry=retry_if_exception_type(exception_types=RETRY_EXCEPTIONS),
+RETRY_ON_TRANSIENT_VWS_FAILURE = retry(
+    retry=retry_if_exception_type(exception_types=TRANSIENT_VWS_EXCEPTIONS),
+    stop=stop_after_attempt(max_attempt_number=TRANSIENT_VWS_RETRY_ATTEMPTS),
     wait=wait_fixed(wait=10),
     reraise=True,
 )


### PR DESCRIPTION
Retries setup-time transient Vuforia failures, including requests timeouts, in the shared test retry helper. Updates pytest-retry's filtered exception tuple and fixture decorators to use the renamed transient failure helper. Bounds setup retries to 10 attempts so outages fail instead of hanging until CI timeout. Validation: commit and push hooks passed, plus scoped Ruff and the mock-only TestDateFormats shard passed locally.