### PR TITLE
Remove the last default instead of suppressing it

### DIFF
--- a/src/mock_vws/_services_validators/request_rate_validators.py
+++ b/src/mock_vws/_services_validators/request_rate_validators.py
@@ -1,7 +1,6 @@
 """Validators for the VWS per-second request rate."""
 
 import threading
-import time
 from collections import deque
 from collections.abc import Callable, Iterable, Mapping
 
@@ -25,7 +24,7 @@ class RequestRateLimiter:
     def __init__(
         self,
         *,
-        time_function: Callable[[], float] = time.monotonic,  # noqa: NOD001
+        time_function: Callable[[], float],
     ) -> None:
         """Initialize an empty rate limiter."""
         self._request_times: dict[str, deque[float]] = {}

--- a/src/mock_vws/target_manager.py
+++ b/src/mock_vws/target_manager.py
@@ -1,5 +1,6 @@
 """A fake implementation of a Vuforia target manager."""
 
+import time
 from typing import TYPE_CHECKING
 
 from beartype import beartype
@@ -27,7 +28,9 @@ class TargetManager:
         self._cloud_databases: set[CloudDatabase] = set()
         self._vumark_databases: set[VuMarkDatabase] = set()
         self._model_target_datasets: dict[str, ModelTargetDataset] = {}
-        self._request_rate_limiter = RequestRateLimiter()
+        self._request_rate_limiter = RequestRateLimiter(
+            time_function=time.monotonic,
+        )
 
     @property
     def request_rate_limiter(self) -> RequestRateLimiter:


### PR DESCRIPTION
Removes the repository's only remaining `NOD001` suppression by removing the default for real.

`RequestRateLimiter` lives in `_services_validators`, a private module, so requiring `time_function` is not an API change. It has two construction sites: the test already passed a fake clock, and `target_manager.py` now passes `time.monotonic` explicitly.

`time` is no longer used in `request_rate_validators.py` once the default is gone, so the import moves to `target_manager.py`.

**1 → 0.** mypy clean, ruff clean. The one failing test, `TestDataTypes::test_text[vumark_generate_instance]`, fails identically on `main` with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)