### PR TITLE
Validate Model Target JWT headers

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -138,7 +138,9 @@ Model Target datasets
 
 The Model Target Web API mock supports OAuth2 token requests, standard and advanced dataset creation, status polling, dataset downloads, and deletion.
 The generated dataset download is a small valid zip file containing request metadata, not a real Vuforia Engine Model Target dataset.
-Model Target API routes require a syntactically JSON Web Token-shaped bearer token, such as the token returned by the mock OAuth2 route.
+Model Target API routes require a three-part JSON Web Token with a JSON object
+header and a non-``none`` ``alg`` value, such as the token returned by the mock
+OAuth2 route.
 The mock does not verify token signatures, claims, expiry, or revocation.
 
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.

--- a/newsfragments/3192.change
+++ b/newsfragments/3192.change
@@ -1,1 +1,2 @@
-Improve Model Target Web API mock authentication failure responses.
+Improve Model Target Web API mock authentication failure responses, including
+malformed and unsecured JSON Web Token headers.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -128,6 +128,30 @@ def _basic_auth_credentials(auth_header: str | None) -> tuple[str, str] | None:
 
 
 @beartype
+def _jwt_header_error(*, bearer_token: str) -> str | None:
+    """Return the Vuforia error for an invalid JSON Web Token header."""
+    encoded_header = bearer_token.partition(".")[0]
+    try:
+        padding = "=" * (-len(encoded_header) % 4)
+        decoded_header = base64.b64decode(
+            s=encoded_header + padding,
+            altchars=b"-_",
+            validate=True,
+        )
+        header = json.loads(s=decoded_header)
+    except ValueError:
+        header = None
+
+    if not isinstance(header, dict):
+        return "Invalid unsecured/JWS/JWE header: Invalid JSON object"
+    if "alg" not in header:
+        return 'Missing "alg" in header JSON object'
+    if header["alg"] == "none":
+        return "Unsecured (plain) JWTs are rejected, extend class to handle"
+    return None
+
+
+@beartype
 def _require_bearer_token(request: RequestData) -> _ResponseType | None:
     """Return an error response if the request has no bearer token."""
     auth_header = _get_header(request=request, name="Authorization")
@@ -153,6 +177,15 @@ def _require_bearer_token(request: RequestData) -> _ResponseType | None:
             status_code=HTTPStatus.UNAUTHORIZED,
             code="401",
             message="Invalid JWT serialization: Missing dot delimiter(s)",
+            target="jwt",
+            details=None,
+        )
+    jwt_header_error = _jwt_header_error(bearer_token=bearer_token)
+    if jwt_header_error is not None:
+        return _error_response(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            code="401",
+            message=jwt_header_error,
             target="jwt",
             details=None,
         )

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -19,7 +19,7 @@ from tests.mock_vws.fixtures.vuforia_backends import VuforiaBackend
 
 _VWS_HOST = "https://vws.vuforia.com"
 _DATASET_UUID = "0b12466eee5d49409a440927006ff5d8"
-_MOCK_BEARER_TOKEN = "mock.header.signature"
+_MOCK_BEARER_TOKEN = "eyJhbGciOiJtb2NrIn0.e30.signature"
 
 
 def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
@@ -237,6 +237,24 @@ class TestAuthentication:
                 "Bearer invalid-token",
                 "Invalid JWT serialization: Missing dot delimiter(s)",
                 id="malformed",
+            ),
+            pytest.param(
+                "Bearer ..",
+                "Invalid unsecured/JWS/JWE header: Invalid JSON object",
+                id="invalid-header-json",
+            ),
+            pytest.param(
+                "Bearer e30.e30.signature",
+                'Missing "alg" in header JSON object',
+                id="missing-algorithm",
+            ),
+            pytest.param(
+                "Bearer eyJhbGciOiJub25lIn0.e30.",
+                (
+                    "Unsecured (plain) JWTs are rejected, extend class to "
+                    "handle"
+                ),
+                id="unsecured",
             ),
         ],
     )

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -44,6 +44,7 @@ from tests.mock_vws.utils.usage_test_helpers import (
     processing_time_seconds,
 )
 
