### PR TITLE
Install uv in release job and record 2026.08.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,12 @@ jobs:
           # The default GITHUB_TOKEN cannot bypass rulesets.
           token: ${{ secrets.RELEASE_PAT }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
       - name: Calver calculate version
         uses: StephaneBour/actions-calver@master
         id: calver

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,27 @@ Changelog
 
 .. towncrier release notes start
 
+2026.08.04
+----------
+
+- Cloud databases with ``request_quota=0`` now return a
+  ``RequestQuotaReached`` response from VWS endpoints.
+
+- Add a mock implementation of the Model Target Web API, including OAuth2 token creation, standard and advanced dataset creation, status polling, dataset download, and deletion.
+
+- Improve Model Target Web API mock authentication failure responses.
+
+- Match real Vuforia Model Target dataset creation validation error shape, including per-request UUID, details list, and status codes (415 for unsupported media type, 400 with ``BAD_REQUEST`` validation details).
+
+- Match real Vuforia Model Target unknown-dataset response shape (``NOT_FOUND`` code, ``Could not find a model-view database with uuid <uuid>`` message, ``userId:`` target).
+
+- Make synthetic Model Target dataset zip downloads byte-for-byte reproducible.
+
+- Match real Vuforia Model Target Web API error responses for invalid request bodies, invalid dataset creation payloads, unknown datasets, and downloads of still-processing datasets.
+
+- Add configurable ``TargetQuotaReached``, ``ProjectSuspended``, and
+  ``ProjectHasNoAPIAccess`` responses from VWS endpoints.
+
 2026.04.26
 ----------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,21 @@ Changelog
 
 .. towncrier release notes start
 
+2026.08.04.1
+------------
+
+- Replace the PyTorch image-quality stack with OpenCV and a lightweight BRISQUE
+  implementation. This reduces dependency download and installation sizes and
+  removes the need to configure PyTorch's CPU-only package index.
+
+- Match real Vuforia Model Target unknown-dataset response shape (``NOT_FOUND`` code, ``Could not find a model-view database with uuid <uuid>`` message, ``userId:`` target).
+  Keep each Model Target dataset status response internally consistent when processing completes while the response is being generated.
+
+- Add configurable ``TooManyRequests`` responses from VWS endpoints using the
+  ``CloudDatabase.requests_per_second_limit`` setting.
+
+- Add ``CloudQueryFailureResponse`` and the ``MockVWS.cloud_query_failure_response`` parameter for returning configurable Cloud Query failure status codes, headers, and raw bodies through the ``requests`` and ``httpx`` backends.
+
 2026.08.04
 ----------
 

--- a/newsfragments/2114.change
+++ b/newsfragments/2114.change
@@ -1,1 +1,0 @@
-Add a mock implementation of the Model Target Web API, including OAuth2 token creation, standard and advanced dataset creation, status polling, dataset download, and deletion.

--- a/newsfragments/3192.change
+++ b/newsfragments/3192.change
@@ -1,1 +1,0 @@
-Improve Model Target Web API mock authentication failure responses.

--- a/newsfragments/3193.change
+++ b/newsfragments/3193.change
@@ -1,1 +1,0 @@
-Match real Vuforia Model Target dataset creation validation error shape, including per-request UUID, details list, and status codes (415 for unsupported media type, 400 with ``BAD_REQUEST`` validation details).

--- a/newsfragments/3194.change
+++ b/newsfragments/3194.change
@@ -1,2 +1,0 @@
-Match real Vuforia Model Target unknown-dataset response shape (``NOT_FOUND`` code, ``Could not find a model-view database with uuid <uuid>`` message, ``userId:`` target).
-Keep each Model Target dataset status response internally consistent when processing completes while the response is being generated.

--- a/newsfragments/3194.change
+++ b/newsfragments/3194.change
@@ -1,1 +1,0 @@
-Match real Vuforia Model Target unknown-dataset response shape (``NOT_FOUND`` code, ``Could not find a model-view database with uuid <uuid>`` message, ``userId:`` target).

--- a/newsfragments/3195.change
+++ b/newsfragments/3195.change
@@ -1,1 +1,0 @@
-Make synthetic Model Target dataset zip downloads byte-for-byte reproducible.

--- a/newsfragments/3197.change
+++ b/newsfragments/3197.change
@@ -1,1 +1,0 @@
-Match real Vuforia Model Target Web API error responses for invalid request bodies, invalid dataset creation payloads, unknown datasets, and downloads of still-processing datasets.

--- a/newsfragments/3306.change
+++ b/newsfragments/3306.change
@@ -1,2 +1,0 @@
-Add configurable ``TargetQuotaReached``, ``ProjectSuspended``, and
-``ProjectHasNoAPIAccess`` responses from VWS endpoints.

--- a/newsfragments/3308.change
+++ b/newsfragments/3308.change
@@ -1,2 +1,0 @@
-Add configurable ``TooManyRequests`` responses from VWS endpoints using the
-``CloudDatabase.requests_per_second_limit`` setting.

--- a/newsfragments/3314.change
+++ b/newsfragments/3314.change
@@ -1,1 +1,0 @@
-Add ``CloudQueryFailureResponse`` and the ``MockVWS.cloud_query_failure_response`` parameter for returning configurable Cloud Query failure status codes, headers, and raw bodies through the ``requests`` and ``httpx`` backends.

--- a/newsfragments/53.change
+++ b/newsfragments/53.change
@@ -1,2 +1,0 @@
-Cloud databases with ``request_quota=0`` now return a
-``RequestQuotaReached`` response from VWS endpoints.

--- a/newsfragments/opencv-quality.change
+++ b/newsfragments/opencv-quality.change
@@ -1,3 +1,0 @@
-Replace the PyTorch image-quality stack with OpenCV and a lightweight BRISQUE
-implementation. This reduces dependency download and installation sizes and
-removes the need to configure PyTorch's CPU-only package index.


### PR DESCRIPTION
## Summary

- install `uv` before the Towncrier release steps
- carry the generated `2026.08.04` changelog entry back to `main`
- remove the news fragments consumed by the successful release

## Root cause

The newly split release workflow used `uv run` in the release job, but `uv` was only installed in the downstream PyPI job. The first release attempt therefore failed with `uv: command not found` before creating any release state.

## Validation

- `actionlint .github/workflows/release.yml`
- `zizmor --strict-collection .github/workflows/release.yml`
- successful release workflow run: https://github.com/VWS-Python/vws-python-mock/actions/runs/30890802990
