### PR TITLE
Match the result codes table casing for ProjectHasNoApiAccess

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -138,14 +138,13 @@ against real databases in the corresponding states:
   ``target_quota`` targets.
 * ``ProjectSuspended`` is returned by VWS endpoints when a database uses the
   :attr:`mock_vws.states.States.PROJECT_SUSPENDED` state.
-* ``ProjectHasNoAPIAccess`` is returned by VWS endpoints when a database uses
+* ``ProjectHasNoApiAccess`` is returned by VWS endpoints when a database uses
   the :attr:`mock_vws.states.States.PROJECT_HAS_NO_API_ACCESS` state.
-  Vuforia's own result codes table spells this ``ProjectHasNoApiAccess``, with
-  ``Api`` rather than ``API``.
-  We have never seen a response from a real database in this state, so we
-  cannot tell which spelling real Vuforia returns.
-  The mock uses ``ProjectHasNoAPIAccess`` to match the spelling used by
-  ``vws-python`` and ``vws-cli``.
+  This casing comes from Vuforia's result codes table, as no response from a
+  real database in this state has been seen.
+  ``vws-python`` and ``vws-cli`` map this result code by the
+  ``ProjectHasNoAPIAccess`` spelling, so they do not recognize this response
+  until they are updated.
 * ``TooManyRequests`` is returned when a
   :class:`mock_vws.database.CloudDatabase` exceeds its
   ``requests_per_second_limit``. Set the limit to ``0`` to return this result

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -140,6 +140,12 @@ against real databases in the corresponding states:
   :attr:`mock_vws.states.States.PROJECT_SUSPENDED` state.
 * ``ProjectHasNoAPIAccess`` is returned by VWS endpoints when a database uses
   the :attr:`mock_vws.states.States.PROJECT_HAS_NO_API_ACCESS` state.
+  Vuforia's own result codes table spells this ``ProjectHasNoApiAccess``, with
+  ``Api`` rather than ``API``.
+  We have never seen a response from a real database in this state, so we
+  cannot tell which spelling real Vuforia returns.
+  The mock uses ``ProjectHasNoAPIAccess`` to match the spelling used by
+  ``vws-python`` and ``vws-cli``.
 * ``TooManyRequests`` is returned when a
   :class:`mock_vws.database.CloudDatabase` exceeds its
   ``requests_per_second_limit``. Set the limit to ``0`` to return this result

--- a/newsfragments/project-has-no-api-access-casing.change
+++ b/newsfragments/project-has-no-api-access-casing.change
@@ -1,0 +1,1 @@
+Document that the casing of the ``ProjectHasNoAPIAccess`` result code is unconfirmed, as Vuforia's documentation spells it ``ProjectHasNoApiAccess`` and no response from a real database in that state has been observed.

--- a/newsfragments/project-has-no-api-access-casing.change
+++ b/newsfragments/project-has-no-api-access-casing.change
@@ -1,1 +1,1 @@
-Document that the casing of the ``ProjectHasNoAPIAccess`` result code is unconfirmed, as Vuforia's documentation spells it ``ProjectHasNoApiAccess`` and no response from a real database in that state has been observed.
+Change the ``ProjectHasNoAPIAccess`` result code to ``ProjectHasNoApiAccess``, matching Vuforia's result codes table.

--- a/src/mock_vws/_constants.py
+++ b/src/mock_vws/_constants.py
@@ -61,6 +61,10 @@ class ResultCodes(Enum):
     TARGET_QUOTA_REACHED = "TargetQuotaReached"
     PROJECT_SUSPENDED = "ProjectSuspended"
     PROJECT_INACTIVE = "ProjectInactive"
+    # Vuforia's result codes table spells this "ProjectHasNoApiAccess". We have
+    # never seen a real response for a database in this state, so the casing is
+    # unconfirmed. We keep "ProjectHasNoAPIAccess" to match ``vws-python`` and
+    # ``vws-cli``, which map this result code by that spelling.
     PROJECT_HAS_NO_API_ACCESS = "ProjectHasNoAPIAccess"
     INACTIVE_PROJECT = "InactiveProject"
     TOO_MANY_REQUESTS = "TooManyRequests"

--- a/src/mock_vws/_constants.py
+++ b/src/mock_vws/_constants.py
@@ -61,11 +61,10 @@ class ResultCodes(Enum):
     TARGET_QUOTA_REACHED = "TargetQuotaReached"
     PROJECT_SUSPENDED = "ProjectSuspended"
     PROJECT_INACTIVE = "ProjectInactive"
-    # Vuforia's result codes table spells this "ProjectHasNoApiAccess". We have
-    # never seen a real response for a database in this state, so the casing is
-    # unconfirmed. We keep "ProjectHasNoAPIAccess" to match ``vws-python`` and
-    # ``vws-cli``, which map this result code by that spelling.
-    PROJECT_HAS_NO_API_ACCESS = "ProjectHasNoAPIAccess"
+    # We have never seen a real response for a database in this state, so this
+    # casing comes from Vuforia's result codes table rather than from an
+    # observed response.
+    PROJECT_HAS_NO_API_ACCESS = "ProjectHasNoApiAccess"
     INACTIVE_PROJECT = "InactiveProject"
     TOO_MANY_REQUESTS = "TooManyRequests"
     INVALID_ACCEPT_HEADER = "InvalidAcceptHeader"

--- a/src/mock_vws/_services_validators/exceptions.py
+++ b/src/mock_vws/_services_validators/exceptions.py
@@ -239,11 +239,11 @@ class ProjectSuspendedError(ValidatorError):
 
 
 @beartype
