### PR TITLE
Add a fixture factory to the multi-backend test harness

### DIFF
--- a/tests/backend_harness.py
+++ b/tests/backend_harness.py
@@ -25,6 +25,7 @@ import pytest
 
 # ``pytest.fixture`` returns one of these, but ``pytest`` does not export
 # the type.
+# See https://github.com/pytest-dev/pytest/issues/14853.
 from _pytest.fixtures import (  # pylint: disable=import-private-name
     FixtureFunctionDefinition,
 )

--- a/tests/backend_harness.py
+++ b/tests/backend_harness.py
@@ -17,10 +17,15 @@ it stays a move rather than a rewrite.
 """
 
 import contextlib
-from collections.abc import Callable, Generator, Iterable
+import functools
+from collections.abc import Callable, Generator, Iterable, Sequence
 from enum import Enum
 
 import pytest
+
+# ``pytest.fixture`` returns one of these, but ``pytest`` does not export
+# the type.
+from _pytest.fixtures import FixtureFunctionDefinition
 from beartype import beartype
 
 
@@ -64,7 +69,7 @@ def add_skip_options(
 
 
 @beartype
-def backend_ids(*, backends: Iterable[Enum]) -> list[str]:
+def _backend_ids(*, backends: Iterable[Enum]) -> list[str]:
     """The IDs which ``pytest`` shows for a set of backends.
 
     Args:
@@ -78,7 +83,7 @@ def backend_ids(*, backends: Iterable[Enum]) -> list[str]:
 
 @beartype
 @contextlib.contextmanager
