### PR TITLE
Add configurable VuMark generation failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,7 @@ jobs:
           - tests/mock_vws/test_flask_app_usage.py
           - tests/mock_vws/test_model_target_web_api.py
           - tests/mock_vws/test_vumark_generation_api.py
+          - tests/mock_vws/test_vumark_generation_failure.py
           - tests/mock_vws/test_target_validators.py
           - tests/mock_vws/test_docker.py
           - ci/test_custom_linters.py

--- a/docs/source/mock-api-reference.rst
+++ b/docs/source/mock-api-reference.rst
@@ -15,6 +15,10 @@ API Reference
    :members:
    :undoc-members:
 
+.. autoclass:: mock_vws.VuMarkGenerationFailure
+   :members:
+   :undoc-members:
+
 .. Many parts of the CloudDatabase API are used for the Flask target
 .. database app, but Python users are not expected to use them.
 .. Therefore, they are not documented.

--- a/newsfragments/vumark-generation-failure.change
+++ b/newsfragments/vumark-generation-failure.change
@@ -1,0 +1,1 @@
+Allow VuMark generation requests to be configured to return ``QuotaExceeded``, ``LicenseCheckFailed``, or ``AuthorizationFailed`` responses.

--- a/src/mock_vws/__init__.py
+++ b/src/mock_vws/__init__.py
@@ -3,9 +3,11 @@
 from mock_vws._mock_common import MissingSchemeError
 from mock_vws._requests_mock_server.decorators import MockVWS
 from mock_vws.cloud_query import CloudQueryFailureResponse
+from mock_vws.vumark import VuMarkGenerationFailure
 
 __all__ = [
     "CloudQueryFailureResponse",
     "MissingSchemeError",
     "MockVWS",
+    "VuMarkGenerationFailure",
 ]

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -25,6 +25,7 @@ from mock_vws.target_raters import (
     BrisqueTargetTrackingRater,
     TargetTrackingRater,
 )
+from mock_vws.vumark import VuMarkGenerationFailure
 
 from .mock_web_query_api import MockVuforiaWebQueryAPI
 from .mock_web_services_api import MockVuforiaWebServicesAPI
@@ -60,6 +61,7 @@ class MockVWS(ContextDecorator):
         real_http: bool = False,
         response_delay_seconds: float = 0.0,
         sleep_fn: Callable[[float], None] = time.sleep,
+        vumark_generation_failure: VuMarkGenerationFailure | None = None,
     ) -> None:
         """Route requests to Vuforia's Web Service APIs to fakes of those
         APIs.
@@ -80,6 +82,10 @@ class MockVWS(ContextDecorator):
                 Query request, bypassing normal request validation and image
                 matching. By default, Cloud Query requests are handled
                 normally.
+            vumark_generation_failure: A failure to return for every VuMark
+                generation request, bypassing normal request validation and
+                instance generation. By default, VuMark generation requests
+                are handled normally.
             query_match_checker: A callable which takes two image values and
                 returns whether they will match in a query request.
             duplicate_match_checker: A callable which takes two image values
@@ -115,6 +121,7 @@ class MockVWS(ContextDecorator):
             processing_time_seconds=float(processing_time_seconds),
             duplicate_match_checker=duplicate_match_checker,
             target_tracking_rater=target_tracking_rater,
+            vumark_generation_failure=vumark_generation_failure,
         )
 
         self._mock_vwq_api = MockVuforiaWebQueryAPI(

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -49,6 +49,7 @@ from mock_vws.model_target import ModelTargetDatasetType
 from mock_vws.target import ImageTarget
 from mock_vws.target_manager import TargetManager
 from mock_vws.target_raters import TargetTrackingRater
+from mock_vws.vumark import VuMarkGenerationFailure
 
 if TYPE_CHECKING:
     from mock_vws.database import CloudDatabase
@@ -125,6 +126,7 @@ class MockVuforiaWebServicesAPI:
         processing_time_seconds: float,
         duplicate_match_checker: ImageMatcher,
         target_tracking_rater: TargetTrackingRater,
+        vumark_generation_failure: VuMarkGenerationFailure | None,
     ) -> None:
         """
         Args:
@@ -137,6 +139,8 @@ class MockVuforiaWebServicesAPI:
               and returns whether they are duplicates.
             target_tracking_rater: A callable for rating targets for
         tracking.
+            vumark_generation_failure: A configured failure which takes
+                precedence over normal VuMark generation handling.
 
         Attributes:
             routes: The `Route`s to be used in the mock.
@@ -146,6 +150,7 @@ class MockVuforiaWebServicesAPI:
         self._processing_time_seconds = processing_time_seconds
         self._duplicate_match_checker = duplicate_match_checker
         self._target_tracking_rater = target_tracking_rater
+        self._vumark_generation_failure = vumark_generation_failure
 
     @route(path_pattern="/oauth2/token", http_methods={HTTPMethod.POST})
     def oauth2_token(  # pylint: disable=no-self-use
@@ -455,6 +460,28 @@ class MockVuforiaWebServicesAPI:
     )
     def generate_vumark_instance(self, request: RequestData) -> _ResponseType:
         """Generate a VuMark instance."""
