### PR TITLE
Support configurable Cloud Query failure responses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
           - tests/mock_vws/test_authorization_header.py::TestMalformed::test_one_part_with_space
           - tests/mock_vws/test_authorization_header.py::TestMalformed::test_missing_signature
           - tests/mock_vws/test_authorization_header.py::TestBadKey
+          - tests/mock_vws/test_cloud_query_failure_response.py
           - tests/mock_vws/test_content_length.py::TestIncorrect::test_not_integer
           - tests/mock_vws/test_content_length.py::TestIncorrect::test_too_large
           - tests/mock_vws/test_content_length.py::TestIncorrect::test_too_small

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -102,6 +102,31 @@ The mock returns ``RequestQuotaReached`` when a
 but the response has not been verified against a real database with an
 exhausted quota.
 
+Configurable Cloud Query failures
+---------------------------------
+
+The Vuforia Cloud Query API documents failure responses with JSON, arbitrary
+content, or no body. Use
+:paramref:`mock_vws.MockVWS.cloud_query_failure_response` to make every Cloud
+Query request return a particular documented failure shape through the
+in-process ``requests`` and ``httpx`` backends::
+
+    from mock_vws import CloudQueryFailureResponse, MockVWS
+
+    failure = CloudQueryFailureResponse(
+        status_code=503,
+        headers={"Content-Type": "text/plain", "Retry-After": "10"},
+        body=b"Temporarily unavailable",
+    )
+
+    with MockVWS(cloud_query_failure_response=failure):
+        # Cloud Query calls return the configured response.
+        ...
+
+The configured response bypasses normal Cloud Query validation and image
+matching. Omitting it preserves the normal successful-query behavior. This
+configuration is not supported by the Flask/Docker backend.
+
 Other configurable result codes
 -------------------------------
 

--- a/docs/source/mock-api-reference.rst
+++ b/docs/source/mock-api-reference.rst
@@ -11,6 +11,10 @@ API Reference
    :members:
    :undoc-members:
 
+.. autoclass:: mock_vws.CloudQueryFailureResponse(*, status_code, headers={}, body=b'')
+   :members:
+   :undoc-members:
+
 .. Many parts of the CloudDatabase API are used for the Flask target
 .. database app, but Python users are not expected to use them.
 .. Therefore, they are not documented.

--- a/newsfragments/3314.change
+++ b/newsfragments/3314.change
@@ -1,0 +1,1 @@
+Add ``CloudQueryFailureResponse`` and the ``MockVWS.cloud_query_failure_response`` parameter for returning configurable Cloud Query failure status codes, headers, and raw bodies through the ``requests`` and ``httpx`` backends.

--- a/src/mock_vws/__init__.py
+++ b/src/mock_vws/__init__.py
@@ -2,8 +2,10 @@
 
 from mock_vws._mock_common import MissingSchemeError
 from mock_vws._requests_mock_server.decorators import MockVWS
+from mock_vws.cloud_query import CloudQueryFailureResponse
 
 __all__ = [
+    "CloudQueryFailureResponse",
     "MissingSchemeError",
     "MockVWS",
 ]

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -14,6 +14,7 @@ from responses import RequestsMock
 
 from mock_vws._mock_common import MissingSchemeError, RequestData
 from mock_vws._respx_mock_server.decorators import start_respx_router
