### PR TITLE
Return targets in a deterministic order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
           - tests/mock_vws/test_query.py::TestSuccess
           - tests/mock_vws/test_query.py::TestIncorrectFields
           - tests/mock_vws/test_query.py::TestMaxNumResults
+          - tests/mock_vws/test_query.py::TestResultOrder
           - tests/mock_vws/test_query.py::TestIncludeTargetData
           - tests/mock_vws/test_query.py::TestAcceptHeader
           - tests/mock_vws/test_query.py::TestActiveFlag

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -37,6 +37,20 @@ The criteria for these images is not defined by the Vuforia documentation.
 The mock is more forgiving than the real Vuforia Web Services.
 Therefore, an image given a 'success' status by the mock may not be given a 'success' status by the real Vuforia Web Services.
 
+Result ordering
+---------------
+
+The real Query API orders results by match score, with the best match first.
+The mock has no match score, so it cannot reproduce that order.
+Instead, the mock orders the targets it returns by upload date and then by target ID.
+This makes repeated runs agree with each other, but it means that the mock's order is not a ranking.
+Do not rely on the first result of a mock query being the best match.
+
+This affects which results survive ``max_num_results``, and which result gets target data with ``include_target_data=top``.
+
+``GET /targets`` and ``GET /duplicates/{target_id}`` use the same order.
+The real Vuforia Web Services do not document an order for those endpoints.
+
 Matching recently deleted targets
 ---------------------------------
 

--- a/newsfragments/deterministic-target-order.change
+++ b/newsfragments/deterministic-target-order.change
@@ -1,0 +1,4 @@
+Return targets in a deterministic order from the Query API, ``GET /targets``
+and ``GET /duplicates/{target_id}``.  Targets are ordered by upload date and
+then by target ID, so repeated runs agree with each other.  This order is not
+Vuforia's match score order.

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -28,7 +28,7 @@ from mock_vws._constants import (
 )
 from mock_vws._database_matchers import get_database_matching_server_keys
 from mock_vws._flask_server.target_manager import TARGET_MANAGER
