### PR TITLE
Install uv in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,12 @@ jobs:
           # The default GITHUB_TOKEN cannot bypass rulesets.
           token: ${{ secrets.RELEASE_PAT }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
       - name: Calver calculate version
         uses: StephaneBour/actions-calver@master
         id: calver


### PR DESCRIPTION
## Summary

Install `uv` before the release workflow uses it to generate release notes and update the changelog.

The 2026.08.04.2 release attempt failed at that step with `uv: command not found`; no tag, release, or package was created.

## Test plan

- `actionlint .github/workflows/release.yml`
- rerun the release workflow after merge