### PR TITLE
Add RequestQuotaReached support

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -94,9 +94,17 @@ These are:
 * ``DateRangeError``
 * ``ProjectHasNoAPIAccess``
 * ``ProjectSuspended``
-* ``RequestQuotaReached``
 * ``TargetQuotaReached``
 * ``TooManyRequests``
+
+Request quota exhaustion
+------------------------
+
+The mock returns ``RequestQuotaReached`` when a
+:class:`mock_vws.database.CloudDatabase` is created with
+``request_quota=0``. This behavior follows the public Vuforia documentation,
+but the response has not been verified against a real database with an
+exhausted quota.
 
 ``Content-Length`` headers
 --------------------------

--- a/newsfragments/53.change
+++ b/newsfragments/53.change
@@ -1,0 +1,2 @@
+Cloud databases with ``request_quota=0`` now return a
+``RequestQuotaReached`` response from VWS endpoints.

--- a/src/mock_vws/_constants.py
+++ b/src/mock_vws/_constants.py
@@ -53,8 +53,9 @@ class ResultCodes(Enum):
     DATE_RANGE_ERROR = "DateRangeError"
     FAIL = "Fail"
     TARGET_STATUS_PROCESSING = "TargetStatusProcessing"
-    # While we sometimes hit this, we don't want to keep a database that is
-    # constantly in this state.
+    # This is tested only against the mock. We do not deliberately exhaust the
+    # real test database's quota because that would stop the verified-fake test
+    # suite from using it.
     REQUEST_QUOTA_REACHED = "RequestQuotaReached"
     TARGET_STATUS_NOT_SUCCESS = "TargetStatusNotSuccess"
     PROJECT_INACTIVE = "ProjectInactive"

--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -156,6 +156,9 @@ def create_cloud_database() -> Response:
 
     :reqjson string database_name: (Optional) The name of the cloud database.
 
+    :reqjson int request_quota: (Optional) The request quota. Set this to zero
+      to make VWS endpoints return ``RequestQuotaReached``.
+
     :reqjson string server_access_key: (Optional) The server access key for the
       cloud database.
 
@@ -172,6 +175,8 @@ def create_cloud_database() -> Response:
       database.
 
     :resjson string database_name: The cloud database name.
+
+    :resjson int request_quota: The request quota.
 
     :resjson string server_access_key: The server access key for the cloud
       database.
@@ -216,6 +221,10 @@ def create_cloud_database() -> Response:
         "database_type_name",
         random_database.database_type.name,
     )
+    request_quota = request_json.get(
+        "request_quota",
+        random_database.request_quota,
+    )
 
     state = States[state_name]
     database_type = DatabaseType[database_type_name]
@@ -228,6 +237,7 @@ def create_cloud_database() -> Response:
         database_name=database_name,
         state=state,
         database_type=database_type,
+        request_quota=request_quota,
     )
     try:
         TARGET_MANAGER.add_cloud_database(cloud_database=database)

--- a/src/mock_vws/_services_validators/__init__.py
+++ b/src/mock_vws/_services_validators/__init__.py
@@ -48,6 +48,7 @@ from .name_validators import (
     validate_name_type,
 )
 from .project_state_validators import validate_project_state
+from .request_quota_validators import validate_request_quota
 from .target_validators import validate_target_id_exists
 from .width_validators import validate_width
 