-def running_backend(
+def _running_backend(
     *,
     backend: Enum,
     config: pytest.Config,
@@ -102,3 +107,50 @@ def running_backend(
 
     with contextlib.contextmanager(func=setup)():
         yield
+
+
+@beartype
+def backend_fixture(
+    *,
+    name: str,
+    backends: Sequence[Enum],
+    setup_for: Callable[..., Generator[None]],
+) -> FixtureFunctionDefinition:
+    """Make a fixture which runs each test once per backend.
+
+    Args:
+        name: The name which tests use to request the fixture.
+        backends: The backends to run each test against.
+        setup_for: A generator function which is called with the keyword
+            arguments ``backend`` and ``request``. It sets that backend
+            up, yields once while the test runs, and then tears it down.
+            Anything else it needs comes from
+            :meth:`~pytest.FixtureRequest.getfixturevalue`, because a
+            fixture made here requests no fixtures but ``request``.
+
+    Returns:
+        A fixture which yields the backend which the test is running
+        against.
+    """
+
+    @pytest.fixture(
+        name=name,
+        params=backends,
+        ids=_backend_ids(backends=backends),
+    )
+    def _fixture(*, request: pytest.FixtureRequest) -> Generator[Enum]:
+        """Run a test against one backend.
+
+        Yields:
+            The backend which the test is running against.
+        """
+        backend: Enum = request.param
+        setup = functools.partial(setup_for, backend=backend, request=request)
+        with _running_backend(
+            backend=backend,
+            config=request.config,
+            setup=setup,
+        ):
+            yield backend
+
+    return _fixture

--- a/tests/backend_harness.py
+++ b/tests/backend_harness.py
@@ -25,7 +25,9 @@ import pytest
 
 # ``pytest.fixture`` returns one of these, but ``pytest`` does not export
 # the type.
-from _pytest.fixtures import FixtureFunctionDefinition
+from _pytest.fixtures import (  # pylint: disable=import-private-name
+    FixtureFunctionDefinition,
+)
 from beartype import beartype
 
 

--- a/tests/mock_vws/fixtures/vuforia_backends.py
+++ b/tests/mock_vws/fixtures/vuforia_backends.py
@@ -1,9 +1,8 @@
 """Choose which backends to use for the tests."""
 
 import contextlib
-import functools
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Generator
 from enum import Enum
 
 import pytest
@@ -23,11 +22,7 @@ from mock_vws._flask_server.vws import VWS_FLASK_APP
 from mock_vws.database import CloudDatabase, VuMarkDatabase
 from mock_vws.states import States
 from mock_vws.target import VuMarkTarget
-from tests.backend_harness import (
-    add_skip_options,
-    backend_ids,
-    running_backend,
-)
+from tests.backend_harness import add_skip_options, backend_fixture
 from tests.mock_vws.fixtures.credentials import (
     InactiveVuMarkCloudDatabase,
     VuMarkCloudDatabase,
@@ -381,135 +376,68 @@ def pytest_collection_modifyitems(
 
 
 @beartype
-def _bind_setup(
+def _setup_backend(
     *,
     backend: VuforiaBackend,
-    vuforia_database: CloudDatabase,
-    inactive_cloud_database: CloudDatabase,
-    vumark_vuforia_database: VuMarkCloudDatabase,
-    inactive_vumark_database: InactiveVuMarkCloudDatabase,
-    monkeypatch: pytest.MonkeyPatch,
-) -> Callable[[], Generator[None]]:
-    """Bind the setup function for a backend to the databases to set
-    up.
-
-    Returns:
-        A setup function which takes no arguments.
-    """
-    return functools.partial(
-        _SETUP_FUNCTIONS[backend],
-        working_database=vuforia_database,
-        inactive_cloud_database=inactive_cloud_database,
-        vumark_vuforia_database=vumark_vuforia_database,
-        inactive_vumark_database=inactive_vumark_database,
-        monkeypatch=monkeypatch,
-    )
-
-
-@pytest.fixture(
-    name="verify_mock_vuforia",
-    params=_ALL_BACKENDS,
-    ids=backend_ids(backends=_ALL_BACKENDS),
-)
-def fixture_verify_mock_vuforia(
-    *,
     request: pytest.FixtureRequest,
-    vuforia_database: CloudDatabase,
-    inactive_cloud_database: CloudDatabase,
-    vumark_vuforia_database: VuMarkCloudDatabase,
-    inactive_vumark_database: InactiveVuMarkCloudDatabase,
-    monkeypatch: pytest.MonkeyPatch,
-) -> Generator[VuforiaBackend]:
-    """Test functions which use this fixture are run multiple times. Once
-    with
-    the real Vuforia, and once with each mock.
-
-    This is useful for verifying the mocks.
-
-    Yields:
-        The backend which the test is running against.
-    """
-    backend: VuforiaBackend = request.param
-    setup = _bind_setup(
-        backend=backend,
-        vuforia_database=vuforia_database,
-        inactive_cloud_database=inactive_cloud_database,
-        vumark_vuforia_database=vumark_vuforia_database,
-        inactive_vumark_database=inactive_vumark_database,
-        monkeypatch=monkeypatch,
-    )
-
-    with running_backend(
-        backend=backend,
-        config=request.config,
-        setup=setup,
-    ):
-        yield backend
-
-
-@pytest.fixture(
-    name="verify_model_target_mock_vuforia",
-    params=_ALL_BACKENDS,
-    ids=backend_ids(backends=_ALL_BACKENDS),
-)
-def fixture_verify_model_target_mock_vuforia(
-    *,
-    request: pytest.FixtureRequest,
-    monkeypatch: pytest.MonkeyPatch,
-) -> Generator[VuforiaBackend]:
-    """Run Model Target Web API contract tests against real and mock
-    APIs.
-    """
-    backend: VuforiaBackend = request.param
-    setup = functools.partial(
-        _MODEL_TARGET_SETUP_FUNCTIONS[backend],
-        monkeypatch=monkeypatch,
-    )
-
-    with running_backend(
-        backend=backend,
-        config=request.config,
-        setup=setup,
-    ):
-        yield backend
-
-
-@pytest.fixture(
-    params=_MOCK_BACKENDS,
-    ids=backend_ids(backends=_MOCK_BACKENDS),
-)
-def mock_only_vuforia(
-    *,
-    request: pytest.FixtureRequest,
-    vuforia_database: CloudDatabase,
-    inactive_cloud_database: CloudDatabase,
-    vumark_vuforia_database: VuMarkCloudDatabase,
-    inactive_vumark_database: InactiveVuMarkCloudDatabase,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> Generator[None]:
-    """Test functions which use this fixture are run multiple times. Once
-    with
-    the each mock.
-
-    This is useful for testing the mock using fixtures which connect to
-    Vuforia.
+    """Set a backend up with the databases which the tests use.
 
     Yields:
-        ``None``.
+        ``None``, once the backend is set up.
     """
-    backend: VuforiaBackend = request.param
-    setup = _bind_setup(
-        backend=backend,
-        vuforia_database=vuforia_database,
-        inactive_cloud_database=inactive_cloud_database,
-        vumark_vuforia_database=vumark_vuforia_database,
-        inactive_vumark_database=inactive_vumark_database,
-        monkeypatch=monkeypatch,
+    yield from _SETUP_FUNCTIONS[backend](
+        working_database=request.getfixturevalue(argname="vuforia_database"),
+        inactive_cloud_database=request.getfixturevalue(
+            argname="inactive_cloud_database",
+        ),
+        vumark_vuforia_database=request.getfixturevalue(
+            argname="vumark_vuforia_database",
+        ),
+        inactive_vumark_database=request.getfixturevalue(
+            argname="inactive_vumark_database",
+        ),
+        monkeypatch=request.getfixturevalue(argname="monkeypatch"),
     )
 
-    with running_backend(
-        backend=backend,
-        config=request.config,
-        setup=setup,
-    ):
-        yield
+
+@beartype
+def _setup_model_target_backend(
+    *,
+    backend: VuforiaBackend,
+    request: pytest.FixtureRequest,
+) -> Generator[None]:
+    """Set a backend up for the Model Target Web API tests.
+
+    Yields:
+        ``None``, once the backend is set up.
+    """
+    yield from _MODEL_TARGET_SETUP_FUNCTIONS[backend](
+        monkeypatch=request.getfixturevalue(argname="monkeypatch"),
+    )
+
+
+# Tests which use this are run against the real Vuforia and against each
+# mock. This is useful for verifying the mocks.
+fixture_verify_mock_vuforia = backend_fixture(
+    name="verify_mock_vuforia",
+    backends=_ALL_BACKENDS,
+    setup_for=_setup_backend,
+)
+
+# Model Target Web API contract tests, run against the real Vuforia and
+# against each mock.
+fixture_verify_model_target_mock_vuforia = backend_fixture(
+    name="verify_model_target_mock_vuforia",
+    backends=_ALL_BACKENDS,
+    setup_for=_setup_model_target_backend,
+)
+
+# Tests which use this are run against each mock, and not against the
+# real Vuforia. This is useful for testing the mock using fixtures which
+# connect to Vuforia.
+fixture_mock_only_vuforia = backend_fixture(
+    name="mock_only_vuforia",
+    backends=_MOCK_BACKENDS,
+    setup_for=_setup_backend,
+)


### PR DESCRIPTION
Each of the three backend fixtures in `vuforia_backends.py` repeated the same five moves: set `params` and `ids`, unpack `request.param`, bind the setup function, and wrap it in `running_backend`. This adds `backend_fixture` to `tests/backend_harness.py`, which builds the fixture from a list of backends and a setup callback, taking those three fixtures from ~135 lines to ~65.

The callback receives `backend` and `request` and gets anything else it needs from `request.getfixturevalue`, so one factory can serve fixtures which need different fixtures themselves; `backend_ids` and `running_backend` are now private, since the factory is their only caller. Collected test IDs are unchanged, and the full suite with `--skip-real --skip-docker_build_tests` gives the same 1103 passed / 500 skipped as before.

One behaviour does change: a backend's fixtures are no longer resolved before its `--skip-<backend>` option is checked, so skipping a backend no longer requires the credentials for it.

This is part of #3414, which also asks for tests for the harness and for extraction as a plugin — the extraction is better designed against a second consumer, so this leaves it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
