### PR TITLE
Add configurable Model Target generation failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
           - tests/mock_vws/test_requests_mock_usage.py
           - tests/mock_vws/test_respx_mock_usage.py
           - tests/mock_vws/test_flask_app_usage.py
+          - tests/mock_vws/test_model_target_generation_failure.py
           - tests/mock_vws/test_model_target_web_api.py
           - tests/mock_vws/test_vumark_generation_api.py
           - tests/mock_vws/test_vumark_generation_failure.py

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -163,6 +163,12 @@ Model Target datasets
 
 The Model Target Web API mock supports OAuth2 token requests, standard and advanced dataset creation, status polling, dataset downloads, and deletion.
 The generated dataset download is a small valid zip file containing request metadata, not a real Vuforia Engine Model Target dataset.
+Use :paramref:`mock_vws.MockVWS.model_target_generation_failure` to make
+in-process Model Target datasets finish with a ``failed`` status and an
+``error`` object. The failure is returned after the configured
+:paramref:`~mock_vws.MockVWS.processing_time_seconds`, so callers can test
+both processing and failed states. This configuration is not supported by the
+Flask/Docker backend.
 Model Target API routes require a three-part JSON Web Token with a JSON object
 header and a non-``none`` ``alg`` value, such as the token returned by the mock
 OAuth2 route.

--- a/docs/source/mock-api-reference.rst
+++ b/docs/source/mock-api-reference.rst
@@ -19,6 +19,10 @@ API Reference
    :members:
    :undoc-members:
 
+.. autoclass:: mock_vws.ModelTargetGenerationFailure
+   :members:
+   :undoc-members:
+
 .. Many parts of the CloudDatabase API are used for the Flask target
 .. database app, but Python users are not expected to use them.
 .. Therefore, they are not documented.

--- a/newsfragments/model-target-generation-failure.change
+++ b/newsfragments/model-target-generation-failure.change
@@ -1,0 +1,1 @@
+Add configurable failed Model Target dataset status responses.

--- a/src/mock_vws/__init__.py
+++ b/src/mock_vws/__init__.py
@@ -3,11 +3,13 @@
 from mock_vws._mock_common import MissingSchemeError
 from mock_vws._requests_mock_server.decorators import MockVWS
 from mock_vws.cloud_query import CloudQueryFailureResponse
+from mock_vws.model_target import ModelTargetGenerationFailure
 from mock_vws.vumark import VuMarkGenerationFailure
 
 __all__ = [
     "CloudQueryFailureResponse",
     "MissingSchemeError",
     "MockVWS",
+    "ModelTargetGenerationFailure",
     "VuMarkGenerationFailure",
 ]

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -255,6 +255,7 @@ def create_standard_model_target_dataset() -> Response:
             target_manager=_model_target_manager(),
             processing_time_seconds=settings.processing_time_seconds,
             dataset_type=ModelTargetDatasetType.STANDARD,
+            generation_failure=None,
         ),
     )
 
@@ -273,6 +274,7 @@ def create_advanced_model_target_dataset() -> Response:
             target_manager=_model_target_manager(),
             processing_time_seconds=settings.processing_time_seconds,
             dataset_type=ModelTargetDatasetType.ADVANCED,
+            generation_failure=None,
         ),
     )
 

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -366,7 +366,7 @@ def create_model_target_dataset(
     target_manager: TargetManager,
     processing_time_seconds: float,
     dataset_type: ModelTargetDatasetType,
-    generation_failure: ModelTargetGenerationFailure | None = None,
+    generation_failure: ModelTargetGenerationFailure | None,
 ) -> _ResponseType:
     """Create a standard or advanced Model Target dataset."""
     auth_error = _require_bearer_token(request=request)

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -12,7 +12,11 @@ from urllib.parse import parse_qs
 from beartype import beartype
 
 from mock_vws._mock_common import RequestData, json_dump
-from mock_vws.model_target import ModelTargetDataset, ModelTargetDatasetType
+from mock_vws.model_target import (
+    ModelTargetDataset,
+    ModelTargetDatasetType,
+    ModelTargetGenerationFailure,
+)
 from mock_vws.target_manager import TargetManager
 
 _ResponseType = tuple[int, dict[str, str], str | bytes]