+_MODEL_TARGET_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
 _MODEL_TARGET_DATASET_REQUEST = {
     "name": "dataset-name",
     "targetSdk": "10.18",
@@ -1347,7 +1348,7 @@ class TestModelTargetWebAPI:
         with MockVWS(processing_time_seconds=0):
             response = requests.post(
                 url="https://vws.vuforia.com/modeltargets/advancedDatasets",
-                headers={"Authorization": "Bearer mock.header.signature"},
+                headers={"Authorization": _MODEL_TARGET_AUTHORIZATION},
                 json=_MODEL_TARGET_DATASET_REQUEST,
                 timeout=30,
             )
@@ -1357,7 +1358,7 @@ class TestModelTargetWebAPI:
                     "https://vws.vuforia.com/modeltargets/"
                     f"advancedDatasets/{dataset_uuid}/status"
                 ),
-                headers={"Authorization": "Bearer mock.header.signature"},
+                headers={"Authorization": _MODEL_TARGET_AUTHORIZATION},
                 timeout=30,
             )
 
@@ -1367,7 +1368,7 @@ class TestModelTargetWebAPI:
     @staticmethod
     def test_dataset_download_is_reproducible() -> None:
         """Downloading the same dataset produces identical bytes."""
-        headers = {"Authorization": "Bearer mock.header.signature"}
+        headers = {"Authorization": _MODEL_TARGET_AUTHORIZATION}
         with MockVWS(processing_time_seconds=0):
             with freeze_time(time_to_freeze="2026-01-01"):
                 create_response = requests.post(

--- a/tests/mock_vws/test_respx_mock_usage.py
+++ b/tests/mock_vws/test_respx_mock_usage.py
@@ -19,6 +19,7 @@ from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.image_matchers import ExactMatcher
 from mock_vws.target import VuMarkTarget
 
+_MODEL_TARGET_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
 _MODEL_TARGET_DATASET_REQUEST = {
     "name": "dataset-name",
     "targetSdk": "10.18",
@@ -191,7 +192,7 @@ class TestModelTargetWebAPI:
         with MockVWS(processing_time_seconds=0):
             create_response = httpx.post(
                 url="https://vws.vuforia.com/modeltargets/datasets",
-                headers={"Authorization": "Bearer mock.header.signature"},
+                headers={"Authorization": _MODEL_TARGET_AUTHORIZATION},
                 json=_MODEL_TARGET_DATASET_REQUEST,
                 timeout=30,
             )
@@ -201,7 +202,7 @@ class TestModelTargetWebAPI:
                     "https://vws.vuforia.com/modeltargets/datasets/"
                     f"{dataset_uuid}/status"
                 ),
-                headers={"Authorization": "Bearer mock.header.signature"},
+                headers={"Authorization": _MODEL_TARGET_AUTHORIZATION},
                 timeout=30,
             )
 


### PR DESCRIPTION
## Summary

- validate the base64url-encoded JSON header of Model Target bearer tokens
- match real Vuforia responses for malformed headers, missing `alg`, and unsecured `alg: none` tokens
- update mock usage examples and document the remaining signature and claims validation limitations

## Why

The mock previously accepted any three-part bearer token, including `Bearer ..`. Real Vuforia rejects malformed or unsecured JWT headers before routing the request. This caused authentication behavior to diverge and allowed invalid tokens to reach dataset operations in tests.

## Impact

Model Target routes now reject these malformed tokens with the same 401 response bodies observed from real Vuforia. Tokens returned by the mock OAuth2 endpoint continue to work. The mock still intentionally does not verify signatures, claims, expiry, or revocation.

## Validation

- verified-fake bearer-token tests against real Vuforia and both mock backends (15 passed)
- Model Target test module with real-service tests skipped (58 passed, 27 skipped)
- requests-mock and respx Model Target usage tests (5 passed)
- Sphinx documentation build with warnings as errors
- all pre-commit and pre-push checks

Progresses #3192.
