### PR TITLE
Add more configurable VWS result codes

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -92,9 +92,6 @@ There are some result codes which the mock cannot return.
 These are:
 
 * ``DateRangeError``
-* ``ProjectHasNoAPIAccess``
-* ``ProjectSuspended``
-* ``TargetQuotaReached``
 * ``TooManyRequests``
 
 Request quota exhaustion
@@ -105,6 +102,20 @@ The mock returns ``RequestQuotaReached`` when a
 ``request_quota=0``. This behavior follows the public Vuforia documentation,
 but the response has not been verified against a real database with an
 exhausted quota.
+
+Other configurable result codes
+-------------------------------
+
+The mock also supports three other result codes which have not been verified
+against real databases in the corresponding states:
+
+* ``TargetQuotaReached`` is returned when adding a target to a
+  :class:`mock_vws.database.CloudDatabase` which already contains
+  ``target_quota`` targets.
+* ``ProjectSuspended`` is returned by VWS endpoints when a database uses the
+  :attr:`mock_vws.states.States.PROJECT_SUSPENDED` state.
+* ``ProjectHasNoAPIAccess`` is returned by VWS endpoints when a database uses
+  the :attr:`mock_vws.states.States.PROJECT_HAS_NO_API_ACCESS` state.
 
 ``Content-Length`` headers
 --------------------------

--- a/newsfragments/3306.change
+++ b/newsfragments/3306.change
@@ -1,0 +1,2 @@
+Add configurable ``TargetQuotaReached``, ``ProjectSuspended``, and
+``ProjectHasNoAPIAccess`` responses from VWS endpoints.

--- a/src/mock_vws/_constants.py
+++ b/src/mock_vws/_constants.py
@@ -58,7 +58,10 @@ class ResultCodes(Enum):
     # suite from using it.
     REQUEST_QUOTA_REACHED = "RequestQuotaReached"
     TARGET_STATUS_NOT_SUCCESS = "TargetStatusNotSuccess"
+    TARGET_QUOTA_REACHED = "TargetQuotaReached"
+    PROJECT_SUSPENDED = "ProjectSuspended"
     PROJECT_INACTIVE = "ProjectInactive"
+    PROJECT_HAS_NO_API_ACCESS = "ProjectHasNoAPIAccess"
     INACTIVE_PROJECT = "InactiveProject"
     TOO_MANY_REQUESTS = "TooManyRequests"
     INVALID_ACCEPT_HEADER = "InvalidAcceptHeader"

--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -159,6 +159,9 @@ def create_cloud_database() -> Response:
     :reqjson int request_quota: (Optional) The request quota. Set this to zero
       to make VWS endpoints return ``RequestQuotaReached``.
 
+    :reqjson int target_quota: (Optional) The target quota. Once this many
+      targets exist, adding another returns ``TargetQuotaReached``.
+
     :reqjson string server_access_key: (Optional) The server access key for the
       cloud database.
 
@@ -166,7 +169,8 @@ def create_cloud_database() -> Response:
       cloud database.
 
     :reqjson string state_name: (Optional) The state of the cloud database.
-     This can be "WORKING" or "PROJECT_INACTIVE". This defaults to "WORKING".
+     This can be "WORKING", "PROJECT_INACTIVE", "PROJECT_SUSPENDED", or
+     "PROJECT_HAS_NO_API_ACCESS". This defaults to "WORKING".
 
     :resjson string client_access_key: The client access key for the cloud
       database.
@@ -178,14 +182,15 @@ def create_cloud_database() -> Response:
 
     :resjson int request_quota: The request quota.
 
+    :resjson int target_quota: The target quota.
+
     :resjson string server_access_key: The server access key for the cloud
       database.
 
     :resjson string server_secret_key: The server secret key for the cloud
       database.
 
-    :resjson string state_name: The cloud database state. This will be
-      "WORKING" or "PROJECT_INACTIVE".
+    :resjson string state_name: The cloud database state.
 
     :reqjsonarr targets: The targets in the cloud database.
 
@@ -225,6 +230,10 @@ def create_cloud_database() -> Response:
         "request_quota",
         random_database.request_quota,
     )
+    target_quota = request_json.get(
+        "target_quota",
+        random_database.target_quota,
+    )
 
     state = States[state_name]
     database_type = DatabaseType[database_type_name]
@@ -238,6 +247,7 @@ def create_cloud_database() -> Response:
         state=state,
         database_type=database_type,
         request_quota=request_quota,
+        target_quota=target_quota,
     )
     try:
         TARGET_MANAGER.add_cloud_database(cloud_database=database)