@@ -362,6 +366,7 @@ def create_model_target_dataset(
     target_manager: TargetManager,
     processing_time_seconds: float,
     dataset_type: ModelTargetDatasetType,
+    generation_failure: ModelTargetGenerationFailure | None = None,
 ) -> _ResponseType:
     """Create a standard or advanced Model Target dataset."""
     auth_error = _require_bearer_token(request=request)
@@ -383,6 +388,7 @@ def create_model_target_dataset(
         request_body=request_json_or_error,
         dataset_type=dataset_type,
         processing_time_seconds=processing_time_seconds,
+        generation_failure=generation_failure,
     )
     target_manager.add_model_target_dataset(model_target_dataset=dataset)
     return _json_response(

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -20,6 +20,7 @@ from mock_vws.image_matchers import (
     ImageMatcher,
     StructuralSimilarityMatcher,
 )
+from mock_vws.model_target import ModelTargetGenerationFailure
 from mock_vws.target_manager import TargetManager
 from mock_vws.target_raters import (
     BrisqueTargetTrackingRater,
@@ -57,6 +58,9 @@ class MockVWS(ContextDecorator):
         duplicate_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
         query_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
         processing_time_seconds: float = 2.0,
+        model_target_generation_failure: (
+            ModelTargetGenerationFailure | None
+        ) = None,
         target_tracking_rater: TargetTrackingRater = _BRISQUE_TRACKING_RATER,
         real_http: bool = False,
         response_delay_seconds: float = 0.0,
@@ -76,6 +80,9 @@ class MockVWS(ContextDecorator):
             processing_time_seconds: The number of seconds to process each
                 image for.
                 In the real Vuforia Web Services, this is not deterministic.
+            model_target_generation_failure: A failure to return after every
+                Model Target dataset finishes processing. By default, Model
+                Target datasets finish successfully.
             base_vwq_url: The base URL for the VWQ API.
             base_vws_url: The base URL for the VWS API.
             cloud_query_failure_response: A response to return for every Cloud
@@ -119,6 +126,7 @@ class MockVWS(ContextDecorator):
         self._mock_vws_api = MockVuforiaWebServicesAPI(
             target_manager=self._target_manager,
             processing_time_seconds=float(processing_time_seconds),
+            model_target_generation_failure=model_target_generation_failure,
             duplicate_match_checker=duplicate_match_checker,
             target_tracking_rater=target_tracking_rater,
             vumark_generation_failure=vumark_generation_failure,

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -45,7 +45,10 @@ from mock_vws._services_validators.exceptions import (
 )
 from mock_vws.database import VuMarkDatabase
 from mock_vws.image_matchers import ImageMatcher
-from mock_vws.model_target import ModelTargetDatasetType
+from mock_vws.model_target import (
+    ModelTargetDatasetType,
+    ModelTargetGenerationFailure,
+)
 from mock_vws.target import ImageTarget
 from mock_vws.target_manager import TargetManager
 from mock_vws.target_raters import TargetTrackingRater
@@ -124,6 +127,7 @@ class MockVuforiaWebServicesAPI:
         *,
         target_manager: TargetManager,
         processing_time_seconds: float,
+        model_target_generation_failure: (ModelTargetGenerationFailure | None),
         duplicate_match_checker: ImageMatcher,
         target_tracking_rater: TargetTrackingRater,
         vumark_generation_failure: VuMarkGenerationFailure | None,
@@ -134,6 +138,8 @@ class MockVuforiaWebServicesAPI:
             processing_time_seconds: The number of seconds to process each
               image for. In the real Vuforia Web Services, this is not
               deterministic.
+            model_target_generation_failure: A configured failure returned
+                after Model Target dataset processing completes.
             duplicate_match_checker: A callable which takes two image
         values
               and returns whether they are duplicates.
@@ -148,6 +154,7 @@ class MockVuforiaWebServicesAPI:
         self._target_manager = target_manager
         self.routes = _ROUTES
         self._processing_time_seconds = processing_time_seconds
+        self._model_target_generation_failure = model_target_generation_failure
         self._duplicate_match_checker = duplicate_match_checker
         self._target_tracking_rater = target_tracking_rater
         self._vumark_generation_failure = vumark_generation_failure
@@ -174,6 +181,7 @@ class MockVuforiaWebServicesAPI:
             target_manager=self._target_manager,
             processing_time_seconds=self._processing_time_seconds,
             dataset_type=ModelTargetDatasetType.STANDARD,
+            generation_failure=self._model_target_generation_failure,
         )
 
     @route(
@@ -190,6 +198,7 @@ class MockVuforiaWebServicesAPI:
             target_manager=self._target_manager,
             processing_time_seconds=self._processing_time_seconds,
             dataset_type=ModelTargetDatasetType.ADVANCED,
+            generation_failure=self._model_target_generation_failure,
         )
 
     @route(

--- a/src/mock_vws/model_target.py
+++ b/src/mock_vws/model_target.py
@@ -19,6 +19,18 @@ class ModelTargetDatasetType(StrEnum):
 
 
 @beartype
+@dataclass(frozen=True, kw_only=True)
+class ModelTargetGenerationFailure:
+    """A configured Model Target dataset generation failure.
+
+    Args:
+        message: The failure message included in the dataset status response.
+    """
+
+    message: str = "Model Target dataset generation failed"
+
+
+@beartype
 def _now() -> datetime.datetime:
     """Return the current time in UTC."""
     return datetime.datetime.now(tz=ZoneInfo(key="UTC"))
@@ -42,6 +54,7 @@ class ModelTargetDataset:
             dataset becomes available.
         uuid_: The dataset UUID.
         created_at: When the dataset creation was requested.
+        generation_failure: A failure to return when processing completes.
     """
 
     request_body: dict[str, Any] = field(hash=False)
@@ -49,6 +62,10 @@ class ModelTargetDataset:
     processing_time_seconds: float = field(hash=False)
     uuid_: str = field(default_factory=lambda: uuid.uuid4().hex)
     created_at: datetime.datetime = field(default_factory=_now)
+    generation_failure: ModelTargetGenerationFailure | None = field(
+        default=None,
+        hash=False,
+    )
 
     @property
     def completed_at(self) -> datetime.datetime:
@@ -62,6 +79,8 @@ class ModelTargetDataset:
         """The current dataset generation status."""
         if _now() < self.completed_at:
             return "processing"
+        if self.generation_failure is not None:
+            return "failed"
         return "done"
 
     def status_body(self) -> dict[str, Any]:
@@ -76,5 +95,10 @@ class ModelTargetDataset:
             body["eta"] = _format_datetime(value=self.completed_at)
         else:
             body["completedAt"] = _format_datetime(value=self.completed_at)
+        if status == "failed" and self.generation_failure is not None:
+            body["error"] = {
+                "code": "ERROR",
+                "message": self.generation_failure.message,
+            }
 
         return body

--- a/src/mock_vws/model_target.py
+++ b/src/mock_vws/model_target.py
@@ -60,12 +60,9 @@ class ModelTargetDataset:
     request_body: dict[str, Any] = field(hash=False)
     dataset_type: ModelTargetDatasetType
     processing_time_seconds: float = field(hash=False)
+    generation_failure: ModelTargetGenerationFailure | None = field(hash=False)
     uuid_: str = field(default_factory=lambda: uuid.uuid4().hex)
     created_at: datetime.datetime = field(default_factory=_now)
-    generation_failure: ModelTargetGenerationFailure | None = field(
-        default=None,
-        hash=False,
-    )
 
     @property
     def completed_at(self) -> datetime.datetime:

--- a/tests/mock_vws/test_model_target_generation_failure.py
+++ b/tests/mock_vws/test_model_target_generation_failure.py
@@ -1,0 +1,126 @@
+"""Tests for configurable Model Target dataset generation failures."""
+
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+import pytest
+import requests
+
+from mock_vws import MockVWS, ModelTargetGenerationFailure
+
+_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
+_CREATE_URL = "https://vws.vuforia.com/modeltargets/datasets"
+_REQUEST_BODY: dict[str, Any] = {
+    "name": "dataset-name",
+    "targetSdk": "10.18",
+    "models": [
+        {
+            "name": "model-name",
+            "cadDataUrl": "https://example.com/model.glb",
+            "views": [
+                {
+                    "name": "view-name",
+                    "guideViewPosition": {
+                        "translation": [0, 0, 5],
+                        "rotation": [0, 0, 0, 1],
+                    },
+                },
+            ],
+        },
+    ],
+}
+type _HTTPResponse = requests.Response | httpx.Response
+type _RequestSender = Callable[[str, dict[str, Any] | None], _HTTPResponse]
+
+
+def _requests_request(
+    url: str,
+    json_body: dict[str, Any] | None,
+) -> _HTTPResponse:
+    """Send a Model Target request with ``requests``."""
+    if json_body is None:
+        return requests.get(
+            url=url,
+            headers={"Authorization": _AUTHORIZATION},
+            timeout=30,
+        )
+    return requests.post(
+        url=url,
+        headers={"Authorization": _AUTHORIZATION},
+        json=json_body,
+        timeout=30,
+    )
+
+
+def _httpx_request(
+    url: str,
+    json_body: dict[str, Any] | None,
+) -> _HTTPResponse:
+    """Send a Model Target request with ``httpx``."""
+    if json_body is None:
+        return httpx.get(
+            url=url,
+            headers={"Authorization": _AUTHORIZATION},
+            timeout=30,
+        )
+    return httpx.post(
+        url=url,
+        headers={"Authorization": _AUTHORIZATION},
+        json=json_body,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="send_request",
+    argvalues=[_requests_request, _httpx_request],
+    ids=["requests", "httpx"],
+)
+@pytest.mark.parametrize(
+    argnames=("processing_time_seconds", "expected_status", "time_field"),
+    argvalues=[
+        pytest.param(60.0, "processing", "eta", id="processing"),
+        pytest.param(0.0, "failed", "completedAt", id="failed"),
+    ],
+)
+def test_configured_generation_failure(
+    *,
+    send_request: _RequestSender,
+    processing_time_seconds: float,
+    expected_status: str,
+    time_field: str,
+) -> None:
+    """A configured failure is returned only after processing
+    completes.
+    """
+    failure = ModelTargetGenerationFailure(message="CAD model is invalid")
+    with MockVWS(
+        processing_time_seconds=processing_time_seconds,
+        model_target_generation_failure=failure,
+    ):
+        create_response = send_request(_CREATE_URL, _REQUEST_BODY)
+        dataset_uuid = create_response.json()["uuid"]
+        status_response = send_request(
+            f"{_CREATE_URL}/{dataset_uuid}/status",
+            None,
+        )
+
+    assert create_response.status_code == HTTPStatus.CREATED
+    assert status_response.status_code == HTTPStatus.OK
+    status_body = status_response.json()
+    assert status_body["status"] == expected_status
+    assert status_body["uuid"] == dataset_uuid
+    assert isinstance(status_body["createdAt"], str)
+    assert isinstance(status_body[time_field], str)
+    assert {"eta", "completedAt"} & status_body.keys() == {time_field}
+    expected_error = (
+        {
+            "code": "ERROR",
+            "message": "CAD model is invalid",
+        }
+        if expected_status == "failed"
+        else None
+    )
+    assert status_body.get("error") == expected_error

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -698,6 +698,7 @@ class TestModelTargetDatasetStatus:
             request_body={},
             dataset_type=ModelTargetDatasetType.STANDARD,
             processing_time_seconds=processing_time_seconds,
+            generation_failure=None,
             uuid_="dataset-uuid",
         )
 


### PR DESCRIPTION
## Summary

- add a public `ModelTargetGenerationFailure` configuration for in-process Model Target mocks
- keep configured datasets in `processing` until their processing time elapses, then return a Vuforia-shaped `failed` status with `completedAt` and an `error` object
- cover the lifecycle through both `requests` and `httpx`, and document the Flask/Docker limitation

## Why

The mock previously modeled only the `processing` and `done` Model Target dataset statuses even though Vuforia also documents `failed` as a terminal generation state. Consumers could not test their failed-generation handling with `MockVWS`.

## Impact

Successful dataset behavior is unchanged by default. Passing `model_target_generation_failure` lets callers deterministically exercise processing and failed status responses in the in-process mock backends.

## Validation

- `uv run pytest tests/mock_vws/test_model_target_generation_failure.py tests/mock_vws/test_model_target_web_api.py ci/test_custom_linters.py --skip-real -q` (64 passed, 27 skipped)
- `uv run mypy src/mock_vws tests/mock_vws/test_model_target_generation_failure.py`
- `uv run sphinx-build -W -b html docs/source .context/docs-build`
- `uv run prek run --all-files`
- all pre-commit and pre-push hooks

Progresses #3194.
