### PR TITLE
Drop the suppressions that are no longer needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
-    "no-defaults==1.0.1",
+    "no-defaults==1.1.0",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pydocstyle==6.3",

--- a/src/mock_vws/decorators.py
+++ b/src/mock_vws/decorators.py
@@ -58,23 +58,23 @@ class MockVWS(ContextDecorator):
     def __init__(
         self,
         *,
-        base_vws_url: str = "https://vws.vuforia.com",  # noqa: NOD001
-        base_vwq_url: str = "https://cloudreco.vuforia.com",  # noqa: NOD001
-        cloud_query_failure_response: CloudQueryFailureResponse | None = None,  # noqa: NOD001
-        duplicate_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,  # noqa: NOD001
-        query_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,  # noqa: NOD001
-        processing_time_seconds: float = 2.0,  # noqa: NOD001
+        base_vws_url: str = "https://vws.vuforia.com",
+        base_vwq_url: str = "https://cloudreco.vuforia.com",
+        cloud_query_failure_response: CloudQueryFailureResponse | None = None,
+        duplicate_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
+        query_match_checker: ImageMatcher = _STRUCTURAL_SIMILARITY_MATCHER,
+        processing_time_seconds: float = 2.0,
         model_target_generation_failure: (
             ModelTargetGenerationFailure | None
-        ) = None,  # noqa: NOD001
+        ) = None,
         model_target_generation_warning: (
             ModelTargetGenerationWarning | None
-        ) = None,  # noqa: NOD001
-        target_tracking_rater: TargetTrackingRater = _BRISQUE_TRACKING_RATER,  # noqa: NOD001
-        real_http: bool = False,  # noqa: NOD001
-        response_delay_seconds: float = 0.0,  # noqa: NOD001
-        sleep_fn: Callable[[float], None] = time.sleep,  # noqa: NOD001
-        vumark_generation_failure: VuMarkGenerationFailure | None = None,  # noqa: NOD001
+        ) = None,
+        target_tracking_rater: TargetTrackingRater = _BRISQUE_TRACKING_RATER,
+        real_http: bool = False,
+        response_delay_seconds: float = 0.0,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        vumark_generation_failure: VuMarkGenerationFailure | None = None,
     ) -> None:
         """Route requests to Vuforia's Web Service APIs to fakes of those
         APIs.


### PR DESCRIPTION
Bumps `no-defaults` to 1.1.0 and removes 13 of the 14 `NOD001` suppressions — not by collapsing them, but because they turned out to be dead.

Moving `MockVWS` to a public module path (#3330) made every directive in `decorators.py` unnecessary: `private_only = true` does not check a public class, so those parameters were never violations after the move. 1.0.1 had no way to report that. 1.1.0 flags them as `NOD002` and `--fix` removes them.

The one remaining suppression, `time_function` in `_services_validators/request_rate_validators.py`, is in a private module and still load-bearing.

**14 → 1.** Comment-only apart from the version pin; ruff clean and the mock suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)