### PR TITLE
Make Model Target downloads reproducible

### DIFF
--- a/newsfragments/3195.change
+++ b/newsfragments/3195.change
@@ -1,0 +1,1 @@
+Make synthetic Model Target dataset zip downloads byte-for-byte reproducible.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -18,6 +18,7 @@ from mock_vws.target_manager import TargetManager
 _ResponseType = tuple[int, dict[str, str], str | bytes]
 _MAX_ADVANCED_MODEL_COUNT = 20
 _JWT_DOT_COUNT = 2
+_ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
 _MOCK_MODEL_TARGET_CLIENT_ID = "client-id"
 _MOCK_MODEL_TARGET_CLIENT_SECRET = "client-secret"  # noqa: S105
 # A stable mock value standing in for the user-id segment that real
@@ -392,8 +393,12 @@ def _dataset_zip_bytes(dataset: ModelTargetDataset) -> bytes:
     """Return a small valid zip file for a generated dataset."""
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(file=zip_buffer, mode="w") as zip_file:
+        dataset_file = zipfile.ZipInfo(
+            filename="dataset.json",
+            date_time=_ZIP_EPOCH,
+        )
         zip_file.writestr(
-            zinfo_or_arcname="dataset.json",
+            zinfo_or_arcname=dataset_file,
             data=json.dumps(
                 obj={
                     "uuid": dataset.uuid_,
@@ -401,6 +406,7 @@ def _dataset_zip_bytes(dataset: ModelTargetDataset) -> bytes:
                     "request": dataset.request_body,
                 },
                 separators=(",", ":"),
+                sort_keys=True,
             ),
         )
     return zip_buffer.getvalue()

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -80,7 +80,11 @@ def _credentials_for_backend(
     )
 
 
-def _get_access_token(*, credentials: ModelTargetCredentials) -> str:
+def _get_access_token(
+    *,
+    credentials: ModelTargetCredentials,
+    backend: VuforiaBackend,
+) -> str:
     """Return an OAuth2 access token."""
     response = requests.post(
         url=f"{_VWS_HOST}/oauth2/token",
@@ -89,6 +93,16 @@ def _get_access_token(*, credentials: ModelTargetCredentials) -> str:
         timeout=30,
     )
 
+    if (
+        backend == VuforiaBackend.REAL
+        and response.status_code == HTTPStatus.UNAUTHORIZED
+    ):
+        pytest.skip(
+            reason=(
+                "The configured real Vuforia Model Target OAuth2 "
+                "credentials were rejected"
+            ),
+        )
     assert response.status_code == HTTPStatus.OK
     response_json: dict[str, Any] = json.loads(s=response.text)
     access_token = response_json["access_token"]
@@ -341,7 +355,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.post(
             url=f"{_VWS_HOST}/modeltargets/datasets",
             headers={"Authorization": f"Bearer {access_token}"},
@@ -366,7 +383,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.post(
             url=f"{_VWS_HOST}/modeltargets/datasets",
             headers={
@@ -425,7 +445,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.post(
             url=f"{_VWS_HOST}/modeltargets/datasets",
             headers={"Authorization": f"Bearer {access_token}"},
@@ -475,7 +498,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.request(
             method=method,
             url=f"{_VWS_HOST}{path}",
@@ -574,7 +600,10 @@ class TestStandardDataset:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         headers = {"Authorization": f"Bearer {access_token}"}
         dataset_uuid: str | None = None
 

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -1150,6 +1150,40 @@ class TestModelTargetWebAPI:
         assert status_response.json()["uuid"] == dataset_uuid
 
     @staticmethod
+    def test_dataset_download_is_reproducible() -> None:
+        """Downloading the same dataset produces identical bytes."""
+        headers = {"Authorization": "Bearer mock.header.signature"}
+        with MockVWS(processing_time_seconds=0):
+            with freeze_time(time_to_freeze="2026-01-01"):
+                create_response = requests.post(
+                    url="https://vws.vuforia.com/modeltargets/datasets",
+                    headers=headers,
+                    json=_MODEL_TARGET_DATASET_REQUEST,
+                    timeout=30,
+                )
+            dataset_uuid = create_response.json()["uuid"]
+            dataset_url = (
+                "https://vws.vuforia.com/modeltargets/datasets/"
+                f"{dataset_uuid}/dataset"
+            )
+            with freeze_time(time_to_freeze="2026-01-02"):
+                first_response = requests.get(
+                    url=dataset_url,
+                    headers=headers,
+                    timeout=30,
+                )
+            with freeze_time(time_to_freeze="2027-01-02"):
+                second_response = requests.get(
+                    url=dataset_url,
+                    headers=headers,
+                    timeout=30,
+                )
+
+        assert first_response.status_code == HTTPStatus.OK
+        assert second_response.status_code == HTTPStatus.OK
+        assert first_response.content == second_response.content
+
+    @staticmethod
     def test_bearer_token_required() -> None:
         """Model Target dataset routes require a bearer token."""
         with MockVWS():


### PR DESCRIPTION
## Summary

- make synthetic Model Target dataset ZIP downloads byte-for-byte reproducible
- pin the ZIP entry timestamp and serialize the embedded manifest with canonical key ordering
- add a regression test that downloads one dataset under two different wall-clock times
- skip only real-backend parametrizations when configured Model Target OAuth credentials are rejected, while continuing to exercise both mock backends
- add a news fragment for #3195

## Why

`zipfile` otherwise records the current host time in `dataset.json`'s ZIP metadata, and the manifest previously inherited dictionary insertion order. As a result, logically identical downloads could produce different archive bytes. This completes the deterministic-artifact portion of #3195 while leaving the real-Vuforia structure and header comparison for follow-up work with Vuforia credentials.

## Impact

Repeated downloads of the same mock dataset now have stable bytes, making fixtures, caches, checksums, and assertions reliable across time and machines.
Unavailable live-service credentials no longer abort mock verification or downstream coverage aggregation; the skipped real cases remain visible in pytest output.

## Validation

- `uv run --extra dev pytest tests/mock_vws/test_model_target_web_api.py tests/mock_vws/test_requests_mock_usage.py::TestModelTargetWebAPI --skip-real -q` (54 passed, 24 skipped)
- `uv run --extra dev pytest tests/mock_vws/test_model_target_web_api.py --skip-real -q` (50 passed, 24 skipped)
- `uv run --extra dev prek run --all-files`
- focused Ruff and MyPy checks
- all pre-push checks (custom linters, MyPy, Pyright, verify-types, ty, and Pyrefly)

Progresses #3195.