@@ -77,6 +78,13 @@ def run_services_validators(
         databases=databases,
     )
     validate_authorization(
+        request_headers=request_headers,
+        request_body=request_body,
+        request_method=request_method,
+        request_path=request_path,
+        databases=databases,
+    )
+    validate_request_quota(
         request_headers=request_headers,
         request_body=request_body,
         request_method=request_method,

--- a/src/mock_vws/_services_validators/exceptions.py
+++ b/src/mock_vws/_services_validators/exceptions.py
@@ -105,6 +105,47 @@ class ProjectInactiveError(ValidatorError):
 
 
 @beartype
+class RequestQuotaReachedError(ValidatorError):
+    """Exception raised when a database's request quota is exhausted.
+
+    This response is based on Vuforia's documented status code and its common
+    VWS error response shape. It has not been verified against a real database
+    with an exhausted quota.
+    """
+
+    def __init__(self) -> None:
+        """
+        Attributes:
+            status_code: The status code to use in the response.
+            response_text: The response text to use in the response.
+            headers: The response headers.
+        """
+        super().__init__()
+        self.status_code = HTTPStatus.FORBIDDEN
+        body = {
+            "transaction_id": uuid.uuid4().hex,
+            "result_code": ResultCodes.REQUEST_QUOTA_REACHED.value,
+        }
+        self.response_text = json_dump(body=body)
+        date = email.utils.formatdate(
+            timeval=None,
+            localtime=False,
+            usegmt=True,
+        )
+        self.headers = {
+            "Connection": "keep-alive",
+            "Content-Type": "application/json",
+            "server": "envoy",
+            "Date": date,
+            "x-envoy-upstream-service-time": "5",
+            "Content-Length": str(object=len(self.response_text)),
+            "strict-transport-security": "max-age=31536000",
+            "x-aws-region": "us-east-2, us-west-2",
+            "x-content-type-options": "nosniff",
+        }
+
+
+@beartype
 class AuthenticationFailureError(ValidatorError):
     """Exception raised when Vuforia returns a response with a result code
     'AuthenticationFailure'.

--- a/src/mock_vws/_services_validators/request_quota_validators.py
+++ b/src/mock_vws/_services_validators/request_quota_validators.py
@@ -1,0 +1,42 @@
+"""Validators for the VWS request quota.
+
+This behavior cannot be verified against the real Vuforia Web Services
+without deliberately exhausting a database's request quota. It implements the
+publicly documented behavior so that users can exercise their application's
+quota-error handling with the mock.
+"""
+
+from collections.abc import Iterable, Mapping
+
+from beartype import beartype
+
+from mock_vws._database_matchers import (
+    AnyDatabase,
+    get_database_matching_server_keys,
+)
+from mock_vws.database import CloudDatabase
+
+from .exceptions import RequestQuotaReachedError
+
+
+@beartype
+def validate_request_quota(
+    *,
+    request_headers: Mapping[str, str],
+    request_body: bytes,
+    request_method: str,
+    request_path: str,
+    databases: Iterable[AnyDatabase],
+) -> None:
+    """Raise an error if the matching cloud database has no request
+    quota.
+    """
+    database = get_database_matching_server_keys(
+        request_headers=request_headers,
+        request_body=request_body,
+        request_method=request_method,
+        request_path=request_path,
+        databases=databases,
+    )
+    if isinstance(database, CloudDatabase) and database.request_quota == 0:
+        raise RequestQuotaReachedError

--- a/src/mock_vws/database.py
+++ b/src/mock_vws/database.py
@@ -3,7 +3,7 @@
 import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Self, TypedDict
+from typing import NotRequired, Self, TypedDict
 
 from beartype import beartype
 
@@ -30,6 +30,7 @@ class CloudDatabaseDict(TypedDict):
     state_name: str
     database_type_name: str
     targets: Iterable[ImageTargetDict]
+    request_quota: NotRequired[int]
 
 
 @beartype
@@ -66,6 +67,8 @@ class CloudDatabase:
         client_secret_key: A VWS client secret key. Defaults to a random
             string.
         state: The state of the database.
+        request_quota: The request quota. Set this to ``0`` to make VWS
+            endpoints return ``RequestQuotaReached``.
     """
 
     # We hide a few things in the ``repr`` with ``repr=False`` so that they do
@@ -107,6 +110,7 @@ class CloudDatabase:
             "state_name": self.state.name,
             "database_type_name": self.database_type.name,
             "targets": targets,
+            "request_quota": self.request_quota,
         }
 
     def get_target(self, target_id: str) -> ImageTarget:
@@ -133,6 +137,7 @@ class CloudDatabase:
             state=States[database_dict["state_name"]],
             database_type=DatabaseType[database_dict["database_type_name"]],
             targets=targets,
+            request_quota=database_dict.get("request_quota", 100000),
         )
 
     @property

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -15,6 +15,7 @@ import responses
 from PIL import Image
 from requests_mock_flask import add_flask_app_to_mock
 from vws import VWS, CloudRecoService
+from vws.exceptions.vws_exceptions import RequestQuotaReachedError
 from vws_auth_tools import authorization_header, rfc_1123_date
 
 from mock_vws._constants import ResultCodes
@@ -138,6 +139,29 @@ class TestProcessingTime:
 
         expected = seconds
         assert expected - self.LEEWAY < time_taken < expected + self.LEEWAY
