### PR TITLE
Validate Model Target JWT signatures

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -174,8 +174,9 @@ successful in-process Model Target datasets include a Vuforia-shaped
 ``warning`` object after processing completes. This configuration is not
 supported by the Flask/Docker backend.
 Model Target API routes require a three-part JSON Web Token with JSON object
-header and payload parts and a non-``none`` ``alg`` value, such as the token
-returned by the mock OAuth2 route.
+header and payload parts, a non-``none`` ``alg`` value, and a non-empty
+base64url-encoded signature, such as the token returned by the mock OAuth2
+route.
 The mock does not verify token signatures, payload claims such as expiry, or
 token revocation.
 

--- a/newsfragments/model-target-jwt-signature.change
+++ b/newsfragments/model-target-jwt-signature.change
@@ -1,0 +1,1 @@
+Reject Model Target bearer tokens with empty or malformed JWT signatures.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -187,7 +187,7 @@ def _jwt_signature_error(*, bearer_token: str) -> str | None:
 
     try:
         padding = "=" * (-len(encoded_signature) % 4)
-        decoded_signature = base64.b64decode(
+        base64.b64decode(
             s=encoded_signature + padding,
             altchars=b"-_",
             validate=True,
@@ -195,8 +195,6 @@ def _jwt_signature_error(*, bearer_token: str) -> str | None:
     except ValueError:
         return "Signed JWT rejected: Invalid signature"
 
-    if not decoded_signature:
-        return "Signed JWT rejected: Invalid signature"
     return None
 
 

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -177,6 +177,30 @@ def _jwt_payload_error(*, bearer_token: str) -> str | None:
 
 
 @beartype
+def _jwt_signature_error(*, bearer_token: str) -> str | None:
+    """Return the Vuforia error for an invalid JSON Web Token
+    signature.
+    """
+    encoded_signature = bearer_token.rpartition(".")[2]
+    if not encoded_signature:
+        return "The signature must not be empty"
+
+    try:
+        padding = "=" * (-len(encoded_signature) % 4)
+        decoded_signature = base64.b64decode(
+            s=encoded_signature + padding,
+            altchars=b"-_",
+            validate=True,
+        )
+    except ValueError:
+        return "Signed JWT rejected: Invalid signature"
+
+    if not decoded_signature:
+        return "Signed JWT rejected: Invalid signature"
+    return None
+
+
+@beartype
 def _require_bearer_token(request: RequestData) -> _ResponseType | None:
     """Return an error response if the request has no bearer token."""
     auth_header = _get_header(request=request, name="Authorization")
@@ -205,21 +229,16 @@ def _require_bearer_token(request: RequestData) -> _ResponseType | None:
             target="jwt",
             details=None,
         )
-    jwt_header_error = _jwt_header_error(bearer_token=bearer_token)
-    if jwt_header_error is not None:
+    jwt_error = _jwt_header_error(bearer_token=bearer_token)
+    if jwt_error is None:
+        jwt_error = _jwt_payload_error(bearer_token=bearer_token)
+    if jwt_error is None:
+        jwt_error = _jwt_signature_error(bearer_token=bearer_token)
+    if jwt_error is not None:
         return _error_response(
             status_code=HTTPStatus.UNAUTHORIZED,
             code="401",
-            message=jwt_header_error,
-            target="jwt",
-            details=None,
-        )
-    jwt_payload_error = _jwt_payload_error(bearer_token=bearer_token)
-    if jwt_payload_error is not None:
-        return _error_response(
-            status_code=HTTPStatus.UNAUTHORIZED,
-            code="401",
-            message=jwt_payload_error,
+            message=jwt_error,
             target="jwt",
             details=None,
         )

--- a/tests/mock_vws/test_model_target_generation_failure.py
+++ b/tests/mock_vws/test_model_target_generation_failure.py
@@ -10,7 +10,7 @@ import requests
 
 from mock_vws import MockVWS, ModelTargetGenerationFailure
 
-_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
+_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.c2lnbmF0dXJl"
 _CREATE_URL = "https://vws.vuforia.com/modeltargets/datasets"
 _REQUEST_BODY: dict[str, Any] = {
     "name": "dataset-name",

--- a/tests/mock_vws/test_model_target_generation_warning.py
+++ b/tests/mock_vws/test_model_target_generation_warning.py
@@ -14,7 +14,7 @@ from mock_vws import (
     ModelTargetGenerationWarning,
 )
 
-_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
+_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.c2lnbmF0dXJl"
 _CREATE_URL = "https://vws.vuforia.com/modeltargets/datasets"
 _REQUEST_BODY: dict[str, Any] = {
     "name": "dataset-name",

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -19,7 +19,7 @@ from tests.mock_vws.fixtures.vuforia_backends import VuforiaBackend
 
 _VWS_HOST = "https://vws.vuforia.com"
 _DATASET_UUID = "0b12466eee5d49409a440927006ff5d8"
-_MOCK_BEARER_TOKEN = "eyJhbGciOiJtb2NrIn0.e30.signature"
+_MOCK_BEARER_TOKEN = "eyJhbGciOiJtb2NrIn0.e30.c2lnbmF0dXJl"
 
 
 def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
@@ -270,6 +270,16 @@ class TestAuthentication:
                 "Bearer eyJhbGciOiJSUzI1NiJ9.InZhbHVlIg.signature",
                 "Payload of JWS object is not a valid JSON object",
                 id="payload-not-json-object",
+            ),
+            pytest.param(
+                "Bearer eyJhbGciOiJSUzI1NiJ9.e30.",
+                "The signature must not be empty",
+                id="blank-signature",
+            ),
+            pytest.param(
+                "Bearer eyJhbGciOiJSUzI1NiJ9.e30.%",
+                "Signed JWT rejected: Invalid signature",
+                id="signature-not-base64",
             ),
         ],
     )

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -44,7 +44,7 @@ from tests.mock_vws.utils.usage_test_helpers import (
     processing_time_seconds,
 )
 
