### PR TITLE
Treat standard and advanced Model Target datasets as separate resources

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -265,9 +265,14 @@ The mock does not validate the contents of each model further, such as whether
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.
 
-Two Model Target Web API error paths remain mock-only in ``tests/mock_vws/test_model_target_web_api.py::TestMockOnlyErrors``.
+Standard and advanced datasets are separate resources.
+A dataset created through the standard routes is not visible to the advanced routes, and the other way around: the mock returns the unknown-dataset error for status, download and delete requests made through the other dataset type's routes.
+Real Vuforia separates these by OAuth scope as well, which the mock does not model, so a client which lacks the advanced-dataset scope may see a different error.
+
+Three Model Target Web API error paths remain mock-only in ``tests/mock_vws/test_model_target_web_api.py::TestMockOnlyErrors``.
 Downloads of still-processing datasets are mock-only because exercising the path against real Vuforia would require creating a dataset on every test run; the mock drives the processing window deterministically.
 Advanced-dataset creation with more than 20 models is mock-only because the available test account lacks the advanced-dataset scope and real Vuforia rejects the request with a 403 before validating model counts.
+Cross-dataset-type access is mock-only for the same reason.
 
 Reco counts reports
 -------------------

--- a/newsfragments/model-target-dataset-type-routes.change
+++ b/newsfragments/model-target-dataset-type-routes.change
@@ -1,0 +1,1 @@
+Treat standard and advanced Model Target datasets as separate resources: status, download and delete requests made through the other dataset type's routes now return the unknown-dataset error rather than acting on the dataset.

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -332,6 +332,7 @@ def get_standard_model_target_dataset_status(
             request=_flask_request_data(),
             target_manager=_model_target_manager(),
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.STANDARD,
         ),
     )
 
@@ -350,6 +351,7 @@ def get_advanced_model_target_dataset_status(
             request=_flask_request_data(),
             target_manager=_model_target_manager(),
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.ADVANCED,
         ),
     )
 
@@ -368,6 +370,7 @@ def download_standard_model_target_dataset(
             request=_flask_request_data(),
             target_manager=_model_target_manager(),
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.STANDARD,
         ),
     )
 
@@ -386,6 +389,7 @@ def download_advanced_model_target_dataset(
             request=_flask_request_data(),
             target_manager=_model_target_manager(),
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.ADVANCED,
         ),
     )
 
@@ -402,6 +406,7 @@ def delete_standard_model_target_dataset(dataset_uuid: str) -> Response:
             request=_flask_request_data(),
             target_manager=_model_target_manager(),
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.STANDARD,
         ),
     )
 