--- a/src/mock_vws/_services_validators/__init__.py
+++ b/src/mock_vws/_services_validators/__init__.py
@@ -49,6 +49,7 @@ from .name_validators import (
 )
 from .project_state_validators import validate_project_state
 from .request_quota_validators import validate_request_quota
+from .target_quota_validators import validate_target_quota
 from .target_validators import validate_target_id_exists
 from .width_validators import validate_width
 
@@ -92,6 +93,13 @@ def run_services_validators(
         databases=databases,
     )
     validate_project_state(
+        request_headers=request_headers,
+        request_body=request_body,
+        request_method=request_method,
+        request_path=request_path,
+        databases=databases,
+    )
+    validate_target_quota(
         request_headers=request_headers,
         request_body=request_body,
         request_method=request_method,

--- a/src/mock_vws/_services_validators/exceptions.py
+++ b/src/mock_vws/_services_validators/exceptions.py
@@ -146,6 +146,99 @@ class RequestQuotaReachedError(ValidatorError):
 
 
 @beartype
+class TargetQuotaReachedError(ValidatorError):
+    """Exception raised when a database's target quota is exhausted."""
+
+    def __init__(self) -> None:
+        """Initialize a ``TargetQuotaReached`` response."""
+        super().__init__()
+        self.status_code = HTTPStatus.FORBIDDEN
+        body = {
+            "transaction_id": uuid.uuid4().hex,
+            "result_code": ResultCodes.TARGET_QUOTA_REACHED.value,
+        }
+        self.response_text = json_dump(body=body)
+        date = email.utils.formatdate(
+            timeval=None,
+            localtime=False,
+            usegmt=True,
+        )
+        self.headers = {
+            "Connection": "keep-alive",
+            "Content-Type": "application/json",
+            "server": "envoy",
+            "Date": date,
+            "x-envoy-upstream-service-time": "5",
+            "Content-Length": str(object=len(self.response_text)),
+            "strict-transport-security": "max-age=31536000",
+            "x-aws-region": "us-east-2, us-west-2",
+            "x-content-type-options": "nosniff",
+        }
+
+
+@beartype
+class ProjectSuspendedError(ValidatorError):
+    """Exception raised when a database has been suspended."""
+
+    def __init__(self) -> None:
+        """Initialize a ``ProjectSuspended`` response."""
+        super().__init__()
+        self.status_code = HTTPStatus.FORBIDDEN
+        body = {
+            "transaction_id": uuid.uuid4().hex,
+            "result_code": ResultCodes.PROJECT_SUSPENDED.value,
+        }
+        self.response_text = json_dump(body=body)
+        date = email.utils.formatdate(
+            timeval=None,
+            localtime=False,
+            usegmt=True,
+        )
+        self.headers = {
+            "Connection": "keep-alive",
+            "Content-Type": "application/json",
+            "server": "envoy",
+            "Date": date,
+            "x-envoy-upstream-service-time": "5",
+            "Content-Length": str(object=len(self.response_text)),
+            "strict-transport-security": "max-age=31536000",
+            "x-aws-region": "us-east-2, us-west-2",
+            "x-content-type-options": "nosniff",
+        }
+
+
+@beartype
+class ProjectHasNoAPIAccessError(ValidatorError):
+    """Exception raised when a database cannot make API requests."""
+
+    def __init__(self) -> None:
+        """Initialize a ``ProjectHasNoAPIAccess`` response."""
+        super().__init__()
+        self.status_code = HTTPStatus.FORBIDDEN
+        body = {
+            "transaction_id": uuid.uuid4().hex,
+            "result_code": ResultCodes.PROJECT_HAS_NO_API_ACCESS.value,
+        }
+        self.response_text = json_dump(body=body)
+        date = email.utils.formatdate(
+            timeval=None,
+            localtime=False,
+            usegmt=True,
+        )
+        self.headers = {
+            "Connection": "keep-alive",
+            "Content-Type": "application/json",
+            "server": "envoy",
+            "Date": date,
+            "x-envoy-upstream-service-time": "5",
+            "Content-Length": str(object=len(self.response_text)),
+            "strict-transport-security": "max-age=31536000",
+            "x-aws-region": "us-east-2, us-west-2",
+            "x-content-type-options": "nosniff",
+        }
+
+
+@beartype
 class AuthenticationFailureError(ValidatorError):
     """Exception raised when Vuforia returns a response with a result code
     'AuthenticationFailure'.

--- a/src/mock_vws/_services_validators/project_state_validators.py
+++ b/src/mock_vws/_services_validators/project_state_validators.py
@@ -10,7 +10,12 @@ from mock_vws._database_matchers import (
     AnyDatabase,
     get_database_matching_server_keys,
 )
-from mock_vws._services_validators.exceptions import ProjectInactiveError
+from mock_vws._services_validators.exceptions import (
+    ProjectHasNoAPIAccessError,
+    ProjectInactiveError,
+    ProjectSuspendedError,
+    ValidatorError,
+)
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.states import States
 
@@ -46,6 +51,13 @@ def validate_project_state(
         request_path=request_path,
         databases=databases,
     )
+
+    state_errors: dict[States, type[ValidatorError]] = {
+        States.PROJECT_HAS_NO_API_ACCESS: ProjectHasNoAPIAccessError,
+        States.PROJECT_SUSPENDED: ProjectSuspendedError,
+    }
+    if error := state_errors.get(database.state):
+        raise error
 
     if database.state != States.PROJECT_INACTIVE:
         return

--- a/src/mock_vws/_services_validators/target_quota_validators.py
+++ b/src/mock_vws/_services_validators/target_quota_validators.py
@@ -1,0 +1,41 @@
+"""Validators for the VWS target quota."""
+
+from collections.abc import Iterable, Mapping
+from http import HTTPMethod
+
+from beartype import beartype
+
+from mock_vws._database_matchers import (
+    AnyDatabase,
+    get_database_matching_server_keys,
+)
+from mock_vws.database import CloudDatabase
+
+from .exceptions import TargetQuotaReachedError
+
+
+@beartype
+def validate_target_quota(
+    *,
+    request_headers: Mapping[str, str],
+    request_body: bytes,
+    request_method: str,
+    request_path: str,
+    databases: Iterable[AnyDatabase],
+) -> None:
+    """Raise an error when adding a target would exceed the quota."""
+    if request_method != HTTPMethod.POST or request_path != "/targets":
+        return
+
+    database = get_database_matching_server_keys(
+        request_headers=request_headers,
+        request_body=request_body,
+        request_method=request_method,
+        request_path=request_path,
+        databases=databases,
+    )
+    if (
+        isinstance(database, CloudDatabase)
+        and len(database.not_deleted_targets) >= database.target_quota
+    ):
+        raise TargetQuotaReachedError

--- a/src/mock_vws/database.py
+++ b/src/mock_vws/database.py
@@ -31,6 +31,7 @@ class CloudDatabaseDict(TypedDict):
     database_type_name: str
     targets: Iterable[ImageTargetDict]
     request_quota: NotRequired[int]
+    target_quota: NotRequired[int]
 
 
 @beartype
@@ -69,6 +70,8 @@ class CloudDatabase:
         state: The state of the database.
         request_quota: The request quota. Set this to ``0`` to make VWS
             endpoints return ``RequestQuotaReached``.
+        target_quota: The target quota. When the database contains this many
+            targets, adding another returns ``TargetQuotaReached``.
     """
 
     # We hide a few things in the ``repr`` with ``repr=False`` so that they do
@@ -111,6 +114,7 @@ class CloudDatabase:
             "database_type_name": self.database_type.name,
             "targets": targets,
             "request_quota": self.request_quota,
+            "target_quota": self.target_quota,
         }
 
     def get_target(self, target_id: str) -> ImageTarget:
