### PR TITLE
Handle non-object Model Target dataset creation bodies

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -180,6 +180,8 @@ route.
 The mock does not verify token signatures, payload claims such as expiry, or
 token revocation.
 
+Dataset creation request bodies which are valid JSON but not JSON objects are
+reported as missing every required top-level field.
 Dataset creation requests are validated for the required top-level ``models``,
 ``name`` and ``targetSdk`` fields, for those fields' types, for each ``models``
 entry being a JSON object, and for the number of models.

--- a/newsfragments/model-target-non-object-body.change
+++ b/newsfragments/model-target-non-object-body.change
@@ -1,0 +1,1 @@
+Reject Model Target dataset creation requests with a body which is valid JSON but not a JSON object, rather than raising an error in the mock.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -321,6 +321,12 @@ def oauth2_token(request: RequestData) -> _ResponseType:
 
 
 @beartype
+def _is_json_object(*, value: object) -> bool:
+    """Return whether a decoded JSON value is an object."""
+    return isinstance(value, dict)
+
+
+@beartype
 def _load_request_json(request: RequestData) -> dict[str, Any] | _ResponseType:
     """Load a Model Target dataset creation request body."""
     content_type = _get_header(request=request, name="Content-Type") or ""
@@ -341,6 +347,13 @@ def _load_request_json(request: RequestData) -> dict[str, Any] | _ResponseType:
             message=f"Invalid Json: {exc}",
             target=None,
             details=None,
+        )
+    if not _is_json_object(value=request_json):
+        # The required top-level fields are read from the request body, so a
+        # body which is valid JSON but not a JSON object is reported as
+        # having every required field missing.
+        return _validation_error_response(
+            details=_top_level_details(request_json={}),
         )
     return request_json
 

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -453,6 +453,55 @@ class TestErrorResponses:
 
     @staticmethod
     @pytest.mark.parametrize(
+        argnames="body",
+        argvalues=[
+            pytest.param("[]", id="array"),
+            pytest.param('"dataset"', id="string"),
+            pytest.param("1", id="number"),
+            pytest.param("true", id="boolean"),
+            pytest.param("null", id="null"),
+        ],
+    )
+    def test_body_not_json_object(
+        *,
+        verify_model_target_mock_vuforia: VuforiaBackend,
+        body: str,
+    ) -> None:
+        """JSON bodies which are not objects are missing every field."""
+        credentials = _credentials_for_backend(
+            backend=verify_model_target_mock_vuforia,
+        )
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
+        response = requests.post(
+            url=f"{_VWS_HOST}/modeltargets/datasets",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+            data=body,
+            timeout=30,
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        error = response.json()["error"]
+        assert error["code"] == "BAD_REQUEST"
+        assert error["message"] == (
+            f"Validation error for request {error['target']}"
+        )
+        actual_messages = {detail["message"] for detail in error["details"]}
+        assert actual_messages == {
+            "/models: element is required",
+            "/name: element is required",
+            "/targetSdk: element is required",
+        }
+        for detail in error["details"]:
+            assert detail["code"] == "VALIDATION_ERROR"
+
+    @staticmethod
+    @pytest.mark.parametrize(
         argnames=("body", "expected_messages"),
         argvalues=[
             pytest.param(


### PR DESCRIPTION
A Model Target dataset creation request whose body is valid JSON but not a JSON object (an array, string, number, boolean or `null`) previously raised a type error inside the mock instead of producing a response.

Such bodies are now reported as missing every required top-level field, reusing the existing validation error shape, and the behaviour is documented in `docs/source/differences-to-vws.rst`.

Towards #3193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)