### PR TITLE
Replace PyTorch image metrics with OpenCV

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,29 +6,3 @@ Installation
    $ pip install vws-python-mock
 
 This requires Python |minimum-python-version|\+.
-
-Faster installation
-~~~~~~~~~~~~~~~~~~~
-
-This package depends on `PyTorch`_, which pip installs from PyPI as a large CUDA-enabled build (~873 MB) even on CPU-only machines.
-To get a much smaller CPU-only build (~200 MB, no CUDA dependencies), install ``torch`` and ``torchvision`` from PyTorch's CPU index before installing this package:
-
-.. code-block:: console
-
-   $ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-   $ pip install vws-python-mock
-
-If you manage dependencies with ``uv``, add the following to your ``pyproject.toml`` instead:
-
-.. code-block:: toml
-
-   [[tool.uv.index]]
-   name = "pytorch-cpu"
-   url = "https://download.pytorch.org/whl/cpu"
-   explicit = true
-
-   [tool.uv.sources]
-   torch = { index = "pytorch-cpu" }
-   torchvision = { index = "pytorch-cpu" }
-
-.. _PyTorch: https://pytorch.org

--- a/newsfragments/opencv-quality.change
+++ b/newsfragments/opencv-quality.change
@@ -1,0 +1,1 @@
+Replace the PyTorch image-quality stack with OpenCV and a lightweight BRISQUE implementation.

--- a/newsfragments/opencv-quality.change
+++ b/newsfragments/opencv-quality.change
@@ -1,1 +1,3 @@
-Replace the PyTorch image-quality stack with OpenCV and a lightweight BRISQUE implementation.
+Replace the PyTorch image-quality stack with OpenCV and a lightweight BRISQUE
+implementation. This reduces dependency download and installation sizes and
+removes the need to configure PyTorch's CPU-only package index.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,16 +37,14 @@ dependencies = [
     "beartype>=0.22.9",
     "flask>=3.0.3",
     "httpx>=0.27.0",
-    "numpy>=1.26.4",
-    "pillow>=11.0.0",
-    "piq>=0.8.0",
+    "numpy>=2.4.4",
+    "opencv-contrib-python-headless>=5.0.0.93",
+    "pillow>=12.2.0",
     "pydantic-settings>=2.6.1",
+    "pyteenybrisque>=0.1.1",
     "requests>=2.32.3",
     "responses>=0.25.3",
     "respx>=0.21.0",
-    "torch>=2.5.1",
-    "torchmetrics>=1.5.1",
-    "torchvision>=0.20.1",
     "tzdata; sys_platform=='win32'",
     "vws-auth-tools>=2024.7.12",
     "werkzeug>=3.1.2",
@@ -144,11 +142,6 @@ version_scheme = "post-release"
 #
 # This must be a PEP 440 compliant version.
 fallback_version = "0.0.0"
-
-[tool.uv]
-sources.torch = { index = "pytorch-cpu" }
-sources.torchvision = { index = "pytorch-cpu" }
-index = [ { name = "pytorch-cpu", url = "https://download.pytorch.org/whl/cpu", explicit = true } ]
 
 [tool.ruff]
 line-length = 79