+        if self._vumark_generation_failure is not None:
+            body_json = json_dump(
+                body={
+                    "transaction_id": uuid.uuid4().hex,
+                    "result_code": self._vumark_generation_failure.value,
+                }
+            )
+            date = email.utils.formatdate(
+                timeval=None,
+                localtime=False,
+                usegmt=True,
+            )
+            return (
+                self._vumark_generation_failure.status_code,
+                {
+                    "Content-Length": str(object=len(body_json)),
+                    "Content-Type": "application/json",
+                    "Date": date,
+                },
+                body_json,
+            )
+
         valid_accept_types: dict[str, bytes] = {
             "image/png": VUMARK_PNG,
             "image/svg+xml": VUMARK_SVG,

--- a/src/mock_vws/vumark.py
+++ b/src/mock_vws/vumark.py
@@ -1,0 +1,23 @@
+"""Public configuration types for the VuMark Generation API."""
+
+from enum import StrEnum, unique
+from http import HTTPStatus
+
+from beartype import beartype
+
+
+@beartype
+@unique
+class VuMarkGenerationFailure(StrEnum):
+    """A configured failure returned by the VuMark Generation API mock."""
+
+    QUOTA_EXCEEDED = "QuotaExceeded"
+    LICENSE_CHECK_FAILED = "LicenseCheckFailed"
+    AUTHORIZATION_FAILED = "AuthorizationFailed"
+
+    @property
+    def status_code(self) -> HTTPStatus:
+        """Return the HTTP status documented for this failure."""
+        if self is VuMarkGenerationFailure.AUTHORIZATION_FAILED:
+            return HTTPStatus.UNAUTHORIZED
+        return HTTPStatus.FORBIDDEN

--- a/tests/mock_vws/test_vumark_generation_failure.py
+++ b/tests/mock_vws/test_vumark_generation_failure.py
@@ -1,0 +1,79 @@
+"""Tests for configurable VuMark generation failures."""
+
+from collections.abc import Callable
+from http import HTTPStatus
+
+import httpx
+import pytest
+import requests
+
+from mock_vws import MockVWS, VuMarkGenerationFailure
+
+_VUMARK_URL = "https://vws.vuforia.com/targets/example/instances"
+_REQUEST_BODY = b'{"instance_id":"example"}'
+type _HTTPResponse = requests.Response | httpx.Response
+type _RequestSender = Callable[[], _HTTPResponse]
+
+
+def _requests_request() -> _HTTPResponse:
+    """Send a VuMark generation request with ``requests``."""
+    return requests.post(
+        url=_VUMARK_URL,
+        headers={
+            "Accept": "image/png",
+            "Content-Type": "application/json",
+        },
+        data=_REQUEST_BODY,
+        timeout=30,
+    )
+
+
+def _httpx_request() -> _HTTPResponse:
+    """Send a VuMark generation request with ``httpx``."""
+    return httpx.post(
+        url=_VUMARK_URL,
+        headers={
+            "Accept": "image/png",
+            "Content-Type": "application/json",
+        },
+        content=_REQUEST_BODY,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="send_request",
+    argvalues=[_requests_request, _httpx_request],
+    ids=["requests", "httpx"],
+)
+@pytest.mark.parametrize(
+    argnames=("failure", "expected_status_code"),
+    argvalues=[
+        (
+            VuMarkGenerationFailure.QUOTA_EXCEEDED,
+            HTTPStatus.FORBIDDEN,
+        ),
+        (
+            VuMarkGenerationFailure.LICENSE_CHECK_FAILED,
+            HTTPStatus.FORBIDDEN,
+        ),
+        (
+            VuMarkGenerationFailure.AUTHORIZATION_FAILED,
+            HTTPStatus.UNAUTHORIZED,
+        ),
+    ],
+)
+def test_configured_failure_response(
+    *,
+    send_request: _RequestSender,
+    failure: VuMarkGenerationFailure,
+    expected_status_code: HTTPStatus,
+) -> None:
+    """Both in-process backends return the configured failure."""
+    with MockVWS(vumark_generation_failure=failure):
+        response = send_request()
+
+    assert response.status_code == expected_status_code
+    assert response.headers["Content-Type"] == "application/json"
+    assert response.json()["result_code"] == failure.value
+    assert response.json()["transaction_id"]


### PR DESCRIPTION
## Summary

- add a public `VuMarkGenerationFailure` configuration enum
- let `MockVWS` return the documented `QuotaExceeded`, `LicenseCheckFailed`, and `AuthorizationFailed` responses from the VuMark generation endpoint
- cover both the requests and httpx in-process backends

This enables VWS-Python/vws-python#3090 to test the sync and async clients through the real mock endpoint instead of hand-written transports.

## Test plan

- `pytest -q tests/mock_vws/test_vumark_generation_failure.py`
- Ruff and mypy on changed Python files