-_MODEL_TARGET_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
+_MODEL_TARGET_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.c2lnbmF0dXJl"
 _MODEL_TARGET_DATASET_REQUEST = {
     "name": "dataset-name",
     "targetSdk": "10.18",

--- a/tests/mock_vws/test_respx_mock_usage.py
+++ b/tests/mock_vws/test_respx_mock_usage.py
@@ -19,7 +19,7 @@ from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.image_matchers import ExactMatcher
 from mock_vws.target import VuMarkTarget
 
-_MODEL_TARGET_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.signature"
+_MODEL_TARGET_AUTHORIZATION = "Bearer eyJhbGciOiJtb2NrIn0.e30.c2lnbmF0dXJl"
 _MODEL_TARGET_DATASET_REQUEST = {
     "name": "dataset-name",
     "targetSdk": "10.18",


### PR DESCRIPTION
## Summary

- reject empty and malformed base64url JWT signature segments with Vuforia-compatible 401 responses
- add verified-fake cases that run against real Vuforia and both mock backends
- update mock bearer-token fixtures, documentation, and the changelog fragment for the stricter syntax

## Why

The Model Target mock already validated JWT header and payload segments, but accepted any signature segment, including an empty or malformed one. Real Vuforia distinguishes these cases and returns stable error messages, so matching them improves authentication fidelity toward #3192.

## Impact

Callers using malformed Model Target bearer tokens now receive the same observable errors as real Vuforia. The mock still does not cryptographically verify signatures or payload claims.

## Root cause

Bearer-token validation returned after checking only JWT structure, header, and payload. The signature segment was never decoded or checked for emptiness.

## Validation

- `uv run pytest -q tests/mock_vws/test_model_target_web_api.py::TestAuthentication::test_invalid_bearer_token tests/mock_vws/test_model_target_generation_failure.py tests/mock_vws/test_model_target_generation_warning.py tests/mock_vws/test_requests_mock_usage.py::TestModelTargetWebAPI tests/mock_vws/test_respx_mock_usage.py::TestModelTargetWebAPI` (44 passed, including live Vuforia)
- `uv run pytest -q tests/mock_vws/test_model_target_web_api.py --skip-real tests/mock_vws/test_model_target_generation_failure.py tests/mock_vws/test_model_target_generation_warning.py tests/mock_vws/test_requests_mock_usage.py::TestModelTargetWebAPI tests/mock_vws/test_respx_mock_usage.py::TestModelTargetWebAPI` (82 passed, 32 skipped)
- `uv run prek run --all-files`
- pre-push type and manifest checks