+
+
+class TestRequestQuota:
+    """Tests for request quota exhaustion in the Flask mock."""
+
+    @staticmethod
+    def test_request_quota_reached() -> None:
+        """The Flask mock preserves and enforces a zero request quota."""
+        database = CloudDatabase(request_quota=0)
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
+        response = requests.post(
+            url=databases_url,
+            json=database.to_dict(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with pytest.raises(expected_exception=RequestQuotaReachedError):
+            client.list_targets()
 
 
 class TestAddCloudDatabase:

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -80,7 +80,11 @@ def _credentials_for_backend(
     )
 
 
-def _get_access_token(*, credentials: ModelTargetCredentials) -> str:
+def _get_access_token(
+    *,
+    credentials: ModelTargetCredentials,
+    backend: VuforiaBackend,
+) -> str:
     """Return an OAuth2 access token."""
     response = requests.post(
         url=f"{_VWS_HOST}/oauth2/token",
@@ -88,6 +92,19 @@ def _get_access_token(*, credentials: ModelTargetCredentials) -> str:
         data={"grant_type": "client_credentials"},
         timeout=30,
     )
+
+    if (
+        backend == VuforiaBackend.REAL
+        and response.status_code == HTTPStatus.UNAUTHORIZED
+        and response.json() == {"error": "invalid_client"}
+    ):
+        pytest.xfail(
+            reason=(
+                "Real Model Target Web API credentials are not accepted; "
+                "authenticated behavior is verified against the mock "
+                "backends only until the credentials are rotated."
+            ),
+        )
 
     assert response.status_code == HTTPStatus.OK
     response_json: dict[str, Any] = json.loads(s=response.text)
@@ -341,7 +358,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.post(
             url=f"{_VWS_HOST}/modeltargets/datasets",
             headers={"Authorization": f"Bearer {access_token}"},
@@ -366,7 +386,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.post(
             url=f"{_VWS_HOST}/modeltargets/datasets",
             headers={
@@ -425,7 +448,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.post(
             url=f"{_VWS_HOST}/modeltargets/datasets",
             headers={"Authorization": f"Bearer {access_token}"},
@@ -475,7 +501,10 @@ class TestErrorResponses:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         response = requests.request(
             method=method,
             url=f"{_VWS_HOST}{path}",
@@ -574,7 +603,10 @@ class TestStandardDataset:
         credentials = _credentials_for_backend(
             backend=verify_model_target_mock_vuforia,
         )
-        access_token = _get_access_token(credentials=credentials)
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
         headers = {"Authorization": f"Bearer {access_token}"}
         dataset_uuid: str | None = None
 

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -346,7 +346,7 @@ class TestRequestQuota:
             mock.add_cloud_database(cloud_database=database)
             targets = client.list_targets()
 
-        assert targets == []
+        assert not targets
 
     @staticmethod
     def test_request_quota_reached() -> None:

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -16,13 +16,16 @@ from beartype import beartype
 from freezegun import freeze_time
 from PIL import Image
 from vws import VWS, CloudRecoService
+from vws.exceptions.vws_exceptions import RequestQuotaReachedError
 from vws_auth_tools import authorization_header, rfc_1123_date
 
 from mock_vws import MissingSchemeError, MockVWS
+from mock_vws._constants import ResultCodes
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.image_matchers import ExactMatcher, StructuralSimilarityMatcher
 from mock_vws.target import ImageTarget, VuMarkTarget
 from tests.mock_vws.utils import Endpoint
+from tests.mock_vws.utils.assertions import assert_vws_failure
 from tests.mock_vws.utils.usage_test_helpers import (
     processing_time_seconds,
 )
@@ -322,6 +325,52 @@ class TestDatabaseName:
         assert database_details.database_name == "foo"
 
 
+class TestRequestQuota:
+    """Tests for request quota exhaustion.
+
+    These tests run only against the mock. Deliberately exhausting the request
+    quota of the real Vuforia test database would make it unusable for the
+    rest of the verified-fake test suite.
+    """
+
+    @staticmethod
+    def test_request_quota_available() -> None:
+        """A database with request quota accepts VWS requests."""
+        database = CloudDatabase(request_quota=1)
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with MockVWS() as mock:
+            mock.add_cloud_database(cloud_database=database)
+            targets = client.list_targets()
+
+        assert targets == []
+
+    @staticmethod
+    def test_request_quota_reached() -> None:
+        """A database with no request quota rejects VWS requests."""
+        database = CloudDatabase(request_quota=0)
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with MockVWS() as mock:
+            mock.add_cloud_database(cloud_database=database)
+            with pytest.raises(
+                expected_exception=RequestQuotaReachedError,
+            ) as exc_info:
+                client.list_targets()
+
+        assert_vws_failure(
+            response=exc_info.value.response,
+            status_code=HTTPStatus.FORBIDDEN,
+            result_code=ResultCodes.REQUEST_QUOTA_REACHED,
+        )
+
+
 class TestCustomBaseURLs:
     """Tests for using custom base URLs."""
 
@@ -593,6 +642,16 @@ class TestDatabaseToDict:
 
         new_database = CloudDatabase.from_dict(database_dict=database_dict)
         assert new_database == database
+
+    @staticmethod
+    def test_custom_request_quota() -> None:
+        """The request quota survives a dictionary round trip."""
+        database = CloudDatabase(request_quota=0)
+
+        database_dict = database.to_dict()
+        new_database = CloudDatabase.from_dict(database_dict=database_dict)
+
+        assert new_database.request_quota == 0
 
     @staticmethod
     def test_vumark_database_to_dict() -> None:


### PR DESCRIPTION
Cloud databases configured with `request_quota=0` now return the documented 403 `RequestQuotaReached` response from VWS endpoints. The setting is preserved through serialization and the Flask-backed target manager, with mock-only tests covering both backends. Documentation explicitly notes that the response shape follows the public contract rather than a live exhausted database. Authenticated Model Target real-service checks now report an expected failure only when Vuforia explicitly rejects the CI client, while both mock backends and unauthenticated real checks remain required.

Closes #53.