### PR TITLE
Remove duplicate target_summary route definition

### DIFF
--- a/src/mock_vws/_services_validators/key_validators.py
+++ b/src/mock_vws/_services_validators/key_validators.py
@@ -124,13 +124,6 @@ def validate_keys(
         optional_keys=set(),
     )
 
-    target_summary = _Route(
-        path_pattern=f"/summary/{target_id_pattern}",
-        http_methods={HTTPMethod.GET},
-        mandatory_keys=set(),
-        optional_keys=set(),
-    )
-
     reco_counts_report = _Route(
         path_pattern=RECO_COUNTS_REPORT_PATH_PATTERN,
         http_methods={HTTPMethod.POST},


### PR DESCRIPTION
`validate_keys` defined `target_summary` twice, identically, so the second assignment overwrote the first with the same value and only one ended up in the `routes` tuple. This deletes the second definition; behaviour is unchanged.

I also checked whether ruff or pylint has a rule for redundant local reassignment that we currently have disabled — neither does. Ruff's nearest rules (`F811`, `PLR1704`, `PLW2901`, the `A0xx` shadowing family) do not cover a plain local being reassigned before its value is read, and none of them are in our ignore list.

Closes #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)