### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -429,7 +429,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -307,6 +307,16 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8
@@ -426,10 +436,4 @@ repos:
         language: golang
         types: [hcl]
         additional_dependencies: [github.com/hashicorp/hcl/v2/cmd/hclfmt@v2.24.0]
-        stages: [pre-commit]
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -427,3 +427,9 @@ repos:
         types: [hcl]
         additional_dependencies: [github.com/hashicorp/hcl/v2/cmd/hclfmt@v2.24.0]
         stages: [pre-commit]
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pydocstyle==6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ lint.per-file-ignores."tests/**" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [ "NOD" ]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
@@ -525,3 +526,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/src/mock_vws/_services_validators/request_rate_validators.py
+++ b/src/mock_vws/_services_validators/request_rate_validators.py
@@ -25,7 +25,7 @@ class RequestRateLimiter:
     def __init__(
         self,
         *,
-        time_function: Callable[[], float] = time.monotonic,
+        time_function: Callable[[], float] = time.monotonic,  # noqa: NOD001
     ) -> None:
         """Initialize an empty rate limiter."""
         self._request_times: dict[str, deque[float]] = {}

--- a/src/mock_vws/decorators.py
+++ b/src/mock_vws/decorators.py
@@ -58,23 +58,23 @@ class MockVWS(ContextDecorator):
     def __init__(
         self,
         *,
-        base_vws_url: str = "https://vws.vuforia.com",
-        base_vwq_url: str = "https://cloudreco.vuforia.com",
-        cloud_query_failure_response: CloudQueryFailureResponse | None = None,
-        duplicate_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
-        query_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
-        processing_time_seconds: float = 2.0,
+        base_vws_url: str = "https://vws.vuforia.com",  # noqa: NOD001
+        base_vwq_url: str = "https://cloudreco.vuforia.com",  # noqa: NOD001
+        cloud_query_failure_response: CloudQueryFailureResponse | None = None,  # noqa: NOD001
+        duplicate_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,  # noqa: NOD001
+        query_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,  # noqa: NOD001
+        processing_time_seconds: float = 2.0,  # noqa: NOD001
         model_target_generation_failure: (
             ModelTargetGenerationFailure | None
-        ) = None,
+        ) = None,  # noqa: NOD001
         model_target_generation_warning: (
             ModelTargetGenerationWarning | None
-        ) = None,
-        target_tracking_rater: TargetTrackingRater = _BRISQUE_TRACKING_RATER,
-        real_http: bool = False,
-        response_delay_seconds: float = 0.0,
-        sleep_fn: Callable[[float], None] = time.sleep,
-        vumark_generation_failure: VuMarkGenerationFailure | None = None,
+        ) = None,  # noqa: NOD001
+        target_tracking_rater: TargetTrackingRater = _BRISQUE_TRACKING_RATER,  # noqa: NOD001
+        real_http: bool = False,  # noqa: NOD001
+        response_delay_seconds: float = 0.0,  # noqa: NOD001
+        sleep_fn: Callable[[float], None] = time.sleep,  # noqa: NOD001
+        vumark_generation_failure: VuMarkGenerationFailure | None = None,  # noqa: NOD001
     ) -> None:
         """Route requests to Vuforia's Web Service APIs to fakes of those
         APIs.


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.