### PR TITLE
Add Model Target generation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,7 @@ jobs:
           - tests/mock_vws/test_respx_mock_usage.py
           - tests/mock_vws/test_flask_app_usage.py
           - tests/mock_vws/test_model_target_generation_failure.py
+          - tests/mock_vws/test_model_target_generation_warning.py
           - tests/mock_vws/test_model_target_web_api.py
           - tests/mock_vws/test_vumark_generation_api.py
           - tests/mock_vws/test_vumark_generation_failure.py

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -169,6 +169,10 @@ in-process Model Target datasets finish with a ``failed`` status and an
 :paramref:`~mock_vws.MockVWS.processing_time_seconds`, so callers can test
 both processing and failed states. This configuration is not supported by the
 Flask/Docker backend.
+Use :paramref:`mock_vws.MockVWS.model_target_generation_warning` to make
+successful in-process Model Target datasets include a Vuforia-shaped
+``warning`` object after processing completes. This configuration is not
+supported by the Flask/Docker backend.
 Model Target API routes require a three-part JSON Web Token with JSON object
 header and payload parts and a non-``none`` ``alg`` value, such as the token
 returned by the mock OAuth2 route.

--- a/docs/source/mock-api-reference.rst
+++ b/docs/source/mock-api-reference.rst
@@ -23,6 +23,10 @@ API Reference
    :members:
    :undoc-members:
 
+.. autoclass:: mock_vws.ModelTargetGenerationWarning(*, message='Warning after creating dataset', details=...)
+   :members:
+   :undoc-members:
+
 .. Many parts of the CloudDatabase API are used for the Flask target
 .. database app, but Python users are not expected to use them.
 .. Therefore, they are not documented.

--- a/newsfragments/model-target-generation-warning.change
+++ b/newsfragments/model-target-generation-warning.change
@@ -1,0 +1,1 @@
+Add configurable Model Target dataset generation warning responses.

--- a/src/mock_vws/__init__.py
+++ b/src/mock_vws/__init__.py
@@ -3,7 +3,10 @@
 from mock_vws._mock_common import MissingSchemeError
 from mock_vws._requests_mock_server.decorators import MockVWS
 from mock_vws.cloud_query import CloudQueryFailureResponse
-from mock_vws.model_target import ModelTargetGenerationFailure
+from mock_vws.model_target import (
+    ModelTargetGenerationFailure,
+    ModelTargetGenerationWarning,
+)
 from mock_vws.vumark import VuMarkGenerationFailure
 
 __all__ = [
@@ -11,5 +14,6 @@ __all__ = [
     "MissingSchemeError",
     "MockVWS",
     "ModelTargetGenerationFailure",
+    "ModelTargetGenerationWarning",
     "VuMarkGenerationFailure",
 ]

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -256,6 +256,7 @@ def create_standard_model_target_dataset() -> Response:
             processing_time_seconds=settings.processing_time_seconds,
             dataset_type=ModelTargetDatasetType.STANDARD,
             generation_failure=None,
+            generation_warning=None,
         ),
     )
 
@@ -275,6 +276,7 @@ def create_advanced_model_target_dataset() -> Response:
             processing_time_seconds=settings.processing_time_seconds,
             dataset_type=ModelTargetDatasetType.ADVANCED,
             generation_failure=None,
+            generation_warning=None,
         ),
     )
 

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -16,6 +16,7 @@ from mock_vws.model_target import (
     ModelTargetDataset,
     ModelTargetDatasetType,
     ModelTargetGenerationFailure,
+    ModelTargetGenerationWarning,
 )
 from mock_vws.target_manager import TargetManager
 
@@ -396,6 +397,7 @@ def create_model_target_dataset(
     processing_time_seconds: float,
     dataset_type: ModelTargetDatasetType,
     generation_failure: ModelTargetGenerationFailure | None,
+    generation_warning: ModelTargetGenerationWarning | None,
 ) -> _ResponseType:
     """Create a standard or advanced Model Target dataset."""
     auth_error = _require_bearer_token(request=request)
