### PR TITLE
Fix two spots where a project convention is broken (#3401)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -421,7 +421,7 @@ repos:
           - *uv_version
 
       - id: yamlfix
-        name: pyproject-fmt
+        name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]

--- a/src/mock_vws/_query_validators/accept_header_validators.py
+++ b/src/mock_vws/_query_validators/accept_header_validators.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(name=__name__)
 
 
 @beartype
-def validate_accept_header(request_headers: Mapping[str, str]) -> None:
+def validate_accept_header(*, request_headers: Mapping[str, str]) -> None:
     """Validate the accept header.
 
     Args:

--- a/src/mock_vws/_query_validators/auth_validators.py
+++ b/src/mock_vws/_query_validators/auth_validators.py
@@ -88,6 +88,7 @@ def validate_client_key_exists(
 
 @beartype
 def validate_auth_header_has_signature(
+    *,
     request_headers: Mapping[str, str],
 ) -> None:
     """Validate the authorization header includes a signature.


### PR DESCRIPTION
Closes part of #3401.

The `yamlfix` pre-commit hook reported itself as `pyproject-fmt`, a name copied from the real `pyproject-fmt-fix` hook, so a yamlfix failure sent whoever read the output to `pyproject.toml` — including in `autofix.ci`, which runs all pre-commit-stage hooks verbosely. `validate_accept_header` and `validate_auth_header_has_signature` were the only two of 63 `validate_*` and `run_*` functions in `src/` taking a positional parameter; both call sites already passed by keyword, so nothing changes at runtime.

The issue also suggested adding checks to `ci/test_custom_linters.py` to stop both recurring, which is not included here — that file was deliberately deleted in #3409, and re-adding it plus its hook, CI matrix entry and lint ignore is a lot of machinery for two one-line fixes. Worth noting for whoever picks that up: the issue's proposed stronger rule "every function in `src/` has no positional parameters" does not hold — around 100 functions have one, mostly Flask route handlers and `from_dict` constructors — so only the narrower validator rule is enforceable.

Verified with `test_query.py` (150 passed, 75 skipped) plus ruff, mypy, pyright, ty, pylint, vulture and the partition check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)