### PR TITLE
Validate Model Target guide view position fields

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -187,9 +187,12 @@ Each model is validated for the required ``cadDataUrl`` and ``name`` fields,
 for those fields' types, and for ``views`` being a JSON array when it is given.
 Each ``views`` entry is validated for being a JSON object, for the required
 ``guideViewPosition`` and ``name`` fields, and for those fields' types.
+Each ``guideViewPosition`` object is validated for the required ``rotation``
+and ``translation`` fields, and for those fields being JSON arrays.
 The mock does not validate the contents of each model further, such as whether
-``cadDataUrl`` values are reachable, the contents of ``guideViewPosition``
-objects, or ``targetSdk`` version numbers.
+``cadDataUrl`` values are reachable, the lengths of ``rotation`` and
+``translation`` arrays or the types of their elements, or ``targetSdk``
+version numbers.
 
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.

--- a/newsfragments/model-target-guide-view-position-fields.change
+++ b/newsfragments/model-target-guide-view-position-fields.change
@@ -1,0 +1,1 @@
+Reject Model Target dataset creation requests with ``guideViewPosition`` objects which are missing ``rotation`` or ``translation``, or which have ``rotation`` or ``translation`` values that are not JSON arrays.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -444,6 +444,47 @@ def _view_details(*, models: list[Any]) -> list[dict[str, str]]:
 
 
 @beartype
+def _guide_view_position_details(
+    *,
+    models: list[Any],
+) -> list[dict[str, str]]:
+    """Return validation details for the guide view positions."""
+    positions = [
+        (model_index, view_index, view["guideViewPosition"])
+        for model_index, model in enumerate(iterable=models)
+        for view_index, view in enumerate(iterable=model.get("views", []))
+    ]
+
+    missing_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({model_index})/views({view_index})"
+                f"/guideViewPosition/{field}: element is required"
+            ),
+        }
+        for model_index, view_index, position in positions
+        for field in ("rotation", "translation")
+        if field not in position
+    ]
+    if missing_details:
+        return missing_details
+
+    return [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({model_index})/views({view_index})"
+                f"/guideViewPosition/{field}: error.expected.jsarray"
+            ),
+        }
+        for model_index, view_index, position in positions
+        for field in ("rotation", "translation")
+        if not isinstance(position[field], list)
+    ]
+
+
+@beartype
 def _model_count_details(
     *,
     models: list[Any],
@@ -538,6 +579,7 @@ def _validate_dataset_request(
         details = (
             _model_field_details(models=models)
             or _view_details(models=models)
+            or _guide_view_position_details(models=models)
             or _model_count_details(
                 models=models,
                 dataset_type=dataset_type,

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -58,6 +58,8 @@ _EMPTY_VIEW: dict[str, Any] = {}
 
 _EMPTY_GUIDE_VIEW_POSITION: list[Any] = []
 
+_EMPTY_GUIDE_VIEW_POSITION_OBJECT: dict[str, Any] = {}
+
 _UNAUTHENTICATED_DATASET_REQUEST: dict[str, Any] = {
     "name": "dataset-name",
     "targetSdk": "10.18",
@@ -611,6 +613,87 @@ class TestErrorResponses:
                     ),
                 },
                 id="view-guide-view-position-not-object",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "views": [
+                                {
+                                    **_VIEW,
+                                    "guideViewPosition": (
+                                        _EMPTY_GUIDE_VIEW_POSITION_OBJECT
+                                    ),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    (
+                        "/models(0)/views(0)/guideViewPosition/rotation: "
+                        "element is required"
+                    ),
+                    (
+                        "/models(0)/views(0)/guideViewPosition/translation: "
+                        "element is required"
+                    ),
+                },
+                id="guide-view-position-missing-fields",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "views": [
+                                {
+                                    **_VIEW,
+                                    "guideViewPosition": {
+                                        "rotation": "0,0,0,1",
+                                        "translation": [0, 0, 5],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    (
+                        "/models(0)/views(0)/guideViewPosition/rotation: "
+                        "error.expected.jsarray"
+                    ),
+                },
+                id="guide-view-position-rotation-not-array",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "views": [
+                                {
+                                    **_VIEW,
+                                    "guideViewPosition": {
+                                        "rotation": [0, 0, 0, 1],
+                                        "translation": 5,
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    (
+                        "/models(0)/views(0)/guideViewPosition/translation: "
+                        "error.expected.jsarray"
+                    ),
+                },
+                id="guide-view-position-translation-not-array",
             ),
         ],
     )


### PR DESCRIPTION
Reject dataset creation requests where a `guideViewPosition` object is missing `rotation` or `translation`, or where either value is not a JSON array, using the same Play JSON-style messages as the existing view field validation.

The array lengths and element types remain unvalidated, and this is now documented in `docs/source/differences-to-vws.rst`.

Towards #3193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)