### PR TITLE
Model VWS request rate limits per endpoint

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -102,6 +102,44 @@ The mock returns ``RequestQuotaReached`` when a
 but the response has not been verified against a real database with an
 exhausted quota.
 
+Request rate limits
+-------------------
+
+Vuforia documents a request rate limit of 15 requests per second for VWS
+endpoints in general, with 45 requests per second for
+``GET /targets/{target_id}``, 10 requests per second for
+``GET /duplicates/{target_id}``, and 1 request per minute for ``GET /targets``.
+
+The mock models these limits separately for each group of endpoints, but it
+applies no limit by default. The documented numbers have not been verified
+against a real database, and applying a limit of 1 request per minute to
+``GET /targets`` by default would break the tests of anything which uses the
+mock. Set ``request_rate_limits`` to
+:data:`mock_vws.request_rate_limits.DOCUMENTED_REQUEST_RATE_LIMITS` to apply
+the documented limits::
+
+    from mock_vws import MockVWS
+    from mock_vws.database import CloudDatabase
+    from mock_vws.request_rate_limits import DOCUMENTED_REQUEST_RATE_LIMITS
+
+    database = CloudDatabase(
+        request_rate_limits=DOCUMENTED_REQUEST_RATE_LIMITS,
+    )
+
+    with MockVWS() as mock:
+        mock.add_cloud_database(cloud_database=database)
+        # A second ``GET /targets`` request within a minute returns
+        # ``TooManyRequests``.
+        ...
+
+``requests_per_second_limit`` remains available. It applies one limit to all
+VWS endpoints together, and it is tracked separately from the per-endpoint
+limits.
+
+Vuforia also documents that ``GET /targets`` fails for databases with more than
+1 million images. The mock does not implement this, as the behavior is not
+reproducible against a test account.
+
 Configurable Cloud Query failures
 ---------------------------------
 
@@ -146,10 +184,9 @@ against real databases in the corresponding states:
   ``ProjectHasNoAPIAccess`` spelling, so they do not recognize this response
   until they are updated.
 * ``TooManyRequests`` is returned when a
-  :class:`mock_vws.database.CloudDatabase` exceeds its
-  ``requests_per_second_limit``. Set the limit to ``0`` to return this result
-  code for every VWS request. By default, the mock does not apply a per-second
-  request limit.
+  :class:`mock_vws.database.CloudDatabase` exceeds a configured request rate
+  limit. Set ``requests_per_second_limit`` to ``0`` to return this result code
+  for every VWS request.
 
 ``Content-Length`` headers
 --------------------------

--- a/docs/source/mock-api-reference.rst
+++ b/docs/source/mock-api-reference.rst
@@ -41,6 +41,22 @@ API Reference
    :undoc-members:
    :exclude-members: to_dict, from_dict, not_deleted_targets
 
+.. autoclass:: mock_vws.request_rate_limits.RequestRateLimit
+   :members:
+   :undoc-members:
+   :exclude-members: to_dict, from_dict
+
+.. autoclass:: mock_vws.request_rate_limits.RequestRateLimits
+   :members:
+   :undoc-members:
+   :exclude-members: to_dict, from_dict, for_endpoint
+
+.. autoclass:: mock_vws.request_rate_limits.RateLimitedEndpoint
+   :members:
+   :undoc-members:
+
+.. autodata:: mock_vws.request_rate_limits.DOCUMENTED_REQUEST_RATE_LIMITS
+
 .. autoclass:: mock_vws.states.States
    :members:
    :undoc-members:

--- a/newsfragments/per-endpoint-request-rate-limits.change
+++ b/newsfragments/per-endpoint-request-rate-limits.change
@@ -1,0 +1,4 @@
+Model VWS request rate limits per endpoint with the new
+``CloudDatabase.request_rate_limits`` setting, including the limits which
+Vuforia documents as ``mock_vws.request_rate_limits.DOCUMENTED_REQUEST_RATE_LIMITS``.
+No request rate limit is applied by default.

