### PR TITLE
Validate Model Target model fields

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -183,8 +183,11 @@ token revocation.
 Dataset creation requests are validated for the required top-level ``models``,
 ``name`` and ``targetSdk`` fields, for those fields' types, for each ``models``
 entry being a JSON object, and for the number of models.
-The mock does not validate the contents of each model, such as ``cadDataUrl``
-values, ``views``, or ``targetSdk`` version numbers.
+Each model is validated for the required ``cadDataUrl`` and ``name`` fields,
+for those fields' types, and for ``views`` being a JSON array when it is given.
+The mock does not validate the contents of each model further, such as whether
+``cadDataUrl`` values are reachable, the contents of ``views`` entries, or
+``targetSdk`` version numbers.
 
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.

--- a/newsfragments/model-target-model-fields.change
+++ b/newsfragments/model-target-model-fields.change
@@ -1,0 +1,1 @@
+Reject Model Target dataset creation requests with models which are missing ``cadDataUrl`` or ``name``, or which have wrongly typed ``cadDataUrl``, ``name`` or ``views`` values.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -346,12 +346,80 @@ def _load_request_json(request: RequestData) -> dict[str, Any] | _ResponseType:
 
 
 @beartype
-def _validate_dataset_request(
+def _model_field_details(*, models: list[Any]) -> list[dict[str, str]]:
+    """Return validation details for the fields of each model."""
+    missing_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": f"/models({index})/{field}: element is required",
+        }
+        for index, model in enumerate(iterable=models)
+        for field in ("cadDataUrl", "name")
+        if field not in model
+    ]
+    if missing_details:
+        return missing_details
+
+    string_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": f"/models({index})/{field}: error.expected.jsstring",
+        }
+        for index, model in enumerate(iterable=models)
+        for field in ("cadDataUrl", "name")
+        if not isinstance(model[field], str)
+    ]
+    views_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": f"/models({index})/views: error.expected.jsarray",
+        }
+        for index, model in enumerate(iterable=models)
+        if "views" in model and not isinstance(model["views"], list)
+    ]
+    return string_details + views_details
+
+
+@beartype
+def _model_count_details(
+    *,
+    models: list[Any],
+    dataset_type: ModelTargetDatasetType,
+) -> list[dict[str, str]]:
+    """Return validation details for the number of models."""
+    model_count = len(models)
+
+    if dataset_type == ModelTargetDatasetType.STANDARD and model_count != 1:
+        return [
+            {
+                "code": "VALIDATION_ERROR",
+                "message": "exactly one model should be provided",
+            },
+        ]
+
+    if (
+        dataset_type == ModelTargetDatasetType.ADVANCED
+        and not 1 <= model_count <= _MAX_ADVANCED_MODEL_COUNT
+    ):
+        return [
+            {
+                "code": "VALIDATION_ERROR",
+                "message": (
+                    "models must contain between 1 and "
+                    f"{_MAX_ADVANCED_MODEL_COUNT} entries"
+                ),
+            },
+        ]
+
+    return []
+
+
+@beartype
+def _top_level_details(
     *,
     request_json: dict[str, Any],
-    dataset_type: ModelTargetDatasetType,
-) -> _ResponseType | None:
-    """Validate the dataset request enough for useful mock feedback."""
+) -> list[dict[str, str]]:
+    """Return validation details for the top-level dataset fields."""
     missing_details = [
         {
             "code": "VALIDATION_ERROR",
@@ -361,7 +429,7 @@ def _validate_dataset_request(
         if field not in request_json
     ]
     if missing_details:
-        return _validation_error_response(details=missing_details)
+        return missing_details
 
     type_details = [
         {
@@ -380,7 +448,7 @@ def _validate_dataset_request(
                 "message": "/models: error.expected.jsarray",
             },
         )
-        return _validation_error_response(details=type_details)
+        return type_details
 
     models: list[Any] = [*models_value]
     type_details.extend(
@@ -391,36 +459,26 @@ def _validate_dataset_request(
         for index, model in enumerate(iterable=models)
         if not isinstance(model, dict)
     )
-    if type_details:
-        return _validation_error_response(details=type_details)
+    return type_details
 
-    model_count = len(models)
 
-    if dataset_type == ModelTargetDatasetType.STANDARD and model_count != 1:
-        return _validation_error_response(
-            details=[
-                {
-                    "code": "VALIDATION_ERROR",
-                    "message": "exactly one model should be provided",
-                },
-            ],
+@beartype
+def _validate_dataset_request(
+    *,
+    request_json: dict[str, Any],
+    dataset_type: ModelTargetDatasetType,
+) -> _ResponseType | None:
+    """Validate the dataset request enough for useful mock feedback."""
+    details = _top_level_details(request_json=request_json)
+    if not details:
+        models: list[Any] = [*request_json["models"]]
+        details = _model_field_details(models=models) or _model_count_details(
+            models=models,
+            dataset_type=dataset_type,
         )
 
-    if (
-        dataset_type == ModelTargetDatasetType.ADVANCED
-        and not 1 <= model_count <= _MAX_ADVANCED_MODEL_COUNT
-    ):
-        return _validation_error_response(
-            details=[
-                {
-                    "code": "VALIDATION_ERROR",
-                    "message": (
-                        "models must contain between 1 and "
-                        f"{_MAX_ADVANCED_MODEL_COUNT} entries"
-                    ),
-                },
-            ],
-        )
+    if details:
+        return _validation_error_response(details=details)
 
     return None
 

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -45,24 +45,26 @@ def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
     }
 
 
-_UNAUTHENTICATED_DATASET_REQUEST = {
-    "name": "dataset-name",
-    "targetSdk": "10.18",
-    "models": [
+_MODEL: dict[str, Any] = {
+    "name": "model-name",
+    "cadDataUrl": "https://example.com/model.glb",
+    "views": [
         {
-            "name": "model-name",
-            "cadDataUrl": "https://example.com/model.glb",
-            "views": [
-                {
-                    "name": "view-name",
-                    "guideViewPosition": {
-                        "translation": [0, 0, 5],
-                        "rotation": [0, 0, 0, 1],
-                    },
-                },
-            ],
+            "name": "view-name",
+            "guideViewPosition": {
+                "translation": [0, 0, 5],
+                "rotation": [0, 0, 0, 1],
+            },
         },
     ],
+}
+
+_EMPTY_MODEL: dict[str, Any] = {}
+
+_UNAUTHENTICATED_DATASET_REQUEST: dict[str, Any] = {
+    "name": "dataset-name",
+    "targetSdk": "10.18",
+    "models": [_MODEL],
 }
 
 
@@ -514,6 +516,46 @@ class TestErrorResponses:
                 },
                 {"/models(1): error.expected.jsobject"},
                 id="second-model-not-object",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [_EMPTY_MODEL],
+                },
+                {
+                    "/models(0)/cadDataUrl: element is required",
+                    "/models(0)/name: element is required",
+                },
+                id="model-missing-fields",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "cadDataUrl": 1,
+                        },
+                    ],
+                },
+                {"/models(0)/cadDataUrl: error.expected.jsstring"},
+                id="model-cad-data-url-not-string",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [{**_MODEL, "name": None}],
+                },
+                {"/models(0)/name: error.expected.jsstring"},
+                id="model-name-not-string",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [{**_MODEL, "views": "view-name"}],
+                },
+                {"/models(0)/views: error.expected.jsarray"},
+                id="model-views-not-array",
             ),
         ],
     )


### PR DESCRIPTION
Reject Model Target dataset creation requests where a model is missing `cadDataUrl` or `name`, where those fields are not strings, or where `views` is present but is not an array.

The new validation details use the same Play JSON-style messages as the existing top-level field validation (`/models(0)/name: element is required`, `/models(0)/cadDataUrl: error.expected.jsstring`, `/models(0)/views: error.expected.jsarray`), and are reported together in one validation error response, following the same pattern as #3327.

`_validate_dataset_request` is split into `_top_level_details`, `_model_field_details` and `_model_count_details` so each step returns details rather than a response.

New cases are added to the existing `TestErrorResponses::test_invalid_dataset_request` parametrisation, so they run against real Vuforia as well as both mock backends once Model Target credentials are available in CI. Locally the "Real Vuforia" parameters fail on missing credentials, as they do on `main`.

`docs/source/differences-to-vws.rst` is updated to narrow the documented limitation: model contents are now partly validated, and what remains unvalidated (`cadDataUrl` reachability, `views` entry contents, `targetSdk` version numbers) is listed.

Towards #3193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)