### PR TITLE
Use prek-action and autofix.ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,36 @@
+---
+name: autofix.ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run fixers
+        uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece  # v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files
+            --hook-stage pre-commit
+            --no-fail-fast
+            --verbose
+        env:
+          UV_NO_CACHE: '1'
+          UV_PYTHON: '3.14'
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
+        if: always()

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Run fixers
-        uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece  # v3.0.0
+        uses: j178/prek-action@v3.0.0
         with:
           prek-version: 0.4.11
           extra-args: >-
@@ -32,5 +32,5 @@ jobs:
           UV_NO_CACHE: '1'
           UV_PYTHON: '3.14'
 
-      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
+      - uses: autofix-ci/action@v1.3.4
         if: always()

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
       - name: Run fixers
         uses: j178/prek-action@v3.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,26 +29,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: '**/pyproject.toml'
-
       - name: Lint
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
-          --verbose
+        uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece  # v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files
+            --hook-stage ${{ matrix.hook-stage }}
+            --verbose
         env:
           # Avoid intermittent uv distribution cache rename failures while
           # prek installs hook environments on Windows.
           UV_NO_CACHE: '1'
           UV_PYTHON: ${{ matrix.python-version }}
-
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()
 
   completion-lint:
     needs: build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
       - name: Lint
         uses: j178/prek-action@v3.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Lint
-        uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece  # v3.0.0
+        uses: j178/prek-action@v3.0.0
         with:
           prek-version: 0.4.11
           extra-args: >-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,48 +3,6 @@ fail_fast: true
 
 .uv_version: &uv_version uv==0.11.7
 
-# We use system Python, with required dependencies specified in pyproject.toml.
-# We therefore cannot use those dependencies in pre-commit CI.
-ci:
-  skip:
-    - actionlint
-    - sphinx-lint
-    - strict-kwargs-fix
-    - check-manifest
-    - custom-linters
-    - deptry
-    - doc8
-    - docs
-    - interrogate
-    - interrogate-docs
-    - linkcheck
-    - mypy
-    - mypy-docs
-    - pylint
-    - pyproject-fmt-fix
-    - pyright
-    - pyright-docs
-    - pyright-verifytypes
-    - ty
-    - ty-docs
-    - pyroma
-    - ruff-check-fix
-    - ruff-check-fix-docs
-    - ruff-format-fix
-    - ruff-format-fix-docs
-    - pydocstringformatter
-    - shellcheck
-    - shellcheck-docs
-    - shfmt
-    - shfmt-docs
-    - spelling
-    - vulture
-    - vulture-docs
-    - yamlfix
-    - zizmor
-    - pyrefly
-    - pyrefly-docs
-
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_install_hook_types: [pre-commit, pre-push]


### PR DESCRIPTION
## Summary

- run the existing lint-stage matrix with the immutable `j178/prek-action@v3.0.0` release and the repository's pinned prek 0.4.11
- add a single Ubuntu `autofix.ci` workflow that runs all pre-commit-stage fixers without fail-fast and publishes their patch through the autofix.ci App
- replace pre-commit.ci hook updates with Dependabot's supported `pre-commit` ecosystem
- remove the obsolete pre-commit.ci skip configuration and Lite action

## Why

This pilots the prek-native, tool-independent workflow agreed in adamtheturtle/Coding-Project-TODOs#8. A separate autofix producer avoids six matrix jobs competing to publish platform- or stage-specific patches, while the existing Ubuntu/Windows and pre-commit/pre-push/manual validation coverage remains intact.

## Deployment notes

Before merging:

- install the autofix.ci GitHub App for this repository or the VWS-Python organization: https://autofix.ci/setup
- after confirming autofix and Dependabot updates work, remove this repository from the pre-commit.ci GitHub App/service so duplicate checks and update PRs stop

## Validation

- `uv run --extra=dev prek run --files .github/dependabot.yml .github/workflows/autofix.yml .github/workflows/lint.yml .pre-commit-config.yaml --hook-stage pre-commit --verbose`
- `uv run --extra=dev -m pytest ci/test_custom_linters.py`
- installed pre-push hooks, including custom linters and manifest checks, run successfully during `git push`