--- a/src/mock_vws/_flask_server/target_manager.py
+++ b/src/mock_vws/_flask_server/target_manager.py
@@ -15,6 +15,7 @@ from pydantic_settings import BaseSettings
 
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.database_type import DatabaseType
+from mock_vws.request_rate_limits import RequestRateLimits
 from mock_vws.states import States
 from mock_vws.target import ImageTarget, VuMarkTarget
 from mock_vws.target_manager import TargetManager
@@ -163,8 +164,15 @@ def create_cloud_database() -> Response:
       targets exist, adding another returns ``TargetQuotaReached``.
 
     :reqjson int requests_per_second_limit: (Optional) The maximum number of
-      VWS requests accepted in a rolling one-second window. Set this to zero
-      to make VWS endpoints return ``TooManyRequests``.
+      VWS requests accepted in a rolling one-second window, across all VWS
+      endpoints. Set this to zero to make VWS endpoints return
+      ``TooManyRequests``.
+
+    :reqjson request_rate_limits: (Optional) Request rate limits for
+      individual groups of VWS endpoints. This is an object with the optional
+      keys "other", "get_target", "get_duplicates" and "list_targets", each
+      either null or an object with the keys "max_requests" and
+      "window_seconds".
 
     :reqjson string server_access_key: (Optional) The server access key for the
       cloud database.
@@ -190,6 +198,9 @@ def create_cloud_database() -> Response:
 
     :resjson int requests_per_second_limit: The per-second request limit, or
       null when rate limiting is disabled.
+
+    :resjson request_rate_limits: The per-endpoint request rate limits, or
+      null when per-endpoint rate limiting is disabled.
 
     :resjson string server_access_key: The server access key for the cloud
       database.
@@ -245,6 +256,12 @@ def create_cloud_database() -> Response:
         "requests_per_second_limit",
         random_database.requests_per_second_limit,
     )
+    request_rate_limits_dict = request_json.get("request_rate_limits")
+    request_rate_limits = (
+        None
+        if request_rate_limits_dict is None
+        else RequestRateLimits.from_dict(limits_dict=request_rate_limits_dict)
+    )
 
     state = States[state_name]
     database_type = DatabaseType[database_type_name]
@@ -260,6 +277,7 @@ def create_cloud_database() -> Response:
         request_quota=request_quota,
         target_quota=target_quota,
         requests_per_second_limit=requests_per_second_limit,
+        request_rate_limits=request_rate_limits,
     )
     try:
         TARGET_MANAGER.add_cloud_database(cloud_database=database)

--- a/src/mock_vws/_services_validators/request_rate_validators.py
+++ b/src/mock_vws/_services_validators/request_rate_validators.py
@@ -1,8 +1,10 @@
-"""Validators for the VWS per-second request rate."""
+"""Validators for the VWS request rates."""
 
+import re
 import threading
 from collections import deque
 from collections.abc import Callable, Iterable, Mapping
+from http import HTTPMethod
 
 from beartype import beartype
 
@@ -11,10 +13,35 @@ from mock_vws._database_matchers import (
     get_database_matching_server_keys,
 )
 from mock_vws.database import CloudDatabase
+from mock_vws.request_rate_limits import (
+    RateLimitedEndpoint,
+    RequestRateLimit,
+)
 
 from .exceptions import TooManyRequestsError
 
 _WINDOW_SECONDS = 1.0
+
+_GET_TARGET_PATH_PATTERN = re.compile(pattern=r"^/targets/[^/]+$")
+_GET_DUPLICATES_PATH_PATTERN = re.compile(pattern=r"^/duplicates/[^/]+$")
+
+
+@beartype
+def _rate_limited_endpoint(
+    *,
+    request_method: str,
+    request_path: str,
+) -> RateLimitedEndpoint:
+    """Return the endpoint group which a request belongs to."""
+    path = request_path.split(sep="?", maxsplit=1)[0]
+    if request_method == HTTPMethod.GET:
+        if path == "/targets":
+            return RateLimitedEndpoint.LIST_TARGETS
+        if _GET_TARGET_PATH_PATTERN.fullmatch(string=path):
+            return RateLimitedEndpoint.GET_TARGET
+        if _GET_DUPLICATES_PATH_PATTERN.fullmatch(string=path):
+            return RateLimitedEndpoint.GET_DUPLICATES
+    return RateLimitedEndpoint.OTHER
 
 
 @beartype
