### PR TITLE
Name the missing secrets file when credentials cannot be loaded

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
           - tests/mock_vws/test_vumark_generation_api.py
           - tests/mock_vws/test_vumark_generation_failure.py
           - tests/mock_vws/test_target_validators.py
+          - tests/mock_vws/test_credentials_loading.py
           - tests/mock_vws/test_healthcheck.py
           - tests/mock_vws/test_docker.py
           - README.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,6 +403,8 @@ ignore_names = [
     "towncrier_draft_autoversion_mode",
     "towncrier_draft_include_empty",
     "towncrier_draft_working_directory",
+    # A test settings field which nothing is ever meant to provide
+    "unsatisfiable_field",
     "VuMarkDatabaseDict",
     "VuMarkTargetDict",
     "warning_is_error",

--- a/tests/mock_vws/fixtures/credentials.py
+++ b/tests/mock_vws/fixtures/credentials.py
@@ -5,11 +5,37 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from pydantic import Field
+from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from mock_vws.database import CloudDatabase
 from mock_vws.states import States
+
+_REPOSITORY_ROOT = Path(__file__).parents[3]
+_SECRETS_FILE = _REPOSITORY_ROOT / "vuforia_secrets.env"
+
+
+def load_settings[SettingsT: BaseSettings](
+    *,
+    settings_class: type[SettingsT],
+) -> SettingsT:
+    """Load settings, pointing at the secrets file if it is missing.
+
+    Without this, a missing secrets file gives a bare list of "Field
+    required" errors which never names the file to create.
+    """
+    try:
+        return settings_class.model_validate(obj={})
+    except ValidationError:
+        if _SECRETS_FILE.exists():
+            raise
+        message = (
+            f"{_SECRETS_FILE} not found. "
+            "Copy vuforia_secrets.env.example to vuforia_secrets.env in "
+            f"{_REPOSITORY_ROOT} and fill it in. "
+            "See the contributing documentation."
+        )
+        raise FileNotFoundError(message) from None
 
 
 class _CloudDatabaseSettings(BaseSettings):
@@ -23,7 +49,7 @@ class _CloudDatabaseSettings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="VUFORIA_",
-        env_file=Path("vuforia_secrets.env"),
+        env_file=_SECRETS_FILE,
         extra="allow",
     )
 
@@ -43,7 +69,7 @@ class _InactiveCloudDatabaseSettings(_CloudDatabaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="INACTIVE_VUFORIA_",
-        env_file=Path("vuforia_secrets.env"),
+        env_file=_SECRETS_FILE,
         extra="allow",
     )
 
@@ -57,7 +83,7 @@ class _InactiveVuMarkDatabaseSettings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="INACTIVE_VUMARK_VUFORIA_",
-        env_file=Path("vuforia_secrets.env"),
+        env_file=_SECRETS_FILE,
         extra="allow",
     )
 
@@ -73,7 +99,7 @@ class _VuMarkCloudDatabaseSettings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="VUMARK_VUFORIA_",
-        env_file=Path("vuforia_secrets.env"),
+        env_file=_SECRETS_FILE,
         extra="allow",
     )
 
@@ -87,7 +113,7 @@ class _ModelTargetSettings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="MODEL_TARGET_VUFORIA_",
-        env_file=Path("vuforia_secrets.env"),
+        env_file=_SECRETS_FILE,
         extra="allow",
     )
 
@@ -125,7 +151,7 @@ def get_model_target_credentials() -> ModelTargetCredentials:
     """Return Model Target Web API credentials from environment
     variables.
     """
