### PR TITLE
Catch connection errors in the Docker health check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
           - tests/mock_vws/test_vumark_generation_api.py
           - tests/mock_vws/test_vumark_generation_failure.py
           - tests/mock_vws/test_target_validators.py
+          - tests/mock_vws/test_healthcheck.py
           - tests/mock_vws/test_docker.py
           - README.rst
           - docs/

--- a/newsfragments/healthcheck-connection-refused.change
+++ b/newsfragments/healthcheck-connection-refused.change
@@ -1,0 +1,1 @@
+Report the Docker containers as unhealthy without a traceback in the health check probe output while nothing is yet listening on the port.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -460,9 +460,6 @@ xfail_strict = true
 
 [tool.coverage]
 run.branch = true
-run.omit = [
-    "src/mock_vws/_flask_server/healthcheck.py",
-]
 run.parallel = true
 run.patch = [ "subprocess" ]
 run.relative_files = true

--- a/src/mock_vws/_flask_server/healthcheck.py
+++ b/src/mock_vws/_flask_server/healthcheck.py
@@ -1,7 +1,6 @@
 """Health check for the Flask server."""
 
 import http.client
-import socket
 import sys
 from http import HTTPStatus
 
@@ -15,7 +14,11 @@ def flask_app_healthy(port: int) -> bool:
     try:
         conn.request(method="GET", url="/some-random-endpoint")
         response = conn.getresponse()
-    except TimeoutError, http.client.HTTPException, socket.gaierror:
+    # ``OSError`` covers ``TimeoutError``, ``ConnectionRefusedError`` and
+    # ``socket.gaierror``.
+    # ``ConnectionRefusedError`` is the expected error while the container is
+    # starting up and nothing is yet listening on the port.
+    except OSError, http.client.HTTPException:
         return False
     finally:
         conn.close()
@@ -27,5 +30,5 @@ def flask_app_healthy(port: int) -> bool:
     }
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(int(not flask_app_healthy(port=5000)))

--- a/tests/mock_vws/test_healthcheck.py
+++ b/tests/mock_vws/test_healthcheck.py
@@ -1,0 +1,84 @@
+"""Tests for the health check used by the Docker images."""
+
+import socket
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from http import HTTPStatus
+
+import pytest
+from beartype import beartype
+from flask import Flask, Response
+from werkzeug.serving import make_server
+
+from mock_vws._flask_server.healthcheck import flask_app_healthy
+
+
+@beartype
+@contextmanager
+def _app_responding_with(*, status: HTTPStatus) -> Generator[int]:
+    """Serve an app which gives the given status, and yield its port."""
+    app = Flask(import_name=__name__, static_folder=None)
+
+    @beartype
+    def _respond(_path: str) -> Response:
+        """Respond with the given status and an empty body."""
+        return Response(status=status)
+
+    app.add_url_rule(rule="/<path:_path>", view_func=_respond)
+
+    server = make_server(host="localhost", port=0, app=app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@beartype
+def _unused_port() -> int:
+    """Return a port with nothing listening on it."""
+    with socket.socket() as sock:
+        sock.bind(("localhost", 0))
+        port: int = sock.getsockname()[1]
+    return port
+
+
+@beartype
+def test_nothing_listening() -> None:
+    """No server on the port means not healthy.
+
+    This is the state during container start-up, before the app binds the
+    port.
+    """
+    assert not flask_app_healthy(port=_unused_port())
+
+
+@pytest.mark.parametrize(
+    argnames="status",
+    argvalues=[
+        HTTPStatus.NOT_FOUND,
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.FORBIDDEN,
+    ],
+)
+@beartype
+def test_healthy(*, status: HTTPStatus) -> None:
+    """An app which handles a request for an unknown endpoint is
+    healthy.
+    """
+    with _app_responding_with(status=status) as port:
+        assert flask_app_healthy(port=port)
+
+
+@pytest.mark.parametrize(
+    argnames="status",
+    argvalues=[HTTPStatus.OK, HTTPStatus.INTERNAL_SERVER_ERROR],
+)
+@beartype
+def test_unhealthy(*, status: HTTPStatus) -> None:
+    """Any other status means not healthy."""
+    with _app_responding_with(status=status) as port:
+        assert not flask_app_healthy(port=port)


### PR DESCRIPTION
`flask_app_healthy` did not catch `ConnectionRefusedError`, so a traceback appeared in the Docker health check probe output for every probe while nothing was yet listening on the port — the normal state during container start-up. It now catches `OSError`, which covers `ConnectionRefusedError`, `TimeoutError` and `socket.gaierror` together.

The module also comes out of the coverage `run.omit` list and gains direct tests (`tests/mock_vws/test_healthcheck.py`, added to the CI pattern matrix): a dead port, the healthy statuses, and other statuses. The `__main__` block is marked `# pragma: no cover`, as in the other Flask server modules.

Closes #3381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)