### PR TITLE
Validate Model Target guide view position array elements

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -188,11 +188,11 @@ for those fields' types, and for ``views`` being a JSON array when it is given.
 Each ``views`` entry is validated for being a JSON object, for the required
 ``guideViewPosition`` and ``name`` fields, and for those fields' types.
 Each ``guideViewPosition`` object is validated for the required ``rotation``
-and ``translation`` fields, and for those fields being JSON arrays.
+and ``translation`` fields, for those fields being JSON arrays, and for the
+elements of those arrays being JSON numbers.
 The mock does not validate the contents of each model further, such as whether
 ``cadDataUrl`` values are reachable, the lengths of ``rotation`` and
-``translation`` arrays or the types of their elements, or ``targetSdk``
-version numbers.
+``translation`` arrays, or ``targetSdk`` version numbers.
 
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.

--- a/newsfragments/model-target-guide-view-position-numbers.change
+++ b/newsfragments/model-target-guide-view-position-numbers.change
@@ -1,0 +1,1 @@
+Reject Model Target dataset creation requests with ``guideViewPosition`` ``rotation`` or ``translation`` arrays which contain values that are not JSON numbers.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -444,6 +444,16 @@ def _view_details(*, models: list[Any]) -> list[dict[str, str]]:
 
 
 @beartype
+def _is_json_number(*, value: object) -> bool:
+    """Return whether a decoded JSON value is a number.
+
+    JSON booleans decode to Python ``bool`` values, which are also ``int``
+    values, so they are excluded.
+    """
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+@beartype
 def _guide_view_position_details(
     *,
     models: list[Any],
@@ -470,7 +480,7 @@ def _guide_view_position_details(
     if missing_details:
         return missing_details
 
-    return [
+    array_details = [
         {
             "code": "VALIDATION_ERROR",
             "message": (
@@ -481,6 +491,23 @@ def _guide_view_position_details(
         for model_index, view_index, position in positions
         for field in ("rotation", "translation")
         if not isinstance(position[field], list)
+    ]
+    if array_details:
+        return array_details
+
+    return [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({model_index})/views({view_index})"
+                f"/guideViewPosition/{field}({element_index}): "
+                "error.expected.jsnumber"
+            ),
+        }
+        for model_index, view_index, position in positions
+        for field in ("rotation", "translation")
+        for element_index, element in enumerate(iterable=position[field])
+        if not _is_json_number(value=element)
     ]
 
 

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -447,8 +447,8 @@ def _view_details(*, models: list[Any]) -> list[dict[str, str]]:
 def _is_json_number(*, value: object) -> bool:
     """Return whether a decoded JSON value is a number.
 
-    JSON booleans decode to Python ``bool`` values, which are also ``int``
-    values, so they are excluded.
+    A JSON boolean decodes to a Python ``bool`` value, which is also an
+    ``int`` value, so ``bool`` values are excluded.
     """
     return isinstance(value, int | float) and not isinstance(value, bool)
 

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -695,6 +695,58 @@ class TestErrorResponses:
                 },
                 id="guide-view-position-translation-not-array",
             ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "views": [
+                                {
+                                    **_VIEW,
+                                    "guideViewPosition": {
+                                        "rotation": [0, "0", 0, 1],
+                                        "translation": [0, 0, 5],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    (
+                        "/models(0)/views(0)/guideViewPosition/rotation(1): "
+                        "error.expected.jsnumber"
+                    ),
+                },
+                id="guide-view-position-rotation-element-not-number",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "views": [
+                                {
+                                    **_VIEW,
+                                    "guideViewPosition": {
+                                        "rotation": [0, 0, 0, 1],
+                                        "translation": [0, 0, True],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    (
+                        "/models(0)/views(0)/guideViewPosition/"
+                        "translation(2): error.expected.jsnumber"
+                    ),
+                },
+                id="guide-view-position-translation-element-not-number",
+            ),
         ],
     )
     def test_invalid_dataset_request(


### PR DESCRIPTION
Reject Model Target dataset creation requests where a `guideViewPosition` `rotation` or `translation` array contains a value which is not a JSON number, using the same Play JSON-style validation messages (`error.expected.jsnumber`) as the existing guide view position validation. JSON booleans are rejected too, despite decoding to Python `int` values.

The remaining unvalidated aspects (array lengths) stay documented as out of scope in `docs/source/differences-to-vws.rst`.

Towards #3193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)