### PR TITLE
Validate Model Target JWT payloads

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -169,10 +169,11 @@ in-process Model Target datasets finish with a ``failed`` status and an
 :paramref:`~mock_vws.MockVWS.processing_time_seconds`, so callers can test
 both processing and failed states. This configuration is not supported by the
 Flask/Docker backend.
-Model Target API routes require a three-part JSON Web Token with a JSON object
-header and a non-``none`` ``alg`` value, such as the token returned by the mock
-OAuth2 route.
-The mock does not verify token signatures, claims, expiry, or revocation.
+Model Target API routes require a three-part JSON Web Token with JSON object
+header and payload parts and a non-``none`` ``alg`` value, such as the token
+returned by the mock OAuth2 route.
+The mock does not verify token signatures, payload claims such as expiry, or
+token revocation.
 
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.

--- a/newsfragments/model-target-jwt-payload.change
+++ b/newsfragments/model-target-jwt-payload.change
@@ -1,0 +1,1 @@
+Reject Model Target bearer tokens whose JWT payload is not a JSON object.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -156,6 +156,26 @@ def _jwt_header_error(*, bearer_token: str) -> str | None:
 
 
 @beartype
+def _jwt_payload_error(*, bearer_token: str) -> str | None:
+    """Return the Vuforia error for an invalid JSON Web Token payload."""
+    encoded_payload = bearer_token.split(sep=".")[1]
+    try:
+        padding = "=" * (-len(encoded_payload) % 4)
+        decoded_payload = base64.b64decode(
+            s=encoded_payload + padding,
+            altchars=b"-_",
+            validate=True,
+        )
+        payload = json.loads(s=decoded_payload)
+    except ValueError:
+        payload = None
+
+    if not isinstance(payload, dict):
+        return "Payload of JWS object is not a valid JSON object"
+    return None
+
+
+@beartype
 def _require_bearer_token(request: RequestData) -> _ResponseType | None:
     """Return an error response if the request has no bearer token."""
     auth_header = _get_header(request=request, name="Authorization")
@@ -190,6 +210,15 @@ def _require_bearer_token(request: RequestData) -> _ResponseType | None:
             status_code=HTTPStatus.UNAUTHORIZED,
             code="401",
             message=jwt_header_error,
+            target="jwt",
+            details=None,
+        )
+    jwt_payload_error = _jwt_payload_error(bearer_token=bearer_token)
+    if jwt_payload_error is not None:
+        return _error_response(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            code="401",
+            message=jwt_payload_error,
             target="jwt",
             details=None,
         )

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -256,6 +256,21 @@ class TestAuthentication:
                 ),
                 id="unsecured",
             ),
+            pytest.param(
+                "Bearer eyJhbGciOiJSUzI1NiJ9.%.signature",
+                "Payload of JWS object is not a valid JSON object",
+                id="payload-not-base64",
+            ),
+            pytest.param(
+                "Bearer eyJhbGciOiJSUzI1NiJ9..signature",
+                "Payload of JWS object is not a valid JSON object",
+                id="blank-payload",
+            ),
+            pytest.param(
+                "Bearer eyJhbGciOiJSUzI1NiJ9.InZhbHVlIg.signature",
+                "Payload of JWS object is not a valid JSON object",
+                id="payload-not-json-object",
+            ),
         ],
     )
     def test_invalid_bearer_token(


### PR DESCRIPTION
## Summary

- reject Model Target bearer tokens whose JWT payload is invalid base64, blank, or not a JSON object
- match Vuforia's 401 error response for malformed JWS payloads
- add verified-fake coverage across real Vuforia and both mock backends
- document the remaining signature, claims, and revocation limitations

## Why

The mock validated JWT serialization and headers but never decoded the payload. Tokens with malformed payloads therefore reached dataset routes, while real Vuforia rejects them during authentication.

## Impact

Model Target authentication now fails earlier and with Vuforia's observed response shape for malformed payloads. Valid mock OAuth2 tokens continue to work, and signature and claim validation remain intentionally out of scope.

## Validation

- `uv run --extra dev pytest tests/mock_vws/test_model_target_web_api.py::TestAuthentication -q` (57 passed against real Vuforia and both mock backends)
- `uv run --extra dev pytest tests/mock_vws/test_model_target_web_api.py ci/test_custom_linters.py --skip-real -q` (66 passed, 30 skipped)
- focused Ruff and MyPy checks
- Sphinx build with warnings as errors
- `uv run --extra dev prek run --all-files`
- all pre-push hooks

Progresses #3192.