@@ -352,9 +345,6 @@ per_rule_ignores.DEP002 = [
     # tzdata is needed on Windows for zoneinfo to work.
     # See https://docs.python.org/3/library/zoneinfo.html#data-sources.
     "tzdata",
-    # torchvision is used transitively via piq, but must be a direct dependency
-    # so that tool.uv.sources can route it to the CPU-only PyTorch index.
-    "torchvision",
 ]
 optional_dependencies_dev_groups = [
     "dev",

--- a/src/mock_vws/image_matchers.py
+++ b/src/mock_vws/image_matchers.py
@@ -1,15 +1,13 @@
 """Matchers for query and duplicate requests."""
 
 import io
+import statistics
 from typing import Protocol, runtime_checkable
 
+import cv2
 import numpy as np
-import torch
 from beartype import beartype
 from PIL import Image
-from torchmetrics.image import (
-    StructuralSimilarityIndexMeasure,
-)
 
 
 @runtime_checkable
@@ -77,48 +75,19 @@ class StructuralSimilarityMatcher:
             # Images must be the same size, and they must be larger than the
             # default SSIM window size of 11x11.
             target_size = (256, 256)
-            first_image_resized = first_image.resize(size=target_size)
-            second_image_resized = second_image.resize(size=target_size)
+            first_image_array = np.asarray(
+                a=first_image.resize(size=target_size).convert(mode="RGB"),
+            )
+            second_image_array = np.asarray(
+                a=second_image.resize(size=target_size).convert(mode="RGB"),
+            )
 
-        first_image_np = np.array(object=first_image_resized, dtype=np.float32)
-        first_image_tensor = torch.tensor(data=first_image_np).float() / 255
-        first_image_tensor = first_image_tensor.view(
-            first_image_resized.size[1],
-            first_image_resized.size[0],
-            len(first_image_resized.getbands()),
+        quality_ssim = cv2.quality.QualitySSIM.create(
+            ref=first_image_array,
         )
+        channel_scores = quality_ssim.compute(cmp=second_image_array)
+        ssim_score = statistics.fmean(data=channel_scores[:3])
 
-        second_image_np = np.array(
-            object=second_image_resized,
-            dtype=np.float32,
-        )
-        second_image_tensor = torch.tensor(data=second_image_np).float() / 255
-        second_image_tensor = second_image_tensor.view(
-            second_image_resized.size[1],
-            second_image_resized.size[0],
-            len(second_image_resized.getbands()),
-        )
-
-        first_image_tensor_batch_dimension = first_image_tensor.permute(
-            2,
-            0,
-            1,
-        ).unsqueeze(dim=0)
-        second_image_tensor_batch_dimension = second_image_tensor.permute(
-            2,
-            0,
-            1,
-        ).unsqueeze(dim=0)
-
-        ssim = StructuralSimilarityIndexMeasure(data_range=1.0)
-        ssim_value = ssim(
-            first_image_tensor_batch_dimension,
-            second_image_tensor_batch_dimension,
-        )
-        ssim_score = ssim_value.item()
-
-        # Normalize SSIM score from -1 to 1 scale to 0 to 10 scale.
-        # This maps -1 to 0 and 1 to 10.
-        normalized_score = (ssim_score + 1) * 5
-        minimum_acceptable_ssim_score = 7
-        return bool(normalized_score > minimum_acceptable_ssim_score)
+        # The old normalized > 7 threshold is equivalent to a raw SSIM > 0.4.
+        minimum_acceptable_ssim_score = 0.4
+        return ssim_score > minimum_acceptable_ssim_score

--- a/src/mock_vws/target_raters.py
+++ b/src/mock_vws/target_raters.py
@@ -26,7 +26,7 @@ def _get_brisque_target_tracking_rating(*, image_content: bytes) -> int:
     """
     image_file = io.BytesIO(initial_bytes=image_content)
     with Image.open(fp=image_file) as image, warnings.catch_warnings():
-        # Uniform images produce a zero-variance warning and a NaN score.
+        # Uniform images produce a zero-variance warning and non-finite score.
         warnings.simplefilter(action="ignore", category=RuntimeWarning)
         brisque_score = score(image=image)
 

--- a/src/mock_vws/target_raters.py
+++ b/src/mock_vws/target_raters.py
@@ -4,13 +4,12 @@ import functools
 import io
 import math
 import secrets
+import warnings
 from typing import Protocol, runtime_checkable
 
-import numpy as np
-import torch
 from beartype import beartype
 from PIL import Image
-from piq.brisque import brisque  # pyright: ignore[reportMissingTypeStubs]
+from pyteenybrisque import score
 
 
 @functools.cache
@@ -26,20 +25,18 @@ def _get_brisque_target_tracking_rating(*, image_content: bytes) -> int:
         image_content: A target's image's content.
     """
     image_file = io.BytesIO(initial_bytes=image_content)
-    with Image.open(fp=image_file) as image:
-        image_np = np.array(object=image, dtype=np.float32)
-        image_tensor = torch.tensor(data=image_np).float() / 255
-        image_tensor = image_tensor.view(
-            image.size[1],
-            image.size[0],
-            len(image.getbands()),
-        )
-    image_tensor = image_tensor.permute(2, 0, 1).unsqueeze(dim=0)
-    try:
-        brisque_score = brisque(x=image_tensor, data_range=255)
-    except AssertionError, IndexError:
+    with Image.open(fp=image_file) as image, warnings.catch_warnings():
+        # Uniform images produce a zero-variance warning and a NaN score.
+        warnings.simplefilter(action="ignore", category=RuntimeWarning)
+        brisque_score = score(image=image)
+
+    if not math.isfinite(brisque_score):
         return 0
-    return math.ceil(int(brisque_score.item()) / 20)
+
+    # BRISQUE ranges from 0 (best) to 100 (worst), while Vuforia's target
+    # tracking rating ranges from 0 (worst) to 5 (best).
+    rating = 5 - math.floor(brisque_score / 20)
+    return min(5, max(0, rating))
 
 
 @runtime_checkable


### PR DESCRIPTION
## What

- calculate structural similarity with `opencv-contrib-python-headless`
- use a small typed BRISQUE implementation and map its lower-is-better score to Vuforia's 0–5 rating
- remove PIQ, PyTorch, TorchMetrics, TorchVision, and the custom PyTorch CPU package index
- raise the NumPy and Pillow minimums required by the replacement stack

## Why

The existing image-quality implementation pulled in a large machine-learning stack for two classical image metrics. OpenCV provides SSIM directly, while `pyteenybrisque` provides the remaining BRISQUE model without bringing PyTorch back into the dependency graph.

The SSIM matcher retains the existing effective raw threshold of 0.4. Uniform images that produce a non-finite BRISQUE score retain a rating of 0.

## Validation

- focused matcher/rater tests: 26 passed
- CI-style skip suite: 110 passed, 1303 skipped
- full pre-commit and pre-push hook suites
- mypy, Pyright, ty, Pyrefly, and Pyright verify-types
- package build, wheel-content check, manifest check, and Towncrier draft
