### PR TITLE
Add configurable VWS request rate limits

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -92,7 +92,6 @@ There are some result codes which the mock cannot return.
 These are:
 
 * ``DateRangeError``
-* ``TooManyRequests``
 
 Request quota exhaustion
 ------------------------
@@ -106,7 +105,7 @@ exhausted quota.
 Other configurable result codes
 -------------------------------
 
-The mock also supports three other result codes which have not been verified
+The mock also supports four other result codes which have not been verified
 against real databases in the corresponding states:
 
 * ``TargetQuotaReached`` is returned when adding a target to a
@@ -116,6 +115,11 @@ against real databases in the corresponding states:
   :attr:`mock_vws.states.States.PROJECT_SUSPENDED` state.
 * ``ProjectHasNoAPIAccess`` is returned by VWS endpoints when a database uses
   the :attr:`mock_vws.states.States.PROJECT_HAS_NO_API_ACCESS` state.
+* ``TooManyRequests`` is returned when a
+  :class:`mock_vws.database.CloudDatabase` exceeds its
+  ``requests_per_second_limit``. Set the limit to ``0`` to return this result
+  code for every VWS request. By default, the mock does not apply a per-second
+  request limit.
 
 ``Content-Length`` headers
 --------------------------

--- a/newsfragments/3308.change
+++ b/newsfragments/3308.change
@@ -1,0 +1,2 @@
+Add configurable ``TooManyRequests`` responses from VWS endpoints using the
+``CloudDatabase.requests_per_second_limit`` setting.

--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -162,6 +162,10 @@ def create_cloud_database() -> Response:
     :reqjson int target_quota: (Optional) The target quota. Once this many
       targets exist, adding another returns ``TargetQuotaReached``.
 
+    :reqjson int requests_per_second_limit: (Optional) The maximum number of
+      VWS requests accepted in a rolling one-second window. Set this to zero
+      to make VWS endpoints return ``TooManyRequests``.
+
     :reqjson string server_access_key: (Optional) The server access key for the
       cloud database.
 
@@ -183,6 +187,9 @@ def create_cloud_database() -> Response:
     :resjson int request_quota: The request quota.
 
     :resjson int target_quota: The target quota.
+
+    :resjson int requests_per_second_limit: The per-second request limit, or
+      null when rate limiting is disabled.
 
     :resjson string server_access_key: The server access key for the cloud
       database.
@@ -234,6 +241,10 @@ def create_cloud_database() -> Response:
         "target_quota",
         random_database.target_quota,
     )
+    requests_per_second_limit = request_json.get(
+        "requests_per_second_limit",
+        random_database.requests_per_second_limit,
+    )
 
     state = States[state_name]
     database_type = DatabaseType[database_type_name]
@@ -248,6 +259,7 @@ def create_cloud_database() -> Response:
         database_type=database_type,
         request_quota=request_quota,
         target_quota=target_quota,
+        requests_per_second_limit=requests_per_second_limit,
     )
     try:
         TARGET_MANAGER.add_cloud_database(cloud_database=database)

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -202,6 +202,7 @@ def validate_request() -> None:
         request_method=request.method,
         request_path=request.path,
         databases=get_all_cloud_databases(),
+        request_rate_limiter=TARGET_MANAGER.request_rate_limiter,
     )
 
 
@@ -590,6 +591,7 @@ def generate_vumark_instance(target_id: str) -> Response:
         request_method=request.method,
         request_path=request.path,
         databases=all_databases,