@@ -27,35 +54,77 @@ class RequestRateLimiter:
         time_function: Callable[[], float],
     ) -> None:
         """Initialize an empty rate limiter."""
-        self._request_times: dict[str, deque[float]] = {}
+        self._request_times: dict[tuple[str, str], deque[float]] = {}
         self._lock = threading.Lock()
         self._time_function = time_function
 
-    def validate(self, *, database: CloudDatabase) -> None:
-        """Raise an error if the database's request rate is exhausted."""
-        limit = database.requests_per_second_limit
-        if limit is None:
-            return
+    def validate(
+        self,
+        *,
+        database: CloudDatabase,
+        endpoint: RateLimitedEndpoint,
+    ) -> None:
+        """Raise an error if a rate limit for the request is exhausted.
+
+        Args:
+            database: The database which the request is made against.
+            endpoint: The endpoint group which the request belongs to.
+
+        Raises:
+            TooManyRequestsError: A limit which applies to the request has
+                been reached.
+        """
+        # The ``requests_per_second_limit`` setting applies to every VWS
+        # request made against the database, no matter which endpoint is
+        # used, and so it has a bucket of its own.
+        buckets: list[tuple[str, RequestRateLimit]] = []
+        if database.requests_per_second_limit is not None:
+            buckets.append(
+                (
+                    "ALL_ENDPOINTS",
+                    RequestRateLimit(
+                        max_requests=database.requests_per_second_limit,
+                        window_seconds=_WINDOW_SECONDS,
+                    ),
+                )
+            )
+
+        if database.request_rate_limits is not None:
+            endpoint_limit = database.request_rate_limits.for_endpoint(
+                endpoint=endpoint,
+            )
+            if endpoint_limit is not None:
+                (limit_endpoint, limit) = endpoint_limit
+                buckets.append((limit_endpoint.name, limit))
 
         with self._lock:
             now = self._time_function()
-            request_times = self._request_times.setdefault(
-                database.server_access_key,
-                deque(),
-            )
-            window_start = now - _WINDOW_SECONDS
-            while request_times and request_times[0] <= window_start:
-                request_times.popleft()
+            request_times_for_buckets: list[deque[float]] = []
+            for bucket_name, limit in buckets:
+                request_times = self._request_times.setdefault(
+                    (database.server_access_key, bucket_name),
+                    deque(),
+                )
+                window_start = now - limit.window_seconds
+                while request_times and request_times[0] <= window_start:
+                    request_times.popleft()
 
-            if len(request_times) >= limit:
-                raise TooManyRequestsError
+                if len(request_times) >= limit.max_requests:
+                    raise TooManyRequestsError
 
-            request_times.append(now)
+                request_times_for_buckets.append(request_times)
+
+            for request_times in request_times_for_buckets:
+                request_times.append(now)
 
     def remove_database(self, *, database: CloudDatabase) -> None:
         """Discard request history for a removed database."""
         with self._lock:
-            self._request_times.pop(database.server_access_key, None)
+            self._request_times = {
+                key: value
+                for key, value in self._request_times.items()
+                if key[0] != database.server_access_key
+            }
 
 
 @beartype
@@ -68,7 +137,7 @@ def validate_request_rate(
     databases: Iterable[AnyDatabase],
     request_rate_limiter: RequestRateLimiter,
 ) -> None:
