### PR TITLE
Move MockVWS to a public module path

### DIFF
--- a/src/mock_vws/__init__.py
+++ b/src/mock_vws/__init__.py
@@ -1,8 +1,8 @@
 """Tools for using a fake implementation of Vuforia."""
 
 from mock_vws._mock_common import MissingSchemeError
-from mock_vws._requests_mock_server.decorators import MockVWS
 from mock_vws.cloud_query import CloudQueryFailureResponse
+from mock_vws.decorators import MockVWS
 from mock_vws.model_target import (
     ModelTargetGenerationFailure,
     ModelTargetGenerationWarning,

--- a/src/mock_vws/decorators.py
+++ b/src/mock_vws/decorators.py
@@ -13,6 +13,12 @@ from requests import PreparedRequest
 from responses import RequestsMock
 
 from mock_vws._mock_common import MissingSchemeError, RequestData
+from mock_vws._requests_mock_server.mock_web_query_api import (
+    MockVuforiaWebQueryAPI,
+)
+from mock_vws._requests_mock_server.mock_web_services_api import (
+    MockVuforiaWebServicesAPI,
+)
 from mock_vws._respx_mock_server.decorators import start_respx_router
 from mock_vws.cloud_query import CloudQueryFailureResponse
 from mock_vws.database import CloudDatabase, VuMarkDatabase
@@ -30,9 +36,6 @@ from mock_vws.target_raters import (
     TargetTrackingRater,
 )
 from mock_vws.vumark import VuMarkGenerationFailure
-
-from .mock_web_query_api import MockVuforiaWebQueryAPI
-from .mock_web_services_api import MockVuforiaWebServicesAPI
 
 if TYPE_CHECKING:
     import respx


### PR DESCRIPTION
`MockVWS` was defined in `mock_vws._requests_mock_server.decorators`, so the class's `__module__` pointed through a private package even though the class is part of the public API.

This moves the module to `mock_vws.decorators` and rewrites the two relative imports of the private API handlers as absolute imports. The documented `from mock_vws import MockVWS` import is unchanged, so this is not a public API break, and nothing outside `__init__.py` referenced the old module path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)