+from mock_vws.cloud_query import CloudQueryFailureResponse
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.image_matchers import (
     ImageMatcher,
@@ -51,6 +52,7 @@ class MockVWS(ContextDecorator):
         *,
         base_vws_url: str = "https://vws.vuforia.com",
         base_vwq_url: str = "https://cloudreco.vuforia.com",
+        cloud_query_failure_response: CloudQueryFailureResponse | None = None,
         duplicate_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
         query_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
         processing_time_seconds: float = 2.0,
@@ -74,6 +76,10 @@ class MockVWS(ContextDecorator):
                 In the real Vuforia Web Services, this is not deterministic.
             base_vwq_url: The base URL for the VWQ API.
             base_vws_url: The base URL for the VWS API.
+            cloud_query_failure_response: A response to return for every Cloud
+                Query request, bypassing normal request validation and image
+                matching. By default, Cloud Query requests are handled
+                normally.
             query_match_checker: A callable which takes two image values and
                 returns whether they will match in a query request.
             duplicate_match_checker: A callable which takes two image values
@@ -114,6 +120,7 @@ class MockVWS(ContextDecorator):
         self._mock_vwq_api = MockVuforiaWebQueryAPI(
             target_manager=self._target_manager,
             query_match_checker=query_match_checker,
+            failure_response=cloud_query_failure_response,
         )
 
     def add_cloud_database(self, cloud_database: CloudDatabase) -> None:

--- a/src/mock_vws/_requests_mock_server/mock_web_query_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_query_api.py
@@ -19,12 +19,13 @@ from mock_vws._query_validators import run_query_validators
 from mock_vws._query_validators.exceptions import (
     ValidatorError,
 )
+from mock_vws.cloud_query import CloudQueryFailureResponse
 from mock_vws.image_matchers import ImageMatcher
 from mock_vws.target_manager import TargetManager
 
 _ROUTES: set[Route] = set()
 
-_ResponseType = tuple[int, Mapping[str, str], str]
+_ResponseType = tuple[int, Mapping[str, str], str | bytes]
 _P = ParamSpec("_P")
 
 
@@ -86,13 +87,16 @@ class MockVuforiaWebQueryAPI:
         self,
         target_manager: TargetManager,
         query_match_checker: ImageMatcher,
+        failure_response: CloudQueryFailureResponse | None,
     ) -> None:
         """
         Args:
             target_manager: The target manager which holds all databases.
             query_match_checker: A callable which takes two image values
-        and
+                and
                 returns whether they match.
+            failure_response: A configured failure response which takes
+                precedence over normal query handling.
 
         Attributes:
             routes: The `Route`s to be used in the mock.
@@ -100,10 +104,18 @@ class MockVuforiaWebQueryAPI:
         self.routes = _ROUTES
         self._target_manager = target_manager
         self._query_match_checker = query_match_checker
+        self._failure_response = failure_response
 
     @route(path_pattern="/v1/query", http_methods={HTTPMethod.POST})
     def query(self, request: RequestData) -> _ResponseType:
         """Perform an image recognition query."""
+        if self._failure_response is not None:
+            return (
+                self._failure_response.status_code,
+                self._failure_response.headers,
+                self._failure_response.body,
+            )
+
         try:
             run_query_validators(
                 request_path=request.path,

--- a/src/mock_vws/cloud_query.py
+++ b/src/mock_vws/cloud_query.py
@@ -1,0 +1,22 @@
+"""Public configuration types for the Vuforia Cloud Query API."""
+
+from dataclasses import dataclass, field
+
+from beartype import beartype
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class CloudQueryFailureResponse:
+    """A failure response returned by the Cloud Query API mock.
+
+    Args:
+        status_code: The HTTP status code to return.
+        headers: The HTTP response headers to return.
+        body: The raw response body. String bodies are encoded as UTF-8 by
+            the HTTP backend; byte bodies are returned unchanged.
+    """
+
+    status_code: int
+    headers: dict[str, str] = field(default_factory=dict[str, str])
+    body: str | bytes = b""

--- a/tests/mock_vws/test_cloud_query_failure_response.py
+++ b/tests/mock_vws/test_cloud_query_failure_response.py
@@ -1,0 +1,132 @@
+"""Tests for configurable Cloud Query failure responses."""
+
+import io
+from collections.abc import Callable
+from http import HTTPMethod, HTTPStatus
+
+import httpx
+import pytest
+import requests
+from urllib3.filepost import encode_multipart_formdata
+from vws_auth_tools import authorization_header, rfc_1123_date
+
+from mock_vws import CloudQueryFailureResponse, MockVWS
+from mock_vws.database import CloudDatabase
+
+_QUERY_URL = "https://cloudreco.vuforia.com/v1/query"
+type _HTTPResponse = requests.Response | httpx.Response
+type _QuerySender = Callable[[dict[str, str], bytes], _HTTPResponse]
+
+
+def _requests_query(headers: dict[str, str], body: bytes) -> _HTTPResponse:
+    """Send a Cloud Query request with ``requests``."""
+    return requests.post(
+        url=_QUERY_URL,
+        headers=headers,
+        data=body,
+        timeout=30,
+    )
+
+
+def _httpx_query(headers: dict[str, str], body: bytes) -> _HTTPResponse:
+    """Send a Cloud Query request with ``httpx``."""
+    return httpx.post(
+        url=_QUERY_URL,
+        headers=headers,
+        content=body,
+        timeout=30,
+    )
+
+
+def _valid_query(
+    *,
+    database: CloudDatabase,
+    image: io.BytesIO,
+) -> tuple[dict[str, str], bytes]:
+    """Build an otherwise-valid, signed Cloud Query request."""
+    request_path = "/v1/query"
+    body, content_type = encode_multipart_formdata(
+        fields={
+            "image": ("image.jpeg", image.getvalue(), "image/jpeg"),
+        }
+    )
+    date = rfc_1123_date()
+    authorization = authorization_header(
+        access_key=database.client_access_key,
+        secret_key=database.client_secret_key,
+        method=HTTPMethod.POST,
+        content=body,
+        content_type="multipart/form-data",
+        date=date,
+        request_path=request_path,
+    )
+    headers = {
+        "Authorization": authorization,
+        "Content-Type": content_type,
+        "Date": date,
+    }
+    return headers, body
+
+
+@pytest.mark.parametrize(
+    argnames="send_query",
+    argvalues=[_requests_query, _httpx_query],
+    ids=["requests", "httpx"],
+)
+@pytest.mark.parametrize(
+    argnames=("status_code", "headers", "body", "expected_body"),
+    argvalues=[
+        (
+            HTTPStatus.BAD_REQUEST,
+            {"Content-Length": "0", "X-Query-Failure": "empty"},
+            b"",
+            b"",
+        ),
+        (
+            HTTPStatus.TOO_MANY_REQUESTS,
+            {
+                "Content-Type": "text/plain; charset=utf-8",
+                "Retry-After": "10",
+                "X-Query-Failure": "text",
+            },
+            "Temporarily unavailable — retry later",
+            "Temporarily unavailable — retry later".encode(),
+        ),
+        (
+            HTTPStatus.SERVICE_UNAVAILABLE,
+            {"Content-Type": "application/octet-stream"},
+            b"\xffupstream failure",
+            b"\xffupstream failure",
+        ),
+    ],
+    ids=["empty-4xx", "text-4xx", "raw-5xx"],
+)
+def test_configured_failure_response(
+    *,
+    high_quality_image: io.BytesIO,
+    send_query: _QuerySender,
+    status_code: HTTPStatus,
+    headers: dict[str, str],
+    body: str | bytes,
+    expected_body: bytes,
+) -> None:
+    """Both in-process backends preserve the configured response."""
+    database = CloudDatabase()
+    query_headers, query_body = _valid_query(
+        database=database,
+        image=high_quality_image,
+    )
+    failure = CloudQueryFailureResponse(
+        status_code=status_code,
+        headers=headers,
+        body=body,
+    )
+
+    with MockVWS(cloud_query_failure_response=failure) as mock:
+        mock.add_cloud_database(cloud_database=database)
+        response = send_query(query_headers, query_body)
+
+    assert response.status_code == status_code
+    assert response.content == expected_body
+    for name, value in headers.items():
+        assert response.headers[name] == value


### PR DESCRIPTION
Closes #3314 by adding a public `CloudQueryFailureResponse` and `MockVWS.cloud_query_failure_response` override so valid Cloud Query requests can exercise documented 4xx and 5xx response shapes through both `requests` and `httpx`.

The configured response preserves exact status, headers, UTF-8 text, empty bodies, and raw bytes, while default query behavior remains unchanged and the Flask/Docker boundary is documented.

Tests cover empty 4xx, arbitrary-text 4xx, and raw-byte 5xx responses on both backends, with the CI matrix, changelog, and API docs updated.

Validated with 79 passing tests, 2 existing skips, pre-commit and pre-push checks, a warning-as-error Sphinx build, and all configured type checkers.