-    """Apply the configured request rate to the matching cloud
+    """Apply the configured request rates to the matching cloud
     database.
     """
     database = get_database_matching_server_keys(
@@ -79,4 +148,8 @@ def validate_request_rate(
         databases=databases,
     )
     if isinstance(database, CloudDatabase):
-        request_rate_limiter.validate(database=database)
+        endpoint = _rate_limited_endpoint(
+            request_method=request_method,
+            request_path=request_path,
+        )
+        request_rate_limiter.validate(database=database, endpoint=endpoint)

--- a/src/mock_vws/database.py
+++ b/src/mock_vws/database.py
@@ -9,6 +9,10 @@ from beartype import beartype
 
 from mock_vws._constants import TargetStatuses
 from mock_vws.database_type import DatabaseType
+from mock_vws.request_rate_limits import (
+    RequestRateLimits,
+    RequestRateLimitsDict,
+)
 from mock_vws.states import States
 from mock_vws.target import (
     ImageTarget,
@@ -33,6 +37,7 @@ class CloudDatabaseDict(TypedDict):
     request_quota: NotRequired[int]
     target_quota: NotRequired[int]
     requests_per_second_limit: NotRequired[int | None]
+    request_rate_limits: NotRequired[RequestRateLimitsDict | None]
 
 
 @beartype
@@ -74,9 +79,15 @@ class CloudDatabase:
         target_quota: The target quota. When the database contains this many
             targets, adding another returns ``TargetQuotaReached``.
         requests_per_second_limit: The maximum number of VWS requests accepted
-            in a rolling one-second window. Set this to ``0`` to make VWS
-            endpoints return ``TooManyRequests``. By default, the mock does
-            not apply a per-second request limit.
+            in a rolling one-second window, across all VWS endpoints. Set this
+            to ``0`` to make VWS endpoints return ``TooManyRequests``. By
+            default, the mock does not apply this limit.
+        request_rate_limits: Request rate limits which apply to individual
+            groups of VWS endpoints, tracked separately from each other and
+            from ``requests_per_second_limit``. Set this to
+            :data:`mock_vws.request_rate_limits.DOCUMENTED_REQUEST_RATE_LIMITS`
+            to apply the limits which Vuforia documents. By default, the mock
+            does not apply per-endpoint request limits.
     """
 
     # We hide a few things in the ``repr`` with ``repr=False`` so that they do
@@ -104,12 +115,18 @@ class CloudDatabase:
     total_recos: int = 0
     target_quota: int = 1000
     requests_per_second_limit: int | None = None
+    request_rate_limits: RequestRateLimits | None = None
 
     def to_dict(self) -> CloudDatabaseDict:
         """Dump a target to a dictionary which can be loaded as JSON."""
         targets: list[ImageTargetDict] = [
             target.to_dict() for target in self.targets
         ]
+        request_rate_limits: RequestRateLimitsDict | None = (
+            None
+            if self.request_rate_limits is None
+            else self.request_rate_limits.to_dict()
+        )
         return {
             "database_name": self.database_name,
             "server_access_key": self.server_access_key,
@@ -122,6 +139,7 @@ class CloudDatabase:
             "request_quota": self.request_quota,
             "target_quota": self.target_quota,
             "requests_per_second_limit": self.requests_per_second_limit,
+            "request_rate_limits": request_rate_limits,
         }
 
     def get_target(self, target_id: str) -> ImageTarget:
@@ -138,6 +156,14 @@ class CloudDatabase:
             ImageTarget.from_dict(target_dict=target_dict)
             for target_dict in database_dict["targets"]
         }
+        request_rate_limits_dict = database_dict.get("request_rate_limits")
+        request_rate_limits = (
+            None
+            if request_rate_limits_dict is None
+            else RequestRateLimits.from_dict(
+                limits_dict=request_rate_limits_dict
+            )
+        )
 
         return cls(
             database_name=database_dict["database_name"],
@@ -153,6 +179,7 @@ class CloudDatabase:
             requests_per_second_limit=database_dict.get(
                 "requests_per_second_limit"
             ),
+            request_rate_limits=request_rate_limits,
         )
 
     @property

