### PR TITLE
Run shfmt through uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies:


### PR DESCRIPTION
Run the `shfmt` pre-commit hook through `uv run --extra=dev` so it uses the project-pinned `shfmt-py` dependency. This removes reliance on an ambient executable and makes the hook consistent with the repository's other development-tool hooks without changing its formatting arguments. Validated with `uv run --extra=dev prek run shfmt --all-files`, the commit hooks, and `git diff --check`.