-class ProjectHasNoAPIAccessError(ValidatorError):
+class ProjectHasNoApiAccessError(ValidatorError):
     """Exception raised when a database cannot make API requests."""
 
     def __init__(self) -> None:
-        """Initialize a ``ProjectHasNoAPIAccess`` response."""
+        """Initialize a ``ProjectHasNoApiAccess`` response."""
         super().__init__()
         self.status_code = HTTPStatus.FORBIDDEN
         body = {

--- a/src/mock_vws/_services_validators/project_state_validators.py
+++ b/src/mock_vws/_services_validators/project_state_validators.py
@@ -11,7 +11,7 @@ from mock_vws._database_matchers import (
     get_database_matching_server_keys,
 )
 from mock_vws._services_validators.exceptions import (
-    ProjectHasNoAPIAccessError,
+    ProjectHasNoApiAccessError,
     ProjectInactiveError,
     ProjectSuspendedError,
     ValidatorError,
@@ -53,7 +53,7 @@ def validate_project_state(
     )
 
     state_errors: dict[States, type[ValidatorError]] = {
-        States.PROJECT_HAS_NO_API_ACCESS: ProjectHasNoAPIAccessError,
+        States.PROJECT_HAS_NO_API_ACCESS: ProjectHasNoApiAccessError,
         States.PROJECT_SUSPENDED: ProjectSuspendedError,
     }
     if error := state_errors.get(database.state):

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -16,9 +16,7 @@ from beartype import beartype
 from freezegun import freeze_time
 from PIL import Image
 from vws import VWS, CloudRecoService
-from vws.exceptions.base_exceptions import VWSError
 from vws.exceptions.vws_exceptions import (
-    ProjectHasNoAPIAccessError,
     ProjectSuspendedError,
     RequestQuotaReachedError,
     TargetQuotaReachedError,
@@ -461,29 +459,9 @@ class TestAdditionalResultCodes:
         )
 
     @staticmethod
-    @pytest.mark.parametrize(
-        argnames=("state", "expected_exception", "result_code"),
-        argvalues=[
-            (
-                States.PROJECT_SUSPENDED,
-                ProjectSuspendedError,
-                ResultCodes.PROJECT_SUSPENDED,
-            ),
-            (
-                States.PROJECT_HAS_NO_API_ACCESS,
-                ProjectHasNoAPIAccessError,
-                ResultCodes.PROJECT_HAS_NO_API_ACCESS,
-            ),
-        ],
-    )
-    def test_project_state_result_codes(
-        *,
-        state: States,
-        expected_exception: type[VWSError],
-        result_code: ResultCodes,
-    ) -> None:
-        """Configured project states reject VWS requests."""
-        database = CloudDatabase(state=state)
+    def test_project_suspended() -> None:
+        """A suspended project rejects VWS requests."""
+        database = CloudDatabase(state=States.PROJECT_SUSPENDED)
         client = VWS(
             server_access_key=database.server_access_key,
             server_secret_key=database.server_secret_key,
@@ -491,14 +469,51 @@ class TestAdditionalResultCodes:
 
         with MockVWS() as mock:
             mock.add_cloud_database(cloud_database=database)
-            with pytest.raises(expected_exception=expected_exception) as exc:
+            with pytest.raises(
+                expected_exception=ProjectSuspendedError,
+            ) as exc:
                 client.list_targets()
 
         assert_vws_failure(
             response=exc.value.response,
             status_code=HTTPStatus.FORBIDDEN,
-            result_code=result_code,
+            result_code=ResultCodes.PROJECT_SUSPENDED,
         )
+
+    @staticmethod
+    def test_project_has_no_api_access() -> None:
+        """A project with no API access rejects VWS requests.
+
+        This does not use ``vws-python`` because that library maps this
+        result code by the ``ProjectHasNoAPIAccess`` spelling, which
+        Vuforia's result codes table does not use.
+        """
+        database = CloudDatabase(state=States.PROJECT_HAS_NO_API_ACCESS)
+        request_path = "/targets"
+
+        with MockVWS() as mock:
+            mock.add_cloud_database(cloud_database=database)
+            date = rfc_1123_date()
+            auth = authorization_header(
+                access_key=database.server_access_key,
+                secret_key=database.server_secret_key,
+                method="GET",
+                content=b"",
+                content_type="",
+                date=date,
+                request_path=request_path,
+            )
+            response = requests.get(
+                url="https://vws.vuforia.com" + request_path,
+                headers={
+                    "Authorization": auth,
+                    "Date": date,
+                },
+                timeout=30,
+            )
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert response.json()["result_code"] == "ProjectHasNoApiAccess"
 
 
 class TestCustomBaseURLs:


### PR DESCRIPTION
Closes #3349.

The mock returned `ProjectHasNoAPIAccess`, while Vuforia's result codes table spells it `ProjectHasNoApiAccess`.

Confirming the casing against a real database needs a project with no API access, which the verified-fake test setup does not create, and no observed response with either spelling could be found. The mock's spelling traced back to a hand-written 2019 doc list of *unhandled* result codes (edd6f91f), never an observed body, so the result codes table is the better source. This changes the mock to match it.

- `ResultCodes.PROJECT_HAS_NO_API_ACCESS` is now `ProjectHasNoApiAccess`.
- The internal `ProjectHasNoAPIAccessError` validator exception is renamed to `ProjectHasNoApiAccessError`.
- `docs/source/differences-to-vws.rst` records that the casing comes from the docs table rather than an observed response.

`vws-python` and `vws-cli` both map this result code by the old spelling, so they no longer recognize this response until they are updated; issues are filed for both. The mock's own test for this state now asserts the raw response instead of going through `vws-python`, whose `from_result_code` would raise `KeyError` for an unmapped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)