--- a/src/mock_vws/request_rate_limits.py
+++ b/src/mock_vws/request_rate_limits.py
@@ -1,0 +1,179 @@
+"""Per-endpoint VWS request rate limits."""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import NotRequired, Self, TypedDict
+
+from beartype import beartype
+
+
+@beartype
+class RateLimitedEndpoint(Enum):
+    """A group of VWS endpoints which share a request rate limit."""
+
+    GET_TARGET = auto()
+    GET_DUPLICATES = auto()
+    LIST_TARGETS = auto()
+    OTHER = auto()
+
+
+@beartype
+class RequestRateLimitDict(TypedDict):
+    """A dictionary type which represents a single request rate limit."""
+
+    max_requests: int
+    window_seconds: float
+
+
+@beartype
+class RequestRateLimitsDict(TypedDict):
+    """A dictionary type which represents per-endpoint rate limits."""
+
+    other: NotRequired[RequestRateLimitDict | None]
+    get_target: NotRequired[RequestRateLimitDict | None]
+    get_duplicates: NotRequired[RequestRateLimitDict | None]
+    list_targets: NotRequired[RequestRateLimitDict | None]
+
+
+@beartype
+@dataclass(eq=True, frozen=True, kw_only=True)
+class RequestRateLimit:
+    """A maximum number of requests within a rolling time window.
+
+    Args:
+        max_requests: The number of requests accepted within the window.
+        window_seconds: The length of the rolling window, in seconds.
+    """
+
+    max_requests: int
+    window_seconds: float
+
+    def to_dict(self) -> RequestRateLimitDict:
+        """Dump a rate limit to a dictionary which can be loaded as
+        JSON.
+        """
+        return {
+            "max_requests": self.max_requests,
+            "window_seconds": self.window_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, limit_dict: RequestRateLimitDict) -> Self:
+        """Load a rate limit from a dictionary."""
+        return cls(
+            max_requests=limit_dict["max_requests"],
+            window_seconds=limit_dict["window_seconds"],
+        )
+
+
+@beartype
+def _limit_to_dict(
+    *,
+    limit: RequestRateLimit | None,
+) -> RequestRateLimitDict | None:
+    """Dump a rate limit, or ``None``, to a JSON-compatible value."""
+    if limit is None:
+        return None
+    return limit.to_dict()
+
+
+@beartype
+def _limit_from_dict(
+    *,
+    limit_dict: RequestRateLimitDict | None,
+) -> RequestRateLimit | None:
+    """Load a rate limit from a dictionary, or ``None``."""
+    if limit_dict is None:
+        return None
+    return RequestRateLimit.from_dict(limit_dict=limit_dict)
+
+
+@beartype
+@dataclass(eq=True, frozen=True, kw_only=True)
+class RequestRateLimits:
+    """Request rate limits for each group of VWS endpoints.
+
+    Each limit is tracked separately, in the same way that the real Vuforia
+    Web Services document separate limits per endpoint.
+    Endpoints without their own limit share the ``other`` limit.
+    A limit of ``None`` means that no limit is applied.
+
+    Args:
+        other: The limit for endpoints without their own limit.
+        get_target: The limit for ``GET /targets/{target_id}`` requests.
+        get_duplicates: The limit for ``GET /duplicates/{target_id}``
+            requests.
+        list_targets: The limit for ``GET /targets`` requests.
+    """
+
+    other: RequestRateLimit | None = None
+    get_target: RequestRateLimit | None = None
+    get_duplicates: RequestRateLimit | None = None
+    list_targets: RequestRateLimit | None = None
+
+    def for_endpoint(
+        self,
+        *,
+        endpoint: RateLimitedEndpoint,
+    ) -> tuple[RateLimitedEndpoint, RequestRateLimit] | None:
+        """Return the limit which applies to an endpoint.
+
+        Args:
+            endpoint: The endpoint to get a limit for.
+
+        Returns:
+            The endpoint group which shares the limit, and the limit itself,
+            or ``None`` if no limit applies.
+        """
+        endpoint_limits = {
+            RateLimitedEndpoint.GET_TARGET: self.get_target,
+            RateLimitedEndpoint.GET_DUPLICATES: self.get_duplicates,
+            RateLimitedEndpoint.LIST_TARGETS: self.list_targets,
+            RateLimitedEndpoint.OTHER: None,
+        }
+        limit = endpoint_limits[endpoint]
+        if limit is not None:
+            return (endpoint, limit)
+        if self.other is not None:
+            return (RateLimitedEndpoint.OTHER, self.other)
+        return None
+
+    def to_dict(self) -> RequestRateLimitsDict:
+        """Dump rate limits to a dictionary which can be loaded as
+        JSON.
+        """
+        return {
+            "other": _limit_to_dict(limit=self.other),
+            "get_target": _limit_to_dict(limit=self.get_target),
+            "get_duplicates": _limit_to_dict(limit=self.get_duplicates),
+            "list_targets": _limit_to_dict(limit=self.list_targets),
+        }
+
+    @classmethod
+    def from_dict(cls, limits_dict: RequestRateLimitsDict) -> Self:
+        """Load rate limits from a dictionary."""
+        return cls(
+            other=_limit_from_dict(limit_dict=limits_dict.get("other")),
+            get_target=_limit_from_dict(
+                limit_dict=limits_dict.get("get_target"),
+            ),
+            get_duplicates=_limit_from_dict(
+                limit_dict=limits_dict.get("get_duplicates"),
+            ),
+            list_targets=_limit_from_dict(
+                limit_dict=limits_dict.get("list_targets"),
+            ),
+        )
+
+
+DOCUMENTED_REQUEST_RATE_LIMITS = RequestRateLimits(
+    other=RequestRateLimit(max_requests=15, window_seconds=1.0),
+    get_target=RequestRateLimit(max_requests=45, window_seconds=1.0),
+    get_duplicates=RequestRateLimit(max_requests=10, window_seconds=1.0),
+    list_targets=RequestRateLimit(max_requests=1, window_seconds=60.0),
+)
+"""The request rate limits documented by Vuforia.
+
+These limits have not been verified against the real Vuforia Web Services,
+and so they are not applied by default.
+"""