@@ -138,6 +142,7 @@ class CloudDatabase:
             database_type=DatabaseType[database_dict["database_type_name"]],
             targets=targets,
             request_quota=database_dict.get("request_quota", 100000),
+            target_quota=database_dict.get("target_quota", 1000),
         )
 
     @property

--- a/src/mock_vws/states.py
+++ b/src/mock_vws/states.py
@@ -12,5 +12,9 @@ class States(StrEnum):
 
     WORKING = auto()
 
+    PROJECT_SUSPENDED = auto()
+
     # A project is inactive if the license key has been deleted.
     PROJECT_INACTIVE = auto()
+
+    PROJECT_HAS_NO_API_ACCESS = auto()

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -15,7 +15,10 @@ import responses
 from PIL import Image
 from requests_mock_flask import add_flask_app_to_mock
 from vws import VWS, CloudRecoService
-from vws.exceptions.vws_exceptions import RequestQuotaReachedError
+from vws.exceptions.vws_exceptions import (
+    RequestQuotaReachedError,
+    TargetQuotaReachedError,
+)
 from vws_auth_tools import authorization_header, rfc_1123_date
 
 from mock_vws._constants import ResultCodes
@@ -162,6 +165,34 @@ class TestRequestQuota:
 
         with pytest.raises(expected_exception=RequestQuotaReachedError):
             client.list_targets()
