### PR TITLE
Require explicit content_type in test helpers

### DIFF
--- a/tests/mock_vws/test_add_target.py
+++ b/tests/mock_vws/test_add_target.py
@@ -39,7 +39,7 @@ def _add_target_to_vws(
     *,
     vws_client: VWS,
     data: dict[str, Any],
-    content_type: str = "application/json",
+    content_type: str,
 ) -> Response:
     """Return a response from a request to the endpoint to add a target.
 
@@ -195,7 +195,11 @@ class TestMissingData:
         data.pop(data_to_remove)
 
         with pytest.raises(expected_exception=FailError) as exc:
-            _add_target_to_vws(vws_client=vws_client, data=data)
+            _add_target_to_vws(
+                vws_client=vws_client,
+                data=data,
+                content_type="application/json",
+            )
 
         assert_vws_failure(
             response=exc.value.response,
@@ -233,7 +237,11 @@ class TestWidth:
         }
 
         with pytest.raises(expected_exception=FailError) as exc:
-            _add_target_to_vws(vws_client=vws_client, data=data)
+            _add_target_to_vws(
+                vws_client=vws_client,
+                data=data,
+                content_type="application/json",
+            )
 
         assert_vws_failure(
             response=exc.value.response,
@@ -343,10 +351,18 @@ class TestTargetName:
 
         if status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
             with pytest.raises(expected_exception=ServerError) as exc:
-                _add_target_to_vws(vws_client=vws_client, data=data)
+                _add_target_to_vws(
+                    vws_client=vws_client,
+                    data=data,
+                    content_type="application/json",
+                )
         else:
             with pytest.raises(expected_exception=FailError) as exc:
-                _add_target_to_vws(vws_client=vws_client, data=data)
+                _add_target_to_vws(
+                    vws_client=vws_client,
+                    data=data,
+                    content_type="application/json",
+                )
 
         assert_vws_failure(
             response=exc.value.response,
@@ -573,7 +589,11 @@ class TestImage:
         }
 
         with pytest.raises(expected_exception=BadImageError) as exc:
-            _add_target_to_vws(vws_client=vws_client, data=data)
+            _add_target_to_vws(
+                vws_client=vws_client,
+                data=data,
+                content_type="application/json",
+            )
 
         assert_vws_failure(
             response=exc.value.response,
@@ -600,7 +620,11 @@ class TestImage:
         }
 
         with pytest.raises(expected_exception=FailError) as exc:
-            _add_target_to_vws(vws_client=vws_client, data=data)
+            _add_target_to_vws(
+                vws_client=vws_client,
+                data=data,
+                content_type="application/json",
+            )
 
         assert_vws_failure(
             response=exc.value.response,
@@ -648,7 +672,11 @@ class TestImage:
         }
 
         with pytest.raises(expected_exception=FailError) as exc:
-            _add_target_to_vws(vws_client=vws_client, data=data)
+            _add_target_to_vws(
+                vws_client=vws_client,
+                data=data,
+                content_type="application/json",
+            )
 
         assert_vws_failure(
             response=exc.value.response,
@@ -749,7 +777,9 @@ class TestActiveFlag:
             "image": image_data_encoded,
         }
 
-        response = _add_target_to_vws(vws_client=vws_client, data=data)
+        response = _add_target_to_vws(
+            vws_client=vws_client, data=data, content_type="application/json"
+        )
         response_json = json.loads(s=response.text)
         target_id = response_json["target_id"]
         target_details = vws_client.get_target_record(target_id=target_id)
@@ -774,7 +804,9 @@ class TestActiveFlag:
             "active_flag": None,
         }
 
-        response = _add_target_to_vws(vws_client=vws_client, data=data)
+        response = _add_target_to_vws(
+            vws_client=vws_client, data=data, content_type="application/json"
+        )
 
         response_json = json.loads(s=response.text)
         target_id = response_json["target_id"]
@@ -812,7 +844,11 @@ class TestUnexpectedData:
         }
 
         with pytest.raises(expected_exception=FailError) as exc:
-            _add_target_to_vws(vws_client=vws_client, data=data)
+            _add_target_to_vws(
+                vws_client=vws_client,
+                data=data,
+                content_type="application/json",
+            )
 
         assert_vws_failure(
             response=exc.value.response,
@@ -875,6 +911,7 @@ class TestApplicationMetadata:
         response = _add_target_to_vws(
             vws_client=vws_client,
             data=request_data,
+            content_type="application/json",
         )
 
         assert_success(response=response)
@@ -902,7 +939,11 @@ class TestApplicationMetadata:
         }
 
         with pytest.raises(expected_exception=FailError) as exc:
-            _add_target_to_vws(vws_client=vws_client, data=data)
+            _add_target_to_vws(
+                vws_client=vws_client,
+                data=data,
+                content_type="application/json",
+            )
 
         assert_vws_failure(
             response=exc.value.response,

--- a/tests/mock_vws/test_update_target.py
+++ b/tests/mock_vws/test_update_target.py
@@ -38,7 +38,7 @@ def _update_target(
     vws_client: VWS,
     data: dict[str, Any],
     target_id: str,
-    content_type: str = "application/json",
+    content_type: str,
 ) -> Response:
     """Make a request to the endpoint to update a target.
 
@@ -160,6 +160,7 @@ class TestUpdate:
             vws_client=vws_client,
             data={},
             target_id=target_id,
+            content_type="application/json",
         )
 
         assert_vws_response(
@@ -203,6 +204,7 @@ class TestUnexpectedData:
                 vws_client=vws_client,
                 data={"extra_thing": 1},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(
@@ -239,6 +241,7 @@ class TestWidth:
                 vws_client=vws_client,
                 data={"width": width},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(
@@ -321,6 +324,7 @@ class TestActiveFlag:
                 vws_client=vws_client,
                 data={"active_flag": desired_active_flag},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(
@@ -375,6 +379,7 @@ class TestApplicationMetadata:
                 vws_client=vws_client,
                 data={"application_metadata": invalid_metadata},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(
@@ -538,6 +543,7 @@ class TestTargetName:
                 vws_client=vws_client,
                 data={"name": name},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(
@@ -759,6 +765,7 @@ class TestImage:
                 vws_client=vws_client,
                 data={"image": not_base64_encoded_processable},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(
@@ -787,6 +794,7 @@ class TestImage:
                 vws_client=vws_client,
                 data={"image": not_base64_encoded_not_processable},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(
@@ -835,6 +843,7 @@ class TestImage:
                 vws_client=vws_client,
                 data={"image": invalid_type_image},
                 target_id=target_id,
+                content_type="application/json",
             )
 
         assert_vws_failure(


### PR DESCRIPTION
Remove the `content_type="application/json"` default from the `_add_target_to_vws` and `_update_target` test helpers, and pass the content type explicitly at every call site.

This is the `tests/` portion of #3326, split out so it can land independently of the linter configuration changes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)