--- a/tests/mock_vws/test_flask_app_usage.py
+++ b/tests/mock_vws/test_flask_app_usage.py
@@ -30,6 +30,7 @@ from mock_vws._flask_server.target_manager import (
 from mock_vws._flask_server.vwq import CLOUDRECO_FLASK_APP
 from mock_vws._flask_server.vws import VWS_FLASK_APP
 from mock_vws.database import CloudDatabase, VuMarkDatabase
+from mock_vws.request_rate_limits import RequestRateLimit, RequestRateLimits
 from mock_vws.target import VuMarkTarget
 from tests.mock_vws.utils.usage_test_helpers import (
     processing_time_seconds,
@@ -213,6 +214,36 @@ class TestRequestQuota:
 
         with pytest.raises(expected_exception=TooManyRequestsError):
             client.list_targets()
+
+    @staticmethod
+    def test_per_endpoint_limits() -> None:
+        """The Flask mock preserves and enforces per-endpoint limits."""
+        database = CloudDatabase(
+            request_rate_limits=RequestRateLimits(
+                list_targets=RequestRateLimit(
+                    max_requests=1,
+                    window_seconds=60.0,
+                ),
+            ),
+        )
+        databases_url = _EXAMPLE_URL_FOR_TARGET_MANAGER + "/cloud_databases"
+        response = requests.post(
+            url=databases_url,
+            json=database.to_dict(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        client.list_targets()
+        with pytest.raises(expected_exception=TooManyRequestsError):
+            client.list_targets()
+
+        # Other endpoints are not limited.
+        client.get_database_summary_report()
 
 
 class TestAddCloudDatabase:

--- a/tests/mock_vws/test_requests_mock_usage.py
+++ b/tests/mock_vws/test_requests_mock_usage.py
@@ -34,6 +34,12 @@ from mock_vws._services_validators.request_rate_validators import (
 )
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.image_matchers import ExactMatcher, StructuralSimilarityMatcher
+from mock_vws.request_rate_limits import (
+    DOCUMENTED_REQUEST_RATE_LIMITS,
+    RateLimitedEndpoint,
+    RequestRateLimit,
+    RequestRateLimits,
+)
 from mock_vws.states import States
 from mock_vws.target import ImageTarget, VuMarkTarget
 from tests.mock_vws.utils import Endpoint
@@ -418,10 +424,240 @@ class TestRequestRateLimit:
         )
         database = CloudDatabase(requests_per_second_limit=1)
 
-        rate_limiter.validate(database=database)
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.OTHER,
+        )
         with pytest.raises(expected_exception=TooManyRequestsValidatorError):
-            rate_limiter.validate(database=database)
-        rate_limiter.validate(database=database)
+            rate_limiter.validate(
+                database=database,
+                endpoint=RateLimitedEndpoint.OTHER,
+            )
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.OTHER,
+        )
+
+    @staticmethod
+    def test_limit_applies_to_all_endpoints() -> None:
+        """The database-wide limit is shared between all endpoints."""
+        request_times = iter([10.0, 10.1])
+        rate_limiter = RequestRateLimiter(
+            time_function=request_times.__next__,
+        )
+        database = CloudDatabase(requests_per_second_limit=1)
+
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.GET_TARGET,
+        )
+        with pytest.raises(expected_exception=TooManyRequestsValidatorError):
+            rate_limiter.validate(
+                database=database,
+                endpoint=RateLimitedEndpoint.LIST_TARGETS,
+            )
+
+
+class TestPerEndpointRequestRateLimits:
+    """Tests for per-endpoint VWS request rate limits."""
+
+    @staticmethod
+    def test_endpoints_are_limited_separately() -> None:
+        """Each endpoint group has its own budget of requests."""
+        request_times = iter([10.0, 10.1, 10.2])
+        rate_limiter = RequestRateLimiter(
+            time_function=request_times.__next__,
+        )
+        database = CloudDatabase(
+            request_rate_limits=RequestRateLimits(
+                get_target=RequestRateLimit(
+                    max_requests=1, window_seconds=1.0
+                ),
+                get_duplicates=RequestRateLimit(
+                    max_requests=1, window_seconds=1.0
+                ),
+            ),
+        )
+
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.GET_TARGET,
+        )
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.GET_DUPLICATES,
+        )
+        with pytest.raises(expected_exception=TooManyRequestsValidatorError):
+            rate_limiter.validate(
+                database=database,
+                endpoint=RateLimitedEndpoint.GET_TARGET,
+            )
+
+    @staticmethod
+    def test_endpoints_without_a_limit_share_the_other_limit() -> None:
+        """Endpoints with no limit of their own share the ``other``
+        limit.
+        """
+        request_times = iter([10.0, 10.1, 10.2])
+        rate_limiter = RequestRateLimiter(
+            time_function=request_times.__next__,
+        )
+        database = CloudDatabase(
+            request_rate_limits=RequestRateLimits(
+                other=RequestRateLimit(max_requests=2, window_seconds=1.0),
+                get_target=RequestRateLimit(
+                    max_requests=1, window_seconds=1.0
+                ),
+            ),
+        )
+
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.OTHER,
+        )
+        # ``GET /targets`` has no limit of its own, so it shares the ``other``
+        # limit.
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.LIST_TARGETS,
+        )
+        with pytest.raises(expected_exception=TooManyRequestsValidatorError):
+            rate_limiter.validate(
+                database=database,
+                endpoint=RateLimitedEndpoint.OTHER,
+            )
+
+    @staticmethod
+    def test_windows_longer_than_a_second() -> None:
+        """A limit may use a window which is longer than one second."""
+        request_times = iter([10.0, 40.0, 71.0])
+        rate_limiter = RequestRateLimiter(
+            time_function=request_times.__next__,
+        )
+        database = CloudDatabase(
+            request_rate_limits=RequestRateLimits(
+                list_targets=RequestRateLimit(
+                    max_requests=1,
+                    window_seconds=60.0,
+                ),
+            ),
+        )
+
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.LIST_TARGETS,
+        )
+        with pytest.raises(expected_exception=TooManyRequestsValidatorError):
+            rate_limiter.validate(
+                database=database,
+                endpoint=RateLimitedEndpoint.LIST_TARGETS,
+            )
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.LIST_TARGETS,
+        )
+
+    @staticmethod
+    def test_rejected_requests_do_not_use_other_budgets() -> None:
+        """A request rejected by one limit does not count towards
+        another.
+        """
+        request_times = iter([10.0, 10.1, 10.2])
+        rate_limiter = RequestRateLimiter(
+            time_function=request_times.__next__,
+        )
+        database = CloudDatabase(
+            requests_per_second_limit=5,
+            request_rate_limits=RequestRateLimits(
+                list_targets=RequestRateLimit(
+                    max_requests=1, window_seconds=1.0
+                )
+            ),
+        )
+
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.LIST_TARGETS,
+        )
+        with pytest.raises(expected_exception=TooManyRequestsValidatorError):
+            rate_limiter.validate(
+                database=database,
+                endpoint=RateLimitedEndpoint.LIST_TARGETS,
+            )
+        rate_limiter.validate(
+            database=database,
+            endpoint=RateLimitedEndpoint.GET_TARGET,
+        )
+
+    @staticmethod
+    def test_documented_limits() -> None:
+        """The documented limits are available to use."""
+        database = CloudDatabase(
+            request_rate_limits=DOCUMENTED_REQUEST_RATE_LIMITS,
+        )
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with MockVWS() as mock:
+            mock.add_cloud_database(cloud_database=database)
+            # ``GET /targets`` is limited to one request per minute.
+            client.list_targets()
+            with pytest.raises(
+                expected_exception=TooManyRequestsError,
+            ) as exc_info:
+                client.list_targets()
+
+            # Other endpoints have their own budgets.
+            client.get_database_summary_report()
+
+        assert_vws_failure(
+            response=exc_info.value.response,
+            status_code=HTTPStatus.TOO_MANY_REQUESTS,
+            result_code=ResultCodes.TOO_MANY_REQUESTS,
+        )
+
+    @staticmethod
+    def test_get_target_and_duplicates_limits(
+        *,
+        image_file_failed_state: io.BytesIO,
+    ) -> None:
+        """``GET /targets/{target_id}`` and ``GET /duplicates/{target_id}``
+        have their own limits.
+        """
+        database = CloudDatabase(
+            request_rate_limits=RequestRateLimits(
+                get_target=RequestRateLimit(
+                    max_requests=2, window_seconds=60.0
+                ),
+                get_duplicates=RequestRateLimit(
+                    max_requests=1,
+                    window_seconds=60.0,
+                ),
+            ),
+        )
+        client = VWS(
+            server_access_key=database.server_access_key,
+            server_secret_key=database.server_secret_key,
+        )
+
+        with MockVWS(processing_time_seconds=0) as mock:
+            mock.add_cloud_database(cloud_database=database)
+            target_id = client.add_target(
+                name="example",
+                width=1,
+                image=image_file_failed_state,
+                application_metadata=None,
+                active_flag=True,
+            )
+            client.get_target_record(target_id=target_id)
+            client.get_duplicate_targets(target_id=target_id)
+            with pytest.raises(expected_exception=TooManyRequestsError):
+                client.get_duplicate_targets(target_id=target_id)
+            client.get_target_record(target_id=target_id)
+            with pytest.raises(expected_exception=TooManyRequestsError):
+                client.get_target_record(target_id=target_id)
 
 
 class TestAdditionalResultCodes:
@@ -823,6 +1059,23 @@ class TestDatabaseToDict:
 
         assert (
             new_database.requests_per_second_limit == requests_per_second_limit
+        )
+
+    @staticmethod
+    def test_custom_request_rate_limits() -> None:
+        """Per-endpoint request rate limits survive a dictionary round
+        trip.
+        """
+        database = CloudDatabase(
+            request_rate_limits=DOCUMENTED_REQUEST_RATE_LIMITS,
+        )
+
+        database_dict = database.to_dict()
+        assert json.dumps(obj=database_dict)
+        new_database = CloudDatabase.from_dict(database_dict=database_dict)
+
+        assert (
+            new_database.request_rate_limits == DOCUMENTED_REQUEST_RATE_LIMITS
         )
 
     @staticmethod


### PR DESCRIPTION
The mock applied a single per-database limit to every VWS request, but Vuforia documents different limits per endpoint, so this adds a `CloudDatabase.request_rate_limits` setting which tracks a rolling-window limit separately for `GET /targets`, `GET /targets/{target_id}`, `GET /duplicates/{target_id}`, and everything else, along with `DOCUMENTED_REQUEST_RATE_LIMITS` holding the numbers Vuforia publishes.

No limit is applied by default: the documented numbers have not been verified against a real database, and a 1-request-per-minute limit on `GET /targets` would break the tests of anything which uses the mock. The existing `requests_per_second_limit` knob is unchanged and still applies one limit across all VWS endpoints, tracked separately from the per-endpoint ones.

The new setting round-trips through `to_dict`/`from_dict` and the Flask target-manager API, and `docs/source/differences-to-vws.rst` now documents both the unlimited default and the unimplemented `GET /targets` failure for databases with over 1 million images.

Closes #3346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)