### PR TITLE
Document Query API unknown field rejection

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -51,6 +51,16 @@ The mock is strict.
 That is, it accepts only a few date formats, and rejects all others.
 If you find a date format which is accepted by the real Query API but rejected by the mock, please create a GitHub issue.
 
+Unknown fields in Query API requests
+------------------------------------
+
+The `Vuforia Query Web API`_ documentation states that the API accepts requests with unknown data fields, and ignores the unknown fields.
+The real Query API does not do this.
+It returns a 400 (``BAD REQUEST``) response with the ``UnknownParameters`` result code when a multipart field other than ``image``, ``max_num_results`` or ``include_target_data`` is given.
+The mock matches the real Query API rather than the documentation.
+
+.. _Vuforia Query Web API: https://developer.vuforia.com/library/vuforia-engine/web-api/vuforia-query-web-api/
+
 Targets stuck in processing
 ---------------------------
 

--- a/tests/mock_vws/test_query.py
+++ b/tests/mock_vws/test_query.py
@@ -762,9 +762,11 @@ class TestIncorrectFields:
         high_quality_image: io.BytesIO,
         vuforia_database: CloudDatabase,
     ) -> None:
-        """
-        If extra fields are given, a ``BAD_REQUEST`` response is
+        """If extra fields are given, a ``BAD_REQUEST`` response is
         returned.
+
+        The Query API documentation says that unknown fields are ignored,
+        but the real Query API rejects them.
         """
         image_content = high_quality_image.getvalue()
         body = {


### PR DESCRIPTION
The [Vuforia Query Web API](https://developer.vuforia.com/library/vuforia-engine/web-api/vuforia-query-web-api/) documentation states that the API accepts requests with unknown data fields and ignores them. The real Query API instead returns a 400 with the `UnknownParameters` result code, which is what the mock does.

The verified fake tests `TestIncorrectFields::test_extra_fields` and `test_missing_image_and_extra_fields` in `tests/mock_vws/test_query.py` already run against real Vuforia and confirm this, so the mock is left unchanged; this notes the divergence from the published documentation in `docs/source/differences-to-vws.rst` and records the reason in the test docstring.

Closes #3350

🤖 Generated with [Claude Code](https://claude.com/claude-code)