+
+    @staticmethod
+    def test_target_quota_reached(
+        *,
+        image_file_failed_state: io.BytesIO,
+    ) -> None:
+        """The Flask mock preserves and enforces a zero target quota."""
+        database = CloudDatabase(target_quota=0)
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
+        response = requests.post(
+            url=databases_url,
+            json=database.to_dict(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with pytest.raises(expected_exception=TargetQuotaReachedError):
+            client.add_target(
+                name="example",
+                width=1,
+                image=image_file_failed_state,
+                application_metadata=None,
+                active_flag=True,
+            )
 
 
 class TestAddCloudDatabase:

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -16,13 +16,20 @@ from beartype import beartype
 from freezegun import freeze_time
 from PIL import Image
 from vws import VWS, CloudRecoService
-from vws.exceptions.vws_exceptions import RequestQuotaReachedError
+from vws.exceptions.base_exceptions import VWSError
+from vws.exceptions.vws_exceptions import (
+    ProjectHasNoAPIAccessError,
+    ProjectSuspendedError,
+    RequestQuotaReachedError,
+    TargetQuotaReachedError,
+)
 from vws_auth_tools import authorization_header, rfc_1123_date
 
 from mock_vws import MissingSchemeError, MockVWS
 from mock_vws._constants import ResultCodes
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.image_matchers import ExactMatcher, StructuralSimilarityMatcher
+from mock_vws.states import States
 from mock_vws.target import ImageTarget, VuMarkTarget
 from tests.mock_vws.utils import Endpoint
 from tests.mock_vws.utils.assertions import assert_vws_failure
@@ -371,6 +378,81 @@ class TestRequestQuota:
         )
 
 
+class TestAdditionalResultCodes:
+    """Tests for configurable, mock-only VWS result codes."""
+
+    @staticmethod
+    def test_target_quota_reached(
+        *,
+        image_file_failed_state: io.BytesIO,
+    ) -> None:
+        """A database at its target quota rejects new targets."""
+        database = CloudDatabase(target_quota=0)
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with MockVWS() as mock:
+            mock.add_cloud_database(cloud_database=database)
+            with pytest.raises(
+                expected_exception=TargetQuotaReachedError,
+            ) as exc_info:
+                client.add_target(
+                    name="example",
+                    width=1,
+                    image=image_file_failed_state,
+                    application_metadata=None,
+                    active_flag=True,
+                )
+
+        assert_vws_failure(
+            response=exc_info.value.response,
+            status_code=HTTPStatus.FORBIDDEN,
+            result_code=ResultCodes.TARGET_QUOTA_REACHED,
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        argnames=("state", "expected_exception", "result_code"),
+        argvalues=[
+            (
+                States.PROJECT_SUSPENDED,
+                ProjectSuspendedError,
+                ResultCodes.PROJECT_SUSPENDED,
+            ),
+            (
+                States.PROJECT_HAS_NO_API_ACCESS,
+                ProjectHasNoAPIAccessError,
+                ResultCodes.PROJECT_HAS_NO_API_ACCESS,
+            ),
+        ],
+    )
+    def test_project_state_result_codes(
+        *,
+        state: States,
+        expected_exception: type[VWSError],
+        result_code: ResultCodes,
+    ) -> None:
+        """Configured project states reject VWS requests."""
+        database = CloudDatabase(state=state)
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with MockVWS() as mock:
+            mock.add_cloud_database(cloud_database=database)
+            with pytest.raises(expected_exception=expected_exception) as exc:
+                client.list_targets()
+
+        assert_vws_failure(
+            response=exc.value.response,
+            status_code=HTTPStatus.FORBIDDEN,
+            result_code=result_code,
+        )
+
+
 class TestCustomBaseURLs:
     """Tests for using custom base URLs."""
 
@@ -652,6 +734,16 @@ class TestDatabaseToDict:
         new_database = CloudDatabase.from_dict(database_dict=database_dict)
 
         assert new_database.request_quota == 0
+
+    @staticmethod
+    def test_custom_target_quota() -> None:
+        """The target quota survives a dictionary round trip."""
+        database = CloudDatabase(target_quota=0)
+
+        database_dict = database.to_dict()
+        new_database = CloudDatabase.from_dict(database_dict=database_dict)
+
+        assert new_database.target_quota == 0
 
     @staticmethod
     def test_vumark_database_to_dict() -> None:


### PR DESCRIPTION
Adds configurable `TargetQuotaReached`, `ProjectSuspended`, and `ProjectHasNoAPIAccess` responses so applications can exercise these error paths against the mock.

The target quota is preserved through database serialization and Flask target-manager creation, while project states are enforced by shared service validation.

Tests cover both in-memory and Flask behavior, and the differences documentation plus release note describe the new controls.

Validation: focused pytest coverage, pre-commit hooks, mypy, Pyright, ty, Pyrefly, and Sphinx all pass; live verified-fake and Docker tests require unavailable external credentials/services.
