### PR TITLE
Pin the coverage version used by the coverage gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,16 +328,15 @@ jobs:
       - name: Require 100% Coverage
         id: coverage
         run: |
-          uv tool install 'coverage[toml]'
+          uv run --extra=dev coverage combine
+          uv run --extra=dev coverage html --skip-covered --skip-empty
 
-          coverage combine
-          coverage html --skip-covered --skip-empty
-
-          # Report and write to summary.
-          coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
+          # Report and write to summary, without failing yet.
+          uv run --extra=dev coverage report --format=markdown \
+            >> "$GITHUB_STEP_SUMMARY" || true
 
           # Report again and fail if under 100%.
-          coverage report
+          uv run --extra=dev coverage report
 
       - name: Upload HTML report if check failed
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The `Combine & check coverage` job installed `coverage` with `uv tool install`, which resolves the latest release at run time and ignores the project's pin of `coverage==7.15.4`. It was the only unpinned tool install across the workflows, and it is a required check on the default branch, so its behaviour was decided by whatever `coverage` released most recently — and the job producing the coverage data used a different (pinned) version from the job consuming it.

Run it through `uv run --extra=dev`, like every other tool invocation in the workflows.

Also add `|| true` to the first `coverage report` call. Under `bash -e` that call already failed the step when coverage was under 100%, so the second call — the one the comment says is the gate — was unreachable in exactly the case it exists for.

Closes #3402

🤖 Generated with [Claude Code](https://claude.com/claude-code)