@@ -418,6 +420,7 @@ def create_model_target_dataset(
         dataset_type=dataset_type,
         processing_time_seconds=processing_time_seconds,
         generation_failure=generation_failure,
+        generation_warning=generation_warning,
     )
     target_manager.add_model_target_dataset(model_target_dataset=dataset)
     return _json_response(

--- a/src/mock_vws/_requests_mock_server/decorators.py
+++ b/src/mock_vws/_requests_mock_server/decorators.py
@@ -20,7 +20,10 @@ from mock_vws.image_matchers import (
     ImageMatcher,
     StructuralSimilarityMatcher,
 )
-from mock_vws.model_target import ModelTargetGenerationFailure
+from mock_vws.model_target import (
+    ModelTargetGenerationFailure,
+    ModelTargetGenerationWarning,
+)
 from mock_vws.target_manager import TargetManager
 from mock_vws.target_raters import (
     BrisqueTargetTrackingRater,
@@ -61,6 +64,9 @@ class MockVWS(ContextDecorator):
         model_target_generation_failure: (
             ModelTargetGenerationFailure | None
         ) = None,
+        model_target_generation_warning: (
+            ModelTargetGenerationWarning | None
+        ) = None,
         target_tracking_rater: TargetTrackingRater = _BRISQUE_TRACKING_RATER,
         real_http: bool = False,
         response_delay_seconds: float = 0.0,
@@ -83,6 +89,10 @@ class MockVWS(ContextDecorator):
             model_target_generation_failure: A failure to return after every
                 Model Target dataset finishes processing. By default, Model
                 Target datasets finish successfully.
+            model_target_generation_warning: A warning to return after every
+                Model Target dataset finishes processing. By default, Model
+                Target datasets finish without warnings. This cannot be
+                combined with ``model_target_generation_failure``.
             base_vwq_url: The base URL for the VWQ API.
             base_vws_url: The base URL for the VWS API.
             cloud_query_failure_response: A response to return for every Cloud
@@ -107,8 +117,19 @@ class MockVWS(ContextDecorator):
 
         Raises:
             MissingSchemeError: There is no scheme in a given URL.
+            ValueError: Both a Model Target generation failure and warning are
+                configured.
         """
         super().__init__()
+        if (
+            model_target_generation_failure is not None
+            and model_target_generation_warning is not None
+        ):
+            msg = (
+                "Model Target generation failure and warning configurations "
+                "are mutually exclusive"
+            )
+            raise ValueError(msg)
         self._real_http = real_http
         self._response_delay_seconds = response_delay_seconds
         self._sleep_fn = sleep_fn
@@ -127,6 +148,7 @@ class MockVWS(ContextDecorator):
             target_manager=self._target_manager,
             processing_time_seconds=float(processing_time_seconds),
             model_target_generation_failure=model_target_generation_failure,
+            model_target_generation_warning=model_target_generation_warning,
             duplicate_match_checker=duplicate_match_checker,
             target_tracking_rater=target_tracking_rater,
             vumark_generation_failure=vumark_generation_failure,

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -48,6 +48,7 @@ from mock_vws.image_matchers import ImageMatcher
 from mock_vws.model_target import (
     ModelTargetDatasetType,
     ModelTargetGenerationFailure,
+    ModelTargetGenerationWarning,
 )
 from mock_vws.target import ImageTarget
 from mock_vws.target_manager import TargetManager
@@ -128,6 +129,7 @@ class MockVuforiaWebServicesAPI:
         target_manager: TargetManager,
         processing_time_seconds: float,
         model_target_generation_failure: (ModelTargetGenerationFailure | None),
+        model_target_generation_warning: (ModelTargetGenerationWarning | None),
         duplicate_match_checker: ImageMatcher,
         target_tracking_rater: TargetTrackingRater,
         vumark_generation_failure: VuMarkGenerationFailure | None,
@@ -139,6 +141,8 @@ class MockVuforiaWebServicesAPI:
               image for. In the real Vuforia Web Services, this is not
               deterministic.
             model_target_generation_failure: A configured failure returned
+                after Model Target dataset processing completes.
+            model_target_generation_warning: A configured warning returned
                 after Model Target dataset processing completes.
             duplicate_match_checker: A callable which takes two image
         values
@@ -155,6 +159,7 @@ class MockVuforiaWebServicesAPI:
         self.routes = _ROUTES
         self._processing_time_seconds = processing_time_seconds
         self._model_target_generation_failure = model_target_generation_failure
+        self._model_target_generation_warning = model_target_generation_warning
         self._duplicate_match_checker = duplicate_match_checker
         self._target_tracking_rater = target_tracking_rater
         self._vumark_generation_failure = vumark_generation_failure
@@ -182,6 +187,7 @@ class MockVuforiaWebServicesAPI:
             processing_time_seconds=self._processing_time_seconds,
             dataset_type=ModelTargetDatasetType.STANDARD,
             generation_failure=self._model_target_generation_failure,
+            generation_warning=self._model_target_generation_warning,
         )
 
     @route(
@@ -199,6 +205,7 @@ class MockVuforiaWebServicesAPI:
             processing_time_seconds=self._processing_time_seconds,
             dataset_type=ModelTargetDatasetType.ADVANCED,
             generation_failure=self._model_target_generation_failure,
+            generation_warning=self._model_target_generation_warning,
         )
 
     @route(

--- a/src/mock_vws/model_target.py
+++ b/src/mock_vws/model_target.py
@@ -1,5 +1,6 @@
 """Model Target dataset objects."""
 
+import copy
 import datetime
 import uuid
 from dataclasses import dataclass, field
@@ -31,6 +32,31 @@ class ModelTargetGenerationFailure:
 
 
 @beartype
+@dataclass(frozen=True, kw_only=True)
+class ModelTargetGenerationWarning:
+    """A configured Model Target dataset generation warning.
+
+    Args:
+        message: The top-level warning message included in the dataset status
+            response.
+        details: The warning details included in the dataset status response.
+    """
+
+    message: str = "Warning after creating dataset"
+    details: list[dict[str, Any]] = field(
+        default_factory=lambda: [
+            {
+                "code": "LOW_RECOGNITION_QUALITY",
+                "message": (
+                    "The processed model appears to have substandard "
+                    "recognition quality."
+                ),
+            },
+        ],
+    )
+
+
+@beartype
 def _now() -> datetime.datetime:
     """Return the current time in UTC."""
     return datetime.datetime.now(tz=ZoneInfo(key="UTC"))
@@ -55,12 +81,14 @@ class ModelTargetDataset:
         uuid_: The dataset UUID.
         created_at: When the dataset creation was requested.
         generation_failure: A failure to return when processing completes.
+        generation_warning: A warning to return when processing completes.
     """
 
     request_body: dict[str, Any] = field(hash=False)
     dataset_type: ModelTargetDatasetType
     processing_time_seconds: float = field(hash=False)
     generation_failure: ModelTargetGenerationFailure | None = field(hash=False)
+    generation_warning: ModelTargetGenerationWarning | None = field(hash=False)
     uuid_: str = field(default_factory=lambda: uuid.uuid4().hex)
     created_at: datetime.datetime = field(default_factory=_now)
 
@@ -96,6 +124,13 @@ class ModelTargetDataset:
             body["error"] = {
                 "code": "ERROR",
                 "message": self.generation_failure.message,
+            }
+        if status == "done" and self.generation_warning is not None:
+            body["warning"] = {
+                "code": "WARNING",
+                "message": self.generation_warning.message,
+                "target": self.uuid_,
+                "details": copy.deepcopy(x=self.generation_warning.details),
             }
 
         return body

--- a/tests/mock_vws/test_model_target_generation_warning.py
+++ b/tests/mock_vws/test_model_target_generation_warning.py
@@ -1,0 +1,157 @@
+"""Tests for configurable Model Target dataset generation warnings."""
+
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+import pytest
+import requests
+
+from mock_vws import (
+    MockVWS,
+    ModelTargetGenerationFailure,
+    ModelTargetGenerationWarning,
+)
+
+_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
+_CREATE_URL = "https://vws.vuforia.com/modeltargets/datasets"
+_REQUEST_BODY: dict[str, Any] = {
+    "name": "dataset-name",
+    "targetSdk": "10.18",
+    "models": [
+        {
+            "name": "model-name",
+            "cadDataUrl": "https://example.com/model.glb",
+            "views": [
+                {
+                    "name": "view-name",
+                    "guideViewPosition": {
+                        "translation": [0, 0, 5],
+                        "rotation": [0, 0, 0, 1],
+                    },
+                },
+            ],
+        },
+    ],
+}
+type _HTTPResponse = requests.Response | httpx.Response
+type _RequestSender = Callable[[str, dict[str, Any] | None], _HTTPResponse]
+
+
+def _requests_request(
+    url: str,
+    json_body: dict[str, Any] | None,
+) -> _HTTPResponse:
+    """Send a Model Target request with ``requests``."""
+    if json_body is None:
+        return requests.get(
+            url=url,
+            headers={"Authorization": _AUTHORIZATION},
+            timeout=30,
+        )
+    return requests.post(
+        url=url,
+        headers={"Authorization": _AUTHORIZATION},
+        json=json_body,
+        timeout=30,
+    )
+
+
+def _httpx_request(
+    url: str,
+    json_body: dict[str, Any] | None,
+) -> _HTTPResponse:
+    """Send a Model Target request with ``httpx``."""
+    if json_body is None:
+        return httpx.get(
+            url=url,
+            headers={"Authorization": _AUTHORIZATION},
+            timeout=30,
+        )
+    return httpx.post(
+        url=url,
+        headers={"Authorization": _AUTHORIZATION},
+        json=json_body,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="send_request",
+    argvalues=[_requests_request, _httpx_request],
+    ids=["requests", "httpx"],
+)
+@pytest.mark.parametrize(
+    argnames=("processing_time_seconds", "expected_status", "time_field"),
+    argvalues=[
+        pytest.param(60.0, "processing", "eta", id="processing"),
+        pytest.param(0.0, "done", "completedAt", id="done"),
+    ],
+)
+def test_configured_generation_warning(
+    *,
+    send_request: _RequestSender,
+    processing_time_seconds: float,
+    expected_status: str,
+    time_field: str,
+) -> None:
+    """A configured warning is returned only after processing
+    completes.
+    """
+    details = [
+        {
+            "code": "LOW_RECOGNITION_QUALITY",
+            "message": "The model has substandard recognition quality.",
+            "innerError": {
+                "code": "SYMMETRIES_OR_AMBIGUITIES",
+                "targets": [{"model": "model-name"}],
+            },
+        },
+    ]
+    warning = ModelTargetGenerationWarning(
+        message="Warning after creating dataset",
+        details=details,
+    )
+    with MockVWS(
+        processing_time_seconds=processing_time_seconds,
+        model_target_generation_warning=warning,
+    ):
+        create_response = send_request(_CREATE_URL, _REQUEST_BODY)
+        dataset_uuid = create_response.json()["uuid"]
+        status_response = send_request(
+            f"{_CREATE_URL}/{dataset_uuid}/status",
+            None,
+        )
+
+    assert create_response.status_code == HTTPStatus.CREATED
+    assert status_response.status_code == HTTPStatus.OK
+    status_body = status_response.json()
+    assert status_body["status"] == expected_status
+    assert status_body["uuid"] == dataset_uuid
+    assert isinstance(status_body["createdAt"], str)
+    assert isinstance(status_body[time_field], str)
+    assert {"eta", "completedAt"} & status_body.keys() == {time_field}
+    expected_warning = (
+        {
+            "code": "WARNING",
+            "message": "Warning after creating dataset",
+            "target": dataset_uuid,
+            "details": details,
+        }
+        if expected_status == "done"
+        else None
+    )
+    assert status_body.get("warning") == expected_warning
+
+
+def test_generation_warning_and_failure_are_mutually_exclusive() -> None:
+    """A dataset cannot be configured to both fail and succeed."""
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="failure and warning configurations are mutually exclusive",
+    ):
+        MockVWS(
+            model_target_generation_failure=ModelTargetGenerationFailure(),
+            model_target_generation_warning=ModelTargetGenerationWarning(),
+        )

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -714,6 +714,7 @@ class TestModelTargetDatasetStatus:
             dataset_type=ModelTargetDatasetType.STANDARD,
             processing_time_seconds=processing_time_seconds,
             generation_failure=None,
+            generation_warning=None,
             uuid_="dataset-uuid",
         )
 


### PR DESCRIPTION
## Summary

- add a public `ModelTargetGenerationWarning` configuration for in-process Model Target mocks
- return a Vuforia-shaped `warning` object only after successful dataset processing completes
- support custom warning details, including nested `innerError` data, for both `requests` and `httpx`
- reject contradictory failure-plus-warning configuration and document the Flask/Docker limitation

## Why

Vuforia documents successful Model Target generations that finish with status `done` while including warning details, but the mock could only simulate processing, clean success, or failure. Consumers therefore could not test warning handling without constructing responses outside the mock.

## Impact

Passing `model_target_generation_warning` to `MockVWS` now lets callers exercise successful generation warnings. Default behavior is unchanged, and configured warnings remain absent while the dataset is still processing.

## Validation

- `uv run --extra dev pytest tests/mock_vws/test_model_target_generation_warning.py tests/mock_vws/test_model_target_generation_failure.py tests/mock_vws/test_model_target_web_api.py ci/test_custom_linters.py --skip-real -q` (98 passed, 24 skipped)
- focused Ruff and MyPy checks
- Sphinx build with warnings as errors
- all pre-commit and pre-push hooks

Progresses #3194.