### PR TITLE
Remove obsolete bdist_wheel.universal setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,9 +131,6 @@ package-data.mock_vws = [
 ]
 zip-safe = false
 
-[tool.distutils]
-bdist_wheel.universal = true
-
 [tool.setuptools_scm]
 # This keeps the start of the version the same as the last release.
 # This is useful for our documentation to include e.g. binary links


### PR DESCRIPTION
## Summary
- Remove `[tool.distutils] bdist_wheel.universal = true` from `pyproject.toml`.
- Universal wheels falsely claim Python 2 support and trigger setuptools deprecation warnings on every build.

## Test plan
- [ ] Confirm package still builds a normal (non-universal) wheel
- [ ] Confirm CI passes

Made with [Cursor](https://cursor.com)