-from mock_vws._mock_common import RequestData, json_dump
+from mock_vws._mock_common import RequestData, json_dump, sorted_targets
 from mock_vws._model_target_web_api import (
     create_model_target_dataset,
     delete_model_target_dataset,
@@ -838,7 +838,7 @@ def get_duplicates(target_id: str) -> Response:
     (target,) = (
         target for target in database.targets if target.target_id == target_id
     )
-    other_targets = database.targets - {target}
+    other_targets = sorted_targets(targets=database.targets - {target})
 
     similar_targets = [
         other.target_id
@@ -892,7 +892,10 @@ def target_list() -> Response:
         request_path=request.path,
         databases=databases,
     )
-    results = [target.target_id for target in database.not_deleted_targets]
+    results = [
+        target.target_id
+        for target in sorted_targets(targets=database.not_deleted_targets)
+    ]
 
     body = {
         "transaction_id": uuid.uuid4().hex,

--- a/src/mock_vws/_mock_common.py
+++ b/src/mock_vws/_mock_common.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from beartype import beartype
 
+from mock_vws.target import ImageTarget
+
 # A database ID as it appears in the path of a reco counts report request.
 DATABASE_ID_PATTERN = "[A-Za-z0-9_-]+"
 # The path of the endpoint which requests a reco counts report.
@@ -73,6 +75,26 @@ class Route:
     route_name: str
     path_pattern: str
     http_methods: Iterable[str]
+
+
+@beartype
+def sorted_targets(*, targets: Iterable[ImageTarget]) -> list[ImageTarget]:
+    """Put targets into a deterministic order.
+
+    Targets are held in a ``set``, so iterating over them gives an order which
+    varies between runs. Endpoints which return lists of targets use this so
+    that repeated runs agree with each other.
+
+    Args:
+        targets: The targets to order.
+
+    Returns:
+        The given targets, ordered by upload date and then by target ID.
+    """
+    return sorted(
+        targets,
+        key=lambda target: (target.upload_date, target.target_id),
+    )
 
 
 @beartype

--- a/src/mock_vws/_query_tools.py
+++ b/src/mock_vws/_query_tools.py
@@ -13,7 +13,7 @@ from werkzeug.formparser import MultiPartParser
 from mock_vws._base64_decoding import decode_base64
 from mock_vws._constants import ResultCodes, TargetStatuses
 from mock_vws._database_matchers import get_database_matching_client_keys
-from mock_vws._mock_common import json_dump
+from mock_vws._mock_common import json_dump, sorted_targets
 from mock_vws.database import CloudDatabase
 from mock_vws.image_matchers import ImageMatcher
 
@@ -71,7 +71,7 @@ def get_query_match_response_text(
 
     matching_targets = [
         target
-        for target in database.targets
+        for target in sorted_targets(targets=database.targets)
         if query_match_checker(
             first_image_content=target.image_value,
             second_image_content=image_value,

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -31,6 +31,7 @@ from mock_vws._mock_common import (
     RequestData,
     Route,
     json_dump,
+    sorted_targets,
 )
 from mock_vws._model_target_web_api import (
     create_model_target_dataset,
@@ -720,7 +721,8 @@ class MockVuforiaWebServicesAPI:
         )
 
         response_results = [
-            target.target_id for target in database.not_deleted_targets
+            target.target_id
+            for target in sorted_targets(targets=database.not_deleted_targets)
         ]
         body = {
             "transaction_id": uuid.uuid4().hex,
@@ -843,7 +845,7 @@ class MockVuforiaWebServicesAPI:
         target_id = request.path.split(sep="/")[-1]
         target = database.get_target(target_id=target_id)
 
-        other_targets = database.targets - {target}
+        other_targets = sorted_targets(targets=database.targets - {target})
 
         similar_targets = [
             other.target_id

--- a/tests/mock_vws/test_get_duplicates.py
+++ b/tests/mock_vws/test_get_duplicates.py
@@ -10,6 +10,8 @@ from vws import VWS
 from vws.exceptions.vws_exceptions import ProjectInactiveError
 from vws.reports import TargetStatuses
 
+from tests.mock_vws.fixtures.vuforia_backends import VuforiaBackend
+
 
 @pytest.mark.usefixtures("verify_mock_vuforia")
 class TestDuplicates:
@@ -136,6 +138,41 @@ class TestDuplicates:
         )
 
         assert duplicates == []
+
+    @staticmethod
+    def test_order_is_upload_date_then_target_id(
+        *,
+        verify_mock_vuforia: VuforiaBackend,
+        high_quality_image: io.BytesIO,
+        vws_client: VWS,
+    ) -> None:
+        """The mock returns duplicates ordered by upload date.
+
+        The real Vuforia Web Services do not document an order, so we do
+        not verify this against them.
+        """
+        if verify_mock_vuforia == VuforiaBackend.REAL:
+            pytest.skip(reason="The real Vuforia does not document an order.")
+
+        target_ids = [
+            vws_client.add_target(
+                name=uuid.uuid4().hex,
+                width=1,
+                image=high_quality_image,
+                active_flag=True,
+                application_metadata=None,
+            )
+            for _ in range(3)
+        ]
+
+        for target_id in target_ids:
+            vws_client.wait_for_target_processed(target_id=target_id)
+
+        duplicates = vws_client.get_duplicate_targets(
+            target_id=target_ids[0],
+        )
+
+        assert duplicates == target_ids[1:]
 
 
 @pytest.mark.usefixtures("verify_mock_vuforia")

--- a/tests/mock_vws/test_query.py
+++ b/tests/mock_vws/test_query.py
@@ -39,6 +39,7 @@ from vws.response import Response
 from vws_auth_tools import authorization_header, rfc_1123_date
 
 from mock_vws.database import CloudDatabase
+from tests.mock_vws.fixtures.vuforia_backends import VuforiaBackend
 from tests.mock_vws.utils import make_image_file
 from tests.mock_vws.utils.assertions import (
     assert_query_success,
@@ -1007,6 +1008,101 @@ def _add_and_wait_for_targets(
 
     for created_target_id in target_ids:
         vws_client.wait_for_target_processed(target_id=created_target_id)
+
+
+@pytest.mark.usefixtures("verify_mock_vuforia")
+class TestResultOrder:
+    """Tests for the order of query results."""
+
+    @staticmethod
+    def test_order_is_upload_date_then_target_id(
+        *,
+        verify_mock_vuforia: VuforiaBackend,
+        high_quality_image: io.BytesIO,
+        vws_client: VWS,
+        vuforia_database: CloudDatabase,
+    ) -> None:
+        """The mock returns matches ordered by upload date.
+
+        The real Query API orders results by match score, which the mock
+        does not model, so we do not verify this against the real Vuforia
+        Web Services.
+        """
+        if verify_mock_vuforia == VuforiaBackend.REAL:
+            pytest.skip(reason="The real Query API orders by match score.")
+
+        target_ids = [
+            vws_client.add_target(
+                name=uuid.uuid4().hex,
+                width=1,
+                image=high_quality_image,
+                active_flag=True,
+                application_metadata=None,
+            )
+            for _ in range(3)
+        ]
+
+        for target_id in target_ids:
+            vws_client.wait_for_target_processed(target_id=target_id)
+
+        image_content = high_quality_image.getvalue()
+        body = {
+            "image": ("image.jpeg", image_content, "image/jpeg"),
+            "max_num_results": (None, 3, "text/plain"),
+        }
+
+        response = _query(vuforia_database=vuforia_database, body=body)
+
+        assert_query_success(response=response)
+        response_json = json.loads(s=response.text)
+        result_target_ids = [
+            result["target_id"] for result in response_json["results"]
+        ]
+        assert result_target_ids == target_ids
+
+    @staticmethod
+    def test_max_num_results_keeps_the_first_results(
+        *,
+        verify_mock_vuforia: VuforiaBackend,
+        high_quality_image: io.BytesIO,
+        vws_client: VWS,
+        vuforia_database: CloudDatabase,
+    ) -> None:
+        """``max_num_results`` truncates a deterministically ordered
+        list.
+
+        Which matches survive the truncation therefore does not vary
+        between runs.
+        """
+        if verify_mock_vuforia == VuforiaBackend.REAL:
+            pytest.skip(reason="The real Query API orders by match score.")
+
+        target_ids = [
+            vws_client.add_target(
+                name=uuid.uuid4().hex,
+                width=1,
+                image=high_quality_image,
+                active_flag=True,
+                application_metadata=None,
+            )
+            for _ in range(3)
+        ]
+
+        for target_id in target_ids:
+            vws_client.wait_for_target_processed(target_id=target_id)
+
+        image_content = high_quality_image.getvalue()
+        body = {
+            "image": ("image.jpeg", image_content, "image/jpeg"),
+            "max_num_results": (None, 1, "text/plain"),
+        }
+
+        response = _query(vuforia_database=vuforia_database, body=body)
+
+        assert_query_success(response=response)
+        response_json = json.loads(s=response.text)
+        (result,) = response_json["results"]
+        assert result["target_id"] == target_ids[0]
 
 
 @pytest.mark.usefixtures("verify_mock_vuforia")

--- a/tests/mock_vws/test_target_list.py
+++ b/tests/mock_vws/test_target_list.py
@@ -1,7 +1,12 @@
 """Tests for the mock of the target list endpoint."""
 
+import io
+import uuid
+
 import pytest
 from vws import VWS
+
+from tests.mock_vws.fixtures.vuforia_backends import VuforiaBackend
 
 
 @pytest.mark.usefixtures("verify_mock_vuforia")
@@ -27,6 +32,34 @@ class TestTargetList:
         vws_client.wait_for_target_processed(target_id=target_id)
         vws_client.delete_target(target_id=target_id)
         assert not vws_client.list_targets()
+
+    @staticmethod
+    def test_order_is_upload_date_then_target_id(
+        *,
+        verify_mock_vuforia: VuforiaBackend,
+        high_quality_image: io.BytesIO,
+        vws_client: VWS,
+    ) -> None:
+        """The mock returns targets ordered by upload date.
+
+        The real Vuforia Web Services do not document an order, so we do
+        not verify this against them.
+        """
+        if verify_mock_vuforia == VuforiaBackend.REAL:
+            pytest.skip(reason="The real Vuforia does not document an order.")
+
+        target_ids = [
+            vws_client.add_target(
+                name=uuid.uuid4().hex,
+                width=1,
+                image=high_quality_image,
+                active_flag=True,
+                application_metadata=None,
+            )
+            for _ in range(3)
+        ]
+
+        assert vws_client.list_targets() == target_ids
 
 
 @pytest.mark.usefixtures("verify_mock_vuforia")


### PR DESCRIPTION
Targets are held in a `set`, so every endpoint which returns a list of them iterated in hash order, which varies between runs because target IDs are random hex and `str` hashing is salted per process. For the Query API this was not merely cosmetic: `max_num_results` truncates the result list after it is built, so a query matching three targets with `max_num_results=1` returned an arbitrary one of the three, and `include_target_data=top` attached target data to whichever result happened to come first.

The Query API, `GET /targets` and `GET /duplicates/{target_id}` now order targets by upload date and then by target ID, on both the in-process and Flask backends. The mock has no match score, so it cannot reproduce real Vuforia's best-match-first order; `differences-to-vws.rst` now says so, so that callers do not read the mock's order as a ranking.

New tests cover the order for each of the three endpoints; they skip on the real backend, whose order the mock does not claim to match.

Closes #3369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)