### PR TITLE
Validate Model Target guide view fields

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -185,9 +185,11 @@ Dataset creation requests are validated for the required top-level ``models``,
 entry being a JSON object, and for the number of models.
 Each model is validated for the required ``cadDataUrl`` and ``name`` fields,
 for those fields' types, and for ``views`` being a JSON array when it is given.
+Each ``views`` entry is validated for being a JSON object, for the required
+``guideViewPosition`` and ``name`` fields, and for those fields' types.
 The mock does not validate the contents of each model further, such as whether
-``cadDataUrl`` values are reachable, the contents of ``views`` entries, or
-``targetSdk`` version numbers.
+``cadDataUrl`` values are reachable, the contents of ``guideViewPosition``
+objects, or ``targetSdk`` version numbers.
 
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.

--- a/newsfragments/model-target-view-fields.change
+++ b/newsfragments/model-target-view-fields.change
@@ -1,0 +1,1 @@
+Reject Model Target dataset creation requests with ``views`` entries which are not JSON objects, which are missing ``guideViewPosition`` or ``name``, or which have wrongly typed ``guideViewPosition`` or ``name`` values.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -381,6 +381,69 @@ def _model_field_details(*, models: list[Any]) -> list[dict[str, str]]:
 
 
 @beartype
+def _view_details(*, models: list[Any]) -> list[dict[str, str]]:
+    """Return validation details for the guide views of each model."""
+    views = [
+        (model_index, view_index, view)
+        for model_index, model in enumerate(iterable=models)
+        for view_index, view in enumerate(iterable=model.get("views", []))
+    ]
+
+    object_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({model_index})/views({view_index}): "
+                "error.expected.jsobject"
+            ),
+        }
+        for model_index, view_index, view in views
+        if not isinstance(view, dict)
+    ]
+    if object_details:
+        return object_details
+
+    missing_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({model_index})/views({view_index})/{field}: "
+                "element is required"
+            ),
+        }
+        for model_index, view_index, view in views
+        for field in ("guideViewPosition", "name")
+        if field not in view
+    ]
+    if missing_details:
+        return missing_details
+
+    name_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({model_index})/views({view_index})/name: "
+                "error.expected.jsstring"
+            ),
+        }
+        for model_index, view_index, view in views
+        if not isinstance(view["name"], str)
+    ]
+    position_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({model_index})/views({view_index})"
+                "/guideViewPosition: error.expected.jsobject"
+            ),
+        }
+        for model_index, view_index, view in views
+        if not isinstance(view["guideViewPosition"], dict)
+    ]
+    return name_details + position_details
+
+
+@beartype
 def _model_count_details(
     *,
     models: list[Any],
@@ -472,9 +535,13 @@ def _validate_dataset_request(
     details = _top_level_details(request_json=request_json)
     if not details:
         models: list[Any] = [*request_json["models"]]
-        details = _model_field_details(models=models) or _model_count_details(
-            models=models,
-            dataset_type=dataset_type,
+        details = (
+            _model_field_details(models=models)
+            or _view_details(models=models)
+            or _model_count_details(
+                models=models,
+                dataset_type=dataset_type,
+            )
         )
 
     if details:

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -22,6 +22,15 @@ _DATASET_UUID = "0b12466eee5d49409a440927006ff5d8"
 _MOCK_BEARER_TOKEN = "eyJhbGciOiJtb2NrIn0.e30.c2lnbmF0dXJl"
 
 
+_VIEW: dict[str, Any] = {
+    "name": "view-name",
+    "guideViewPosition": {
+        "translation": [0, 0, 5],
+        "rotation": [0, 0, 0, 1],
+    },
+}
+
+
 def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
     """Return a standard Model Target dataset request."""
     return {
@@ -31,15 +40,7 @@ def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
             {
                 "name": "model-name",
                 "cadDataUrl": cad_data_url,
-                "views": [
-                    {
-                        "name": "view-name",
-                        "guideViewPosition": {
-                            "translation": [0, 0, 5],
-                            "rotation": [0, 0, 0, 1],
-                        },
-                    },
-                ],
+                "views": [_VIEW],
             },
         ],
     }
@@ -48,18 +49,14 @@ def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
 _MODEL: dict[str, Any] = {
     "name": "model-name",
     "cadDataUrl": "https://example.com/model.glb",
-    "views": [
-        {
-            "name": "view-name",
-            "guideViewPosition": {
-                "translation": [0, 0, 5],
-                "rotation": [0, 0, 0, 1],
-            },
-        },
-    ],
+    "views": [_VIEW],
 }
 
 _EMPTY_MODEL: dict[str, Any] = {}
+
+_EMPTY_VIEW: dict[str, Any] = {}
+
+_EMPTY_GUIDE_VIEW_POSITION: list[Any] = []
 
 _UNAUTHENTICATED_DATASET_REQUEST: dict[str, Any] = {
     "name": "dataset-name",
@@ -556,6 +553,64 @@ class TestErrorResponses:
                 },
                 {"/models(0)/views: error.expected.jsarray"},
                 id="model-views-not-array",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [{**_MODEL, "views": ["view-name"]}],
+                },
+                {"/models(0)/views(0): error.expected.jsobject"},
+                id="view-not-object",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [{**_MODEL, "views": [_EMPTY_VIEW]}],
+                },
+                {
+                    (
+                        "/models(0)/views(0)/guideViewPosition: "
+                        "element is required"
+                    ),
+                    "/models(0)/views(0)/name: element is required",
+                },
+                id="view-missing-fields",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {**_MODEL, "views": [{**_VIEW, "name": 1}]},
+                    ],
+                },
+                {"/models(0)/views(0)/name: error.expected.jsstring"},
+                id="view-name-not-string",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "views": [
+                                _VIEW,
+                                {
+                                    **_VIEW,
+                                    "guideViewPosition": (
+                                        _EMPTY_GUIDE_VIEW_POSITION
+                                    ),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    (
+                        "/models(0)/views(1)/guideViewPosition: "
+                        "error.expected.jsobject"
+                    ),
+                },
+                id="view-guide-view-position-not-object",
             ),
         ],
     )


### PR DESCRIPTION
Reject Model Target dataset creation requests where a `views` entry is not a JSON object, is missing `guideViewPosition` or `name`, or has a wrongly typed `guideViewPosition` or `name`, using the same Play JSON-style validation messages as the existing top-level and model field validation.

The new cases are added to the verified fake `TestErrorResponses::test_invalid_dataset_request` parametrization, so they run against real Vuforia and both mock backends. `docs/source/differences-to-vws.rst` now records that the contents of `guideViewPosition` objects remain out of scope.

Towards #3193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)