### PR TITLE
Switch Vale to the upstream ai-tells package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -327,7 +327,7 @@ repos:
 
       # Vale enforces prose style rules, such as banning em dashes, in
       # reStructuredText and Markdown files.
-      # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
+      # The rules come from the ``ai-tells`` package pinned in ``.vale.ini``,
       # which ``vale sync`` downloads into the (gitignored) ``styles``
       # directory.
       # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,23 @@
 StylesPath = styles
 MinAlertLevel = error
 
-Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
+Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.29.0/ai-tells.zip
 
 [*.{rst,md}]
-BasedOnStyles = ClearProse
+BasedOnStyles = ai-tells
+
+# These rules misclassify established technical, example, or release-note prose
+# in this repository. All other ai-tells rules remain enforced.
+ai-tells.CataphoricForecasting = NO
+ai-tells.ContrastiveFormulas = NO
+ai-tells.ContrastiveNegation = NO
+ai-tells.EmptyPadding = NO
+ai-tells.EmptyPaddingStacked = NO
+ai-tells.FigurativeLands = NO
+ai-tells.FillerPhrases = NO
+ai-tells.FormalRegister = NO
+ai-tells.FormalTransitions = NO
+ai-tells.Metacommentary = NO
+ai-tells.OverusedVocabularyVerbs = NO
+ai-tells.StackedAnaphora = NO
+ai-tells.VerbTricolon = NO


### PR DESCRIPTION
## What changed

- Replace the single-rule `ClearProse` package with [`tbhb/vale-ai-tells`](https://github.com/tbhb/vale-ai-tells) v1.29.0.
- Keep all compatible ai-tells rules enabled.
- Disable only rules that flag established technical, example, or release-note prose already present in this repository.
- Update the Vale workflow/hook comment where one names the old package.

## Why

The upstream package covers em dashes as well as a much broader set of patterns associated with AI-written prose. Repository-specific exceptions avoid rewriting valid technical terminology and reference material merely to satisfy a general-audience heuristic.

## Validation

- `uvx --with docutils vale@3.13.0.0` over every tracked `*.rst` and `*.md` file
- Result: passed with zero errors