-    settings = _ModelTargetSettings.model_validate(obj={})
+    settings = load_settings(settings_class=_ModelTargetSettings)
     return ModelTargetCredentials(
         client_id=settings.client_id,
         client_secret=settings.client_secret,
@@ -136,7 +162,7 @@ def get_model_target_credentials() -> ModelTargetCredentials:
 @pytest.fixture
 def vuforia_database() -> CloudDatabase:
     """Return VWS credentials from environment variables."""
-    settings = _WorkingCloudDatabaseSettings.model_validate(obj={})
+    settings = load_settings(settings_class=_WorkingCloudDatabaseSettings)
     return CloudDatabase(
         database_id=settings.database_id,
         database_name=settings.target_manager_database_name,
@@ -154,7 +180,7 @@ def inactive_cloud_database() -> CloudDatabase:
     Return VWS credentials for an inactive project from environment
     variables.
     """
-    settings = _InactiveCloudDatabaseSettings.model_validate(obj={})
+    settings = load_settings(settings_class=_InactiveCloudDatabaseSettings)
     return CloudDatabase(
         database_name=settings.target_manager_database_name,
         server_access_key=settings.server_access_key,
@@ -168,7 +194,7 @@ def inactive_cloud_database() -> CloudDatabase:
 @pytest.fixture
 def inactive_vumark_database() -> InactiveVuMarkCloudDatabase:
     """Return inactive VuMark credentials from environment variables."""
-    settings = _InactiveVuMarkDatabaseSettings.model_validate(obj={})
+    settings = load_settings(settings_class=_InactiveVuMarkDatabaseSettings)
     return InactiveVuMarkCloudDatabase(
         target_manager_database_name=settings.target_manager_database_name,
         server_access_key=settings.server_access_key,
@@ -179,7 +205,7 @@ def inactive_vumark_database() -> InactiveVuMarkCloudDatabase:
 @pytest.fixture
 def vumark_vuforia_database() -> VuMarkCloudDatabase:
     """Return VuMark VWS credentials from environment variables."""
-    settings = _VuMarkCloudDatabaseSettings.model_validate(obj={})
+    settings = load_settings(settings_class=_VuMarkCloudDatabaseSettings)
 
     return VuMarkCloudDatabase(
         target_manager_database_name=settings.target_manager_database_name,

--- a/tests/mock_vws/test_credentials_loading.py
+++ b/tests/mock_vws/test_credentials_loading.py
@@ -1,0 +1,66 @@
+"""Tests for loading credentials for the test suite."""
+
+from pathlib import Path
+
+import pytest
+from beartype import beartype
+from pydantic import ValidationError
+from pydantic_settings import BaseSettings
+
+from tests.mock_vws.fixtures import credentials
+
+
+class _UnsatisfiableSettings(BaseSettings):
+    """Settings with a field which nothing provides."""
+
+    unsatisfiable_field: str
+
+
+@beartype
+def test_missing_secrets_file(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A missing secrets file gives an error which names the file."""
+    secrets_file = tmp_path / "vuforia_secrets.env"
+    monkeypatch.setattr(
+        target=credentials,
+        name="_SECRETS_FILE",
+        value=secrets_file,
+    )
+    monkeypatch.setattr(
+        target=credentials,
+        name="_REPOSITORY_ROOT",
+        value=tmp_path,
+    )
+
+    with pytest.raises(expected_exception=FileNotFoundError) as exc:
+        credentials.load_settings(settings_class=_UnsatisfiableSettings)
+
+    expected_message = (
+        f"{secrets_file} not found. "
+        "Copy vuforia_secrets.env.example to vuforia_secrets.env in "
+        f"{tmp_path} and fill it in. "
+        "See the contributing documentation."
+    )
+    assert str(object=exc.value) == expected_message
+
+
+@beartype
+def test_secrets_file_present(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Validation errors are not hidden when the secrets file exists."""
+    secrets_file = tmp_path / "vuforia_secrets.env"
+    secrets_file.touch()
+    monkeypatch.setattr(
+        target=credentials,
+        name="_SECRETS_FILE",
+        value=secrets_file,
+    )
+
+    with pytest.raises(expected_exception=ValidationError):
+        credentials.load_settings(settings_class=_UnsatisfiableSettings)


### PR DESCRIPTION
Closes #3403.

Without `vuforia_secrets.env`, every test which uses a credentials fixture errored during setup with a raw pydantic "Field required" list which never named the file to create.

* Wrap the settings load so that, when validation fails and the file is absent, the error names the file to create and where to put it.
* Resolve the env file relative to the repository root rather than the working directory, so credentials also load when `pytest` runs from a subdirectory.
* Add tests for both branches, plus the matching CI pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)