@@ -418,6 +423,7 @@ def delete_advanced_model_target_dataset(dataset_uuid: str) -> Response:
             request=_flask_request_data(),
             target_manager=_model_target_manager(),
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.ADVANCED,
         ),
     )
 

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -673,29 +673,56 @@ def create_model_target_dataset(
 
 
 @beartype
+def _unknown_dataset_response(*, dataset_uuid: str) -> _ResponseType:
+    """Return the error for a dataset which is not visible to a route."""
+    return _error_response(
+        status_code=HTTPStatus.NOT_FOUND,
+        code="NOT_FOUND",
+        message=(
+            f"Could not find a model-view database with uuid {dataset_uuid}"
+        ),
+        target=_MOCK_USER_TARGET,
+        details=None,
+    )
+
+
+@beartype
+def _find_dataset(
+    *,
+    target_manager: TargetManager,
+    dataset_uuid: str,
+    dataset_type: ModelTargetDatasetType,
+) -> ModelTargetDataset | None:
+    """Return a dataset which belongs to a route's dataset type.
+
+    Standard and advanced datasets are separate resources in real Vuforia, so
+    a dataset is invisible to the routes of the other dataset type.
+    """
+    dataset = target_manager.model_target_datasets.get(dataset_uuid)
+    if dataset is None or dataset.dataset_type != dataset_type:
+        return None
+    return dataset
+
+
+@beartype
 def get_model_target_dataset_status(
     *,
     request: RequestData,
     target_manager: TargetManager,
     dataset_uuid: str,
+    dataset_type: ModelTargetDatasetType,
 ) -> _ResponseType:
     """Return the status of a Model Target dataset."""
     auth_error = _require_bearer_token(request=request)
     if auth_error is not None:
         return auth_error
-    try:
-        dataset = target_manager.model_target_datasets[dataset_uuid]
-    except KeyError:
-        return _error_response(
-            status_code=HTTPStatus.NOT_FOUND,
-            code="NOT_FOUND",
-            message=(
-                "Could not find a model-view database with uuid "
-                f"{dataset_uuid}"
-            ),
-            target=_MOCK_USER_TARGET,
-            details=None,
-        )
+    dataset = _find_dataset(
+        target_manager=target_manager,
+        dataset_uuid=dataset_uuid,
+        dataset_type=dataset_type,
+    )
+    if dataset is None:
+        return _unknown_dataset_response(dataset_uuid=dataset_uuid)
     return _json_response(
         status_code=HTTPStatus.OK,
         body=dataset.status_body(),
@@ -732,24 +759,19 @@ def download_model_target_dataset(
     request: RequestData,
     target_manager: TargetManager,
     dataset_uuid: str,
+    dataset_type: ModelTargetDatasetType,
 ) -> _ResponseType:
     """Download a generated Model Target dataset."""
     auth_error = _require_bearer_token(request=request)
     if auth_error is not None:
         return auth_error
-    try:
-        dataset = target_manager.model_target_datasets[dataset_uuid]
-    except KeyError:
-        return _error_response(
-            status_code=HTTPStatus.NOT_FOUND,
-            code="NOT_FOUND",
-            message=(
-                "Could not find a model-view database with uuid "
-                f"{dataset_uuid}"
-            ),
-            target=_MOCK_USER_TARGET,
-            details=None,
-        )
+    dataset = _find_dataset(
+        target_manager=target_manager,
+        dataset_uuid=dataset_uuid,
+        dataset_type=dataset_type,
+    )
+    if dataset is None:
+        return _unknown_dataset_response(dataset_uuid=dataset_uuid)
     if dataset.status != "done":
         return _error_response(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
@@ -779,22 +801,18 @@ def delete_model_target_dataset(
     request: RequestData,
     target_manager: TargetManager,
     dataset_uuid: str,
+    dataset_type: ModelTargetDatasetType,
 ) -> _ResponseType:
     """Delete a Model Target dataset."""
     auth_error = _require_bearer_token(request=request)
     if auth_error is not None:
         return auth_error
-    try:
-        target_manager.remove_model_target_dataset(dataset_uuid=dataset_uuid)
-    except KeyError:
-        return _error_response(
-            status_code=HTTPStatus.NOT_FOUND,
-            code="NOT_FOUND",
-            message=(
-                "Could not find a model-view database with uuid "
-                f"{dataset_uuid}"
-            ),
-            target=_MOCK_USER_TARGET,
-            details=None,
-        )
+    dataset = _find_dataset(
+        target_manager=target_manager,
+        dataset_uuid=dataset_uuid,
+        dataset_type=dataset_type,
+    )
+    if dataset is None:
+        return _unknown_dataset_response(dataset_uuid=dataset_uuid)
+    target_manager.remove_model_target_dataset(dataset_uuid=dataset_uuid)
     return HTTPStatus.OK, {"Content-Length": "0"}, ""

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -241,6 +241,7 @@ class MockVuforiaWebServicesAPI:
             request=request,
             target_manager=self._target_manager,
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.STANDARD,
         )
 
     @route(
@@ -260,6 +261,7 @@ class MockVuforiaWebServicesAPI:
             request=request,
             target_manager=self._target_manager,
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.ADVANCED,
         )
 
     @route(
@@ -279,6 +281,7 @@ class MockVuforiaWebServicesAPI:
             request=request,
             target_manager=self._target_manager,
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.STANDARD,
         )
 
     @route(
@@ -298,6 +301,7 @@ class MockVuforiaWebServicesAPI:
             request=request,
             target_manager=self._target_manager,
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.ADVANCED,
         )
 
     @route(
@@ -316,6 +320,7 @@ class MockVuforiaWebServicesAPI:
             request=request,
             target_manager=self._target_manager,
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.STANDARD,
         )
 
     @route(
@@ -335,6 +340,7 @@ class MockVuforiaWebServicesAPI:
             request=request,
             target_manager=self._target_manager,
             dataset_uuid=dataset_uuid,
+            dataset_type=ModelTargetDatasetType.ADVANCED,
         )
 
     @route(

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -950,6 +950,84 @@ class TestMockOnlyErrors:
         )
         assert error["target"] == dataset_uuid
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        argnames=("created_path", "other_path"),
+        argvalues=[
+            pytest.param(
+                "/modeltargets/datasets",
+                "/modeltargets/advancedDatasets",
+                id="standard-dataset-via-advanced-routes",
+            ),
+            pytest.param(
+                "/modeltargets/advancedDatasets",
+                "/modeltargets/datasets",
+                id="advanced-dataset-via-standard-routes",
+            ),
+        ],
+    )
+    def test_dataset_is_not_visible_to_the_other_dataset_type(
+        *,
+        created_path: str,
+        other_path: str,
+    ) -> None:
+        """A dataset is not reachable through the other type's routes.
+
+        Standard and advanced datasets are separate resources in real
+        Vuforia, with separate OAuth scopes. This is mock-only because the
+        available test account lacks the advanced-dataset scope, so real
+        Vuforia rejects advanced routes with a 403 before looking a dataset
+        up.
+        """
+        headers = {"Authorization": f"Bearer {_MOCK_BEARER_TOKEN}"}
+        with MockVWS():
+            create_response = requests.post(
+                url=f"{_VWS_HOST}{created_path}",
+                headers=headers,
+                json=_UNAUTHENTICATED_DATASET_REQUEST,
+                timeout=30,
+            )
+            assert create_response.status_code == HTTPStatus.CREATED
+            dataset_uuid = create_response.json()["uuid"]
+
+            other_responses = [
+                requests.get(
+                    url=f"{_VWS_HOST}{other_path}/{dataset_uuid}/status",
+                    headers=headers,
+                    timeout=30,
+                ),
+                requests.get(
+                    url=f"{_VWS_HOST}{other_path}/{dataset_uuid}/dataset",
+                    headers=headers,
+                    timeout=30,
+                ),
+                requests.delete(
+                    url=f"{_VWS_HOST}{other_path}/{dataset_uuid}",
+                    headers=headers,
+                    timeout=30,
+                ),
+            ]
+
+            # The dataset survives the delete attempt made through the other
+            # type's routes.
+            own_status_response = requests.get(
+                url=f"{_VWS_HOST}{created_path}/{dataset_uuid}/status",
+                headers=headers,
+                timeout=30,
+            )
+
+        for response in other_responses:
+            assert response.status_code == HTTPStatus.NOT_FOUND
+            error = response.json()["error"]
+            assert error["code"] == "NOT_FOUND"
+            assert error["message"] == (
+                "Could not find a model-view database with uuid "
+                f"{dataset_uuid}"
+            )
+            assert error["target"].startswith("userId:")
+
+        assert own_status_response.status_code == HTTPStatus.OK
+
 
 class TestStandardDataset:
     """Tests for standard Model Target datasets."""


### PR DESCRIPTION
Fixes #3393.

`ModelTargetDataset` recorded whether it was standard or advanced, but nothing read that field after creation. Datasets live in one flat dict keyed by UUID, and the status, download and delete handlers looked the UUID up without regard to which route family the request arrived on — so a dataset created at `POST /modeltargets/datasets` could be polled, downloaded and deleted through `/modeltargets/advancedDatasets/{uuid}` and the other way around.

Real Vuforia treats the two as separate resources, with separate documented OAuth scopes. Code which polls or deletes through the wrong endpoint family passed against the mock and would fail against real Vuforia, with no signal from the mock.

## Change

The status, download and delete handlers now take the route's `dataset_type` and treat a dataset of the other type as absent, returning the existing Vuforia-shaped unknown-dataset error (404 `NOT_FOUND`, `target` of `userId:mock`). Both backends — the in-process requests mock and the Flask app — pass the type from their route definitions.

The 404 shape is the issue's "obvious first guess" rather than an observed real-Vuforia response: the available test account lacks the advanced-dataset scope, so real Vuforia rejects advanced routes with a 403 before looking a dataset up. The new test is therefore in `TestMockOnlyErrors`, and `differences-to-vws.rst` records both the new behaviour and the fact that a client without the advanced scope may see a different error.

## Tests

`TestMockOnlyErrors::test_dataset_is_not_visible_to_the_other_dataset_type` creates a dataset through one route family, asserts status, download and delete all return the unknown-dataset error through the other family, and asserts the dataset survives the cross-type delete. Both directions are parametrised. Verified that both parameters fail without the source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)