### PR TITLE
Validate Model Target dataset field types

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -180,6 +180,12 @@ route.
 The mock does not verify token signatures, payload claims such as expiry, or
 token revocation.
 
+Dataset creation requests are validated for the required top-level ``models``,
+``name`` and ``targetSdk`` fields, for those fields' types, for each ``models``
+entry being a JSON object, and for the number of models.
+The mock does not validate the contents of each model, such as ``cadDataUrl``
+values, ``views``, or ``targetSdk`` version numbers.
+
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.
 

--- a/newsfragments/model-target-dataset-field-types.change
+++ b/newsfragments/model-target-dataset-field-types.change
@@ -1,0 +1,1 @@
+Reject Model Target dataset creation requests with wrongly typed ``name``, ``targetSdk`` or ``models`` entry values.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -363,18 +363,37 @@ def _validate_dataset_request(
     if missing_details:
         return _validation_error_response(details=missing_details)
 
+    type_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": f"/{field}: error.expected.jsstring",
+        }
+        for field in ("name", "targetSdk")
+        if not isinstance(request_json[field], str)
+    ]
+
     models_value = request_json["models"]
     if not isinstance(models_value, list):
-        return _validation_error_response(
-            details=[
-                {
-                    "code": "VALIDATION_ERROR",
-                    "message": "/models: error.expected.jsarray",
-                },
-            ],
+        type_details.append(
+            {
+                "code": "VALIDATION_ERROR",
+                "message": "/models: error.expected.jsarray",
+            },
         )
+        return _validation_error_response(details=type_details)
 
     models: list[Any] = [*models_value]
+    type_details.extend(
+        {
+            "code": "VALIDATION_ERROR",
+            "message": f"/models({index}): error.expected.jsobject",
+        }
+        for index, model in enumerate(iterable=models)
+        if not isinstance(model, dict)
+    )
+    if type_details:
+        return _validation_error_response(details=type_details)
+
     model_count = len(models)
 
     if dataset_type == ModelTargetDatasetType.STANDARD and model_count != 1:

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -480,6 +480,41 @@ class TestErrorResponses:
                 {"exactly one model should be provided"},
                 id="standard-zero-models",
             ),
+            pytest.param(
+                {**_UNAUTHENTICATED_DATASET_REQUEST, "name": 1},
+                {"/name: error.expected.jsstring"},
+                id="name-not-string",
+            ),
+            pytest.param(
+                {**_UNAUTHENTICATED_DATASET_REQUEST, "targetSdk": ["10.18"]},
+                {"/targetSdk: error.expected.jsstring"},
+                id="target-sdk-not-string",
+            ),
+            pytest.param(
+                {"name": None, "targetSdk": None, "models": "model"},
+                {
+                    "/models: error.expected.jsarray",
+                    "/name: error.expected.jsstring",
+                    "/targetSdk: error.expected.jsstring",
+                },
+                id="multiple-type-errors",
+            ),
+            pytest.param(
+                {**_UNAUTHENTICATED_DATASET_REQUEST, "models": ["model"]},
+                {"/models(0): error.expected.jsobject"},
+                id="model-not-object",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        *_UNAUTHENTICATED_DATASET_REQUEST["models"],
+                        "model",
+                    ],
+                },
+                {"/models(1): error.expected.jsobject"},
+                id="second-model-not-object",
+            ),
         ],
     )
     def test_invalid_dataset_request(


### PR DESCRIPTION
Towards #3193.

The Model Target dataset creation mock validated that the required top-level fields were present and that `models` was a list, but not the types of `name`, `targetSdk`, or the individual `models` entries.

This adds:

- `/name: error.expected.jsstring` and `/targetSdk: error.expected.jsstring` details for non-string values.
- `/models(<index>): error.expected.jsobject` details for entries which are not JSON objects.
- Reporting of all type errors in a single validation error response, matching the Play JSON-style shape already used for `/models: error.expected.jsarray`.

`docs/source/differences-to-vws.rst` now states what dataset creation validation the mock does and does not perform, so the remaining out-of-scope validation (model contents such as `cadDataUrl`, `views`, and `targetSdk` version numbers) is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)