### PR TITLE
Fix ty type errors in header tests

### DIFF
--- a/tests/mock_vws/test_authorization_header.py
+++ b/tests/mock_vws/test_authorization_header.py
@@ -38,7 +38,7 @@ class TestAuthorizationHeader:
         is given.
         """
         date = rfc_1123_date()
-        new_headers = {
+        new_headers: dict[str, str] = {
             **endpoint.headers,
             "Date": date,
         }

--- a/tests/mock_vws/test_date_header.py
+++ b/tests/mock_vws/test_date_header.py
@@ -46,7 +46,7 @@ class TestMissing:
             request_path=endpoint.path_url,
         )
 
-        new_headers = {
+        new_headers: dict[str, str] = {
             **endpoint.headers,
             "Authorization": authorization_string,
         }


### PR DESCRIPTION
The `ty` bump in #3247 began flagging `Endpoint(headers=new_headers)` in two tests, because `ty` widens a dict's value type to include `None` after a `.pop(..., None)` call, making it no longer assignable to `Mapping[str, str]`. This annotates the two affected `new_headers` dicts as `dict[str, str]` so their declared type stays fixed.