### PR TITLE
Keep Model Target status responses consistent

### DIFF
--- a/newsfragments/3194.change
+++ b/newsfragments/3194.change
@@ -1,1 +1,2 @@
 Match real Vuforia Model Target unknown-dataset response shape (``NOT_FOUND`` code, ``Could not find a model-view database with uuid <uuid>`` message, ``userId:`` target).
+Keep each Model Target dataset status response internally consistent when processing completes while the response is being generated.

--- a/src/mock_vws/model_target.py
+++ b/src/mock_vws/model_target.py
@@ -66,12 +66,13 @@ class ModelTargetDataset:
 
     def status_body(self) -> dict[str, Any]:
         """Return a status response body for this dataset."""
+        status = self.status
         body: dict[str, Any] = {
-            "status": self.status,
+            "status": status,
             "uuid": self.uuid_,
             "createdAt": _format_datetime(value=self.created_at),
         }
-        if self.status == "processing":
+        if status == "processing":
             body["eta"] = _format_datetime(value=self.completed_at)
         else:
             body["completedAt"] = _format_datetime(value=self.completed_at)

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 
 from mock_vws import MockVWS
+from mock_vws.model_target import ModelTargetDataset, ModelTargetDatasetType
 from tests.mock_vws.fixtures.credentials import (
     ModelTargetCredentials,
     get_model_target_credentials,
@@ -655,3 +656,35 @@ class TestStandardDataset:
                     HTTPStatus.OK,
                     HTTPStatus.NO_CONTENT,
                 }
+
+
+class TestModelTargetDatasetStatus:
+    """Tests for Model Target dataset status response bodies."""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        argnames=("processing_time_seconds", "status", "time_field"),
+        argvalues=[
+            pytest.param(3600.0, "processing", "eta", id="processing"),
+            pytest.param(0.0, "done", "completedAt", id="done"),
+        ],
+    )
+    def test_status_uses_matching_time_field(
+        *,
+        processing_time_seconds: float,
+        status: str,
+        time_field: str,
+    ) -> None:
+        """Each status includes only its matching timestamp field."""
+        dataset = ModelTargetDataset(
+            request_body={},
+            dataset_type=ModelTargetDatasetType.STANDARD,
+            processing_time_seconds=processing_time_seconds,
+            uuid_="dataset-uuid",
+        )
+
+        body = dataset.status_body()
+
+        assert body["status"] == status
+        assert body["uuid"] == "dataset-uuid"
+        assert {"eta", "completedAt"} & body.keys() == {time_field}


### PR DESCRIPTION
## Summary

- snapshot a Model Target dataset's status once while building its response
- keep `processing` paired with `eta` and terminal statuses paired with `completedAt`
- cover processing and completed payloads using real `ModelTargetDataset` instances
- update the #3194 changelog fragment

## Why

`ModelTargetDataset.status_body()` read the live status twice. If processing completed between those reads, the response could report `"status": "processing"` while including `completedAt` instead of `eta`. Taking one status snapshot keeps the response internally consistent and advances the status-fidelity work in #3194.

## Impact

Consumers of the mock no longer receive a mixed-state Model Target status payload at the processing boundary. The public response shape is otherwise unchanged.

## Validation

- `uv run pytest tests/mock_vws/test_model_target_web_api.py --skip-real -q` (52 passed, 24 skipped)
- `uv run mypy src/mock_vws/model_target.py tests/mock_vws/test_model_target_web_api.py`
- `uv run ruff check src/mock_vws/model_target.py tests/mock_vws/test_model_target_web_api.py`
- `uv run ruff format --check src/mock_vws/model_target.py tests/mock_vws/test_model_target_web_api.py`
- repository pre-commit and pre-push hooks