+        request_rate_limiter=TARGET_MANAGER.request_rate_limiter,
     )
 
     database = get_database_matching_server_keys(

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -317,6 +317,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
@@ -392,6 +393,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
@@ -469,6 +471,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=all_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
 
             database = get_database_matching_server_keys(
@@ -530,6 +533,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
@@ -591,6 +595,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
@@ -648,6 +653,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
@@ -717,6 +723,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
@@ -788,6 +795,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
@@ -902,6 +910,7 @@ class MockVuforiaWebServicesAPI:
                 request_method=request.method,
                 request_path=request.path,
                 databases=self._target_manager.cloud_databases,
+                request_rate_limiter=self._target_manager.request_rate_limiter,
             )
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text

--- a/src/mock_vws/_services_validators/__init__.py
+++ b/src/mock_vws/_services_validators/__init__.py
@@ -49,6 +49,10 @@ from .name_validators import (
 )
 from .project_state_validators import validate_project_state
 from .request_quota_validators import validate_request_quota
+from .request_rate_validators import (
+    RequestRateLimiter,
+    validate_request_rate,
+)
 from .target_quota_validators import validate_target_quota
 from .target_validators import validate_target_id_exists
 from .width_validators import validate_width
@@ -62,6 +66,7 @@ def run_services_validators(
     request_body: bytes,
     request_method: str,
     databases: Iterable[AnyDatabase],
+    request_rate_limiter: RequestRateLimiter,
 ) -> None:
     """Run all validators.
 
@@ -71,6 +76,7 @@ def run_services_validators(
         request_body: The body of the request.
         request_method: The HTTP method of the request.
         databases: All Vuforia databases.
+        request_rate_limiter: The rate limiter tracking recent requests.
     """
     validate_auth_header_exists(request_headers=request_headers)
     validate_auth_header_has_signature(request_headers=request_headers)
@@ -91,6 +97,14 @@ def run_services_validators(
         request_method=request_method,
         request_path=request_path,
         databases=databases,
+    )
+    validate_request_rate(
+        request_headers=request_headers,
+        request_body=request_body,
+        request_method=request_method,
+        request_path=request_path,
+        databases=databases,
+        request_rate_limiter=request_rate_limiter,
     )
     validate_project_state(
         request_headers=request_headers,

--- a/src/mock_vws/_services_validators/exceptions.py
+++ b/src/mock_vws/_services_validators/exceptions.py
@@ -146,6 +146,37 @@ class RequestQuotaReachedError(ValidatorError):
 
 
 @beartype
+class TooManyRequestsError(ValidatorError):
+    """Exception raised when a database exceeds its request rate limit."""
+
+    def __init__(self) -> None:
+        """Initialize a ``TooManyRequests`` response."""
+        super().__init__()
+        self.status_code = HTTPStatus.TOO_MANY_REQUESTS
+        body = {
+            "transaction_id": uuid.uuid4().hex,
+            "result_code": ResultCodes.TOO_MANY_REQUESTS.value,
+        }
+        self.response_text = json_dump(body=body)
+        date = email.utils.formatdate(
+            timeval=None,
+            localtime=False,
+            usegmt=True,
+        )
+        self.headers = {
+            "Connection": "keep-alive",
+            "Content-Type": "application/json",
+            "server": "envoy",
+            "Date": date,
+            "x-envoy-upstream-service-time": "5",
+            "Content-Length": str(object=len(self.response_text)),
+            "strict-transport-security": "max-age=31536000",
+            "x-aws-region": "us-east-2, us-west-2",
+            "x-content-type-options": "nosniff",
+        }
+
+
+@beartype
 class TargetQuotaReachedError(ValidatorError):
     """Exception raised when a database's target quota is exhausted."""
 

--- a/src/mock_vws/_services_validators/request_rate_validators.py
+++ b/src/mock_vws/_services_validators/request_rate_validators.py
@@ -1,0 +1,83 @@
+"""Validators for the VWS per-second request rate."""
+
+import threading
+import time
+from collections import deque
+from collections.abc import Callable, Iterable, Mapping
+
+from beartype import beartype
+
+from mock_vws._database_matchers import (
+    AnyDatabase,
+    get_database_matching_server_keys,
+)
+from mock_vws.database import CloudDatabase
+
+from .exceptions import TooManyRequestsError
+
+_WINDOW_SECONDS = 1.0
+
+
+@beartype
+class RequestRateLimiter:
+    """Track request times independently for each cloud database."""
+
+    def __init__(
+        self,
+        *,
+        time_function: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Initialize an empty rate limiter."""
+        self._request_times: dict[str, deque[float]] = {}
+        self._lock = threading.Lock()
+        self._time_function = time_function
+
+    def validate(self, *, database: CloudDatabase) -> None:
+        """Raise an error if the database's request rate is exhausted."""
+        limit = database.requests_per_second_limit
+        if limit is None:
+            return
+
+        with self._lock:
+            now = self._time_function()
+            request_times = self._request_times.setdefault(
+                database.server_access_key,
+                deque(),
+            )
+            window_start = now - _WINDOW_SECONDS
+            while request_times and request_times[0] <= window_start:
+                request_times.popleft()
+
+            if len(request_times) >= limit:
+                raise TooManyRequestsError
+
+            request_times.append(now)
+
+    def remove_database(self, *, database: CloudDatabase) -> None:
+        """Discard request history for a removed database."""
+        with self._lock:
+            self._request_times.pop(database.server_access_key, None)
+
+
+@beartype
+def validate_request_rate(
+    *,
+    request_headers: Mapping[str, str],
+    request_body: bytes,
+    request_method: str,
+    request_path: str,
+    databases: Iterable[AnyDatabase],
+    request_rate_limiter: RequestRateLimiter,
+) -> None:
+    """Apply the configured request rate to the matching cloud
+    database.
+    """
+    database = get_database_matching_server_keys(
+        request_headers=request_headers,
+        request_body=request_body,
+        request_method=request_method,
+        request_path=request_path,
+        databases=databases,
+    )
+    if isinstance(database, CloudDatabase):
+        request_rate_limiter.validate(database=database)

--- a/src/mock_vws/database.py
+++ b/src/mock_vws/database.py
@@ -32,6 +32,7 @@ class CloudDatabaseDict(TypedDict):
     targets: Iterable[ImageTargetDict]
     request_quota: NotRequired[int]
     target_quota: NotRequired[int]
+    requests_per_second_limit: NotRequired[int | None]
 
 
 @beartype
@@ -72,6 +73,10 @@ class CloudDatabase:
             endpoints return ``RequestQuotaReached``.
         target_quota: The target quota. When the database contains this many
             targets, adding another returns ``TargetQuotaReached``.
+        requests_per_second_limit: The maximum number of VWS requests accepted
+            in a rolling one-second window. Set this to ``0`` to make VWS
+            endpoints return ``TooManyRequests``. By default, the mock does
+            not apply a per-second request limit.
     """
 
     # We hide a few things in the ``repr`` with ``repr=False`` so that they do
@@ -98,6 +103,7 @@ class CloudDatabase:
     previous_month_recos: int = 0
     total_recos: int = 0
     target_quota: int = 1000
+    requests_per_second_limit: int | None = None
 
     def to_dict(self) -> CloudDatabaseDict:
         """Dump a target to a dictionary which can be loaded as JSON."""
@@ -115,6 +121,7 @@ class CloudDatabase:
             "targets": targets,
             "request_quota": self.request_quota,
             "target_quota": self.target_quota,
+            "requests_per_second_limit": self.requests_per_second_limit,
         }
 
     def get_target(self, target_id: str) -> ImageTarget:
@@ -143,6 +150,9 @@ class CloudDatabase:
             targets=targets,
             request_quota=database_dict.get("request_quota", 100000),
             target_quota=database_dict.get("target_quota", 1000),
+            requests_per_second_limit=database_dict.get(
+                "requests_per_second_limit"
+            ),
         )
 
     @property

--- a/src/mock_vws/target_manager.py
+++ b/src/mock_vws/target_manager.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING
 
 from beartype import beartype
 
+from mock_vws._services_validators.request_rate_validators import (
+    RequestRateLimiter,
+)
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.model_target import ModelTargetDataset
 
@@ -24,6 +27,12 @@ class TargetManager:
         self._cloud_databases: set[CloudDatabase] = set()
         self._vumark_databases: set[VuMarkDatabase] = set()
         self._model_target_datasets: dict[str, ModelTargetDataset] = {}
+        self._request_rate_limiter = RequestRateLimiter()
+
+    @property
+    def request_rate_limiter(self) -> RequestRateLimiter:
+        """The rate limiter for databases in this target manager."""
+        return self._request_rate_limiter
 
     @property
     def cloud_databases(self) -> set[CloudDatabase]:
@@ -52,6 +61,7 @@ class TargetManager:
         self._cloud_databases = {
             db for db in self._cloud_databases if db != cloud_database
         }
+        self._request_rate_limiter.remove_database(database=cloud_database)
 
     def remove_vumark_database(self, vumark_database: VuMarkDatabase) -> None:
         """Remove a VuMark database.

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -18,6 +18,7 @@ from vws import VWS, CloudRecoService
 from vws.exceptions.vws_exceptions import (
     RequestQuotaReachedError,
     TargetQuotaReachedError,
+    TooManyRequestsError,
 )
 from vws_auth_tools import authorization_header, rfc_1123_date
 
@@ -193,6 +194,25 @@ class TestRequestQuota:
                 application_metadata=None,
                 active_flag=True,
             )
+
+    @staticmethod
+    def test_too_many_requests() -> None:
+        """The Flask mock preserves and enforces a zero request rate limit."""
+        database = CloudDatabase(requests_per_second_limit=0)
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
+        response = requests.post(
+            url=databases_url,
+            json=database.to_dict(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with pytest.raises(expected_exception=TooManyRequestsError):
+            client.list_targets()
 
 
 class TestAddCloudDatabase:

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -22,11 +22,18 @@ from vws.exceptions.vws_exceptions import (
     ProjectSuspendedError,
     RequestQuotaReachedError,
     TargetQuotaReachedError,
+    TooManyRequestsError,
 )
 from vws_auth_tools import authorization_header, rfc_1123_date
 
 from mock_vws import MissingSchemeError, MockVWS
 from mock_vws._constants import ResultCodes
+from mock_vws._services_validators.exceptions import (
+    TooManyRequestsError as TooManyRequestsValidatorError,
+)
+from mock_vws._services_validators.request_rate_validators import (
+    RequestRateLimiter,
+)
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.image_matchers import ExactMatcher, StructuralSimilarityMatcher
 from mock_vws.states import States
@@ -376,6 +383,46 @@ class TestRequestQuota:
             status_code=HTTPStatus.FORBIDDEN,
             result_code=ResultCodes.REQUEST_QUOTA_REACHED,
         )
+
+
+class TestRequestRateLimit:
+    """Tests for configurable per-second VWS request limits."""
+
+    @staticmethod
+    def test_zero_limit() -> None:
+        """A zero request rate limit rejects every VWS request."""
+        database = CloudDatabase(requests_per_second_limit=0)
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with MockVWS() as mock:
+            mock.add_cloud_database(cloud_database=database)
+            with pytest.raises(
+                expected_exception=TooManyRequestsError,
+            ) as exc_info:
+                client.list_targets()
+
+        assert_vws_failure(
+            response=exc_info.value.response,
+            status_code=HTTPStatus.TOO_MANY_REQUESTS,
+            result_code=ResultCodes.TOO_MANY_REQUESTS,
+        )
+
+    @staticmethod
+    def test_rolling_window() -> None:
+        """Requests are accepted again after the rolling window passes."""
+        request_times = iter([10.0, 10.5, 11.0])
+        rate_limiter = RequestRateLimiter(
+            time_function=request_times.__next__,
+        )
+        database = CloudDatabase(requests_per_second_limit=1)
+
+        rate_limiter.validate(database=database)
+        with pytest.raises(expected_exception=TooManyRequestsValidatorError):
+            rate_limiter.validate(database=database)
+        rate_limiter.validate(database=database)
 
 
 class TestAdditionalResultCodes:
@@ -744,6 +791,23 @@ class TestDatabaseToDict:
         new_database = CloudDatabase.from_dict(database_dict=database_dict)
 
         assert new_database.target_quota == 0
+
+    @staticmethod
+    def test_custom_requests_per_second_limit() -> None:
+        """The per-second request limit survives a dictionary round
+        trip.
+        """
+        requests_per_second_limit = 12
+        database = CloudDatabase(
+            requests_per_second_limit=requests_per_second_limit
+        )
+
+        database_dict = database.to_dict()
+        new_database = CloudDatabase.from_dict(database_dict=database_dict)
+
+        assert (
+            new_database.requests_per_second_limit == requests_per_second_limit
+        )
 
     @staticmethod
     def test_vumark_database_to_dict() -> None:


### PR DESCRIPTION
Adds configurable per-database rolling one-second VWS request limits, including a deterministic zero limit for testing TooManyRequests handling. Rate-limited requests now return HTTP 429 with the documented result code across both the in-process and Flask mock backends. Database serialization, public documentation, tests, and a news fragment cover the new setting. Validation includes 73 local tests, the full pre-commit and pre-push suites, all configured type checkers, and a warnings-as-errors Sphinx build.