### PR TITLE
Support cadDataBlob for Model Target dataset creation

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -251,16 +251,22 @@ reported as missing every required top-level field.
 Dataset creation requests are validated for the required top-level ``models``,
 ``name`` and ``targetSdk`` fields, for those fields' types, for each ``models``
 entry being a JSON object, and for the number of models.
-Each model is validated for the required ``cadDataUrl`` and ``name`` fields,
-for those fields' types, and for ``views`` being a JSON array when it is given.
+Each model is validated for the required ``name`` field, for exactly one of
+``cadDataUrl`` and ``cadDataBlob`` being given, for the types of the
+``cadDataBlob``, ``cadDataFormat``, ``cadDataUrl`` and ``name`` fields, for
+``cadDataFormat`` being one of ``DAE``, ``FBX``, ``GLB``, ``IGES``, ``OBJ``,
+``PVZ``, ``STL``, ``VRML`` and ``ZIP`` when it is given, and for ``views``
+being a JSON array when it is given.
 Each ``views`` entry is validated for being a JSON object, for the required
 ``guideViewPosition`` and ``name`` fields, and for those fields' types.
 Each ``guideViewPosition`` object is validated for the required ``rotation``
 and ``translation`` fields, for those fields being JSON arrays, and for the
 elements of those arrays being JSON numbers.
 The mock does not validate the contents of each model further, such as whether
-``cadDataUrl`` values are reachable, the lengths of ``rotation`` and
-``translation`` arrays, or ``targetSdk`` version numbers.
+``cadDataUrl`` values are reachable, whether ``cadDataBlob`` values are valid
+base64-encoded archives of the named ``cadDataFormat``, whether
+``cadDataFormat`` is given alongside ``cadDataBlob``, the lengths of
+``rotation`` and ``translation`` arrays, or ``targetSdk`` version numbers.
 
 For unknown Model Target datasets, the mock returns an error whose ``target`` is ``userId:mock``.
 Real Vuforia uses ``userId:<numeric-user-id>`` where the numeric portion is per-account.

--- a/newsfragments/model-target-cad-data-blob.change
+++ b/newsfragments/model-target-cad-data-blob.change
@@ -1,0 +1,1 @@
+Support ``cadDataBlob`` and ``cadDataFormat`` in Model Target dataset creation requests, and require exactly one of ``cadDataUrl`` and ``cadDataBlob`` for each model.

--- a/newsfragments/model-target-model-fields.change
+++ b/newsfragments/model-target-model-fields.change
@@ -1,1 +1,1 @@
-Reject Model Target dataset creation requests with models which are missing ``cadDataUrl`` or ``name``, or which have wrongly typed ``cadDataUrl``, ``name`` or ``views`` values.
+Reject Model Target dataset creation requests with models which are missing ``name``, or which have wrongly typed ``cadDataUrl``, ``name`` or ``views`` values.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -31,6 +31,21 @@ _MOCK_MODEL_TARGET_CLIENT_SECRET = "client-secret"  # noqa: S105
 # ``userId:7635391``. The numeric portion is per-account in real Vuforia;
 # the mock uses a fixed placeholder.
 _MOCK_USER_TARGET = "userId:mock"
+# The CAD data formats documented by the Model Target Web API OpenAPI
+# specification.
+_CAD_DATA_FORMATS = frozenset(
+    {
+        "DAE",
+        "FBX",
+        "GLB",
+        "IGES",
+        "OBJ",
+        "PVZ",
+        "STL",
+        "VRML",
+        "ZIP",
+    },
+)
 
 
 @beartype
@@ -359,19 +374,39 @@ def _load_request_json(request: RequestData) -> dict[str, Any] | _ResponseType:
 
 
 @beartype
+def _cad_data_source_details(*, models: list[Any]) -> list[dict[str, str]]:
+    """Return validation details for each model's CAD data source.
+
+    One and only one of ``cadDataUrl`` and ``cadDataBlob`` may be given per
+    model.
+    """
+    return [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({index}): one and only one of cadDataUrl and "
+                "cadDataBlob is required"
+            ),
+        }
+        for index, model in enumerate(iterable=models)
+        if ("cadDataUrl" in model) == ("cadDataBlob" in model)
+    ]
+
+
+@beartype
 def _model_field_details(*, models: list[Any]) -> list[dict[str, str]]:
     """Return validation details for the fields of each model."""
     missing_details = [
         {
             "code": "VALIDATION_ERROR",
-            "message": f"/models({index})/{field}: element is required",
+            "message": f"/models({index})/name: element is required",
         }
         for index, model in enumerate(iterable=models)
-        for field in ("cadDataUrl", "name")
-        if field not in model
+        if "name" not in model
     ]
-    if missing_details:
-        return missing_details
+    cad_data_source_details = _cad_data_source_details(models=models)
+    if missing_details or cad_data_source_details:
+        return missing_details + cad_data_source_details
 
     string_details = [
         {
@@ -379,8 +414,22 @@ def _model_field_details(*, models: list[Any]) -> list[dict[str, str]]:
             "message": f"/models({index})/{field}: error.expected.jsstring",
         }
         for index, model in enumerate(iterable=models)
-        for field in ("cadDataUrl", "name")
-        if not isinstance(model[field], str)
+        for field in ("cadDataBlob", "cadDataFormat", "cadDataUrl", "name")
+        if field in model and not isinstance(model[field], str)
+    ]
+    if string_details:
+        return string_details
+
+    format_details = [
+        {
+            "code": "VALIDATION_ERROR",
+            "message": (
+                f"/models({index})/cadDataFormat: error.expected.validenum"
+            ),
+        }
+        for index, model in enumerate(iterable=models)
+        if "cadDataFormat" in model
+        and model["cadDataFormat"] not in _CAD_DATA_FORMATS
     ]
     views_details = [
         {
@@ -390,7 +439,7 @@ def _model_field_details(*, models: list[Any]) -> list[dict[str, str]]:
         for index, model in enumerate(iterable=models)
         if "views" in model and not isinstance(model["views"], list)
     ]
-    return string_details + views_details
+    return format_details + views_details
 
 
 @beartype

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -1,7 +1,9 @@
 """Verified fake tests for the Model Target Web API."""
 
 import base64
+import io
 import json
+import zipfile
 from http import HTTPMethod, HTTPStatus
 from typing import Any
 from uuid import uuid4
@@ -46,10 +48,41 @@ def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
     }
 
 
+def _cad_data_blob() -> str:
+    """Return a base64-encoded zipped model for inline CAD data."""
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(file=zip_buffer, mode="w") as zip_file:
+        zip_file.writestr(
+            zinfo_or_arcname="model.gltf",
+            data=json.dumps(obj={"asset": {"version": "2.0"}}),
+        )
+    return base64.b64encode(s=zip_buffer.getvalue()).decode(encoding="ascii")
+
+
+def _blob_dataset_request() -> dict[str, Any]:
+    """Return a standard dataset request with inline CAD data."""
+    return {
+        "name": f"dataset-{uuid4().hex}",
+        "targetSdk": "10.18",
+        "models": [
+            {
+                "name": "model-name",
+                "cadDataBlob": _cad_data_blob(),
+                "cadDataFormat": "ZIP",
+                "views": [_VIEW],
+            },
+        ],
+    }
+
+
 _MODEL: dict[str, Any] = {
     "name": "model-name",
     "cadDataUrl": "https://example.com/model.glb",
     "views": [_VIEW],
+}
+
+_MODEL_WITHOUT_CAD_DATA: dict[str, Any] = {
+    key: value for key, value in _MODEL.items() if key != "cadDataUrl"
 }
 
 _EMPTY_MODEL: dict[str, Any] = {}
@@ -571,10 +604,45 @@ class TestErrorResponses:
                     "models": [_EMPTY_MODEL],
                 },
                 {
-                    "/models(0)/cadDataUrl: element is required",
+                    (
+                        "/models(0): one and only one of cadDataUrl and "
+                        "cadDataBlob is required"
+                    ),
                     "/models(0)/name: element is required",
                 },
                 id="model-missing-fields",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [_MODEL_WITHOUT_CAD_DATA],
+                },
+                {
+                    (
+                        "/models(0): one and only one of cadDataUrl and "
+                        "cadDataBlob is required"
+                    ),
+                },
+                id="model-without-cad-data",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL,
+                            "cadDataBlob": "ZmFrZQ==",
+                            "cadDataFormat": "ZIP",
+                        },
+                    ],
+                },
+                {
+                    (
+                        "/models(0): one and only one of cadDataUrl and "
+                        "cadDataBlob is required"
+                    ),
+                },
+                id="model-with-both-cad-data-sources",
             ),
             pytest.param(
                 {
@@ -588,6 +656,36 @@ class TestErrorResponses:
                 },
                 {"/models(0)/cadDataUrl: error.expected.jsstring"},
                 id="model-cad-data-url-not-string",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [
+                        {
+                            **_MODEL_WITHOUT_CAD_DATA,
+                            "cadDataBlob": 1,
+                            "cadDataFormat": "ZIP",
+                        },
+                    ],
+                },
+                {"/models(0)/cadDataBlob: error.expected.jsstring"},
+                id="model-cad-data-blob-not-string",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [{**_MODEL, "cadDataFormat": 1}],
+                },
+                {"/models(0)/cadDataFormat: error.expected.jsstring"},
+                id="model-cad-data-format-not-string",
+            ),
+            pytest.param(
+                {
+                    **_UNAUTHENTICATED_DATASET_REQUEST,
+                    "models": [{**_MODEL, "cadDataFormat": "gltf"}],
+                },
+                {"/models(0)/cadDataFormat: error.expected.validenum"},
+                id="model-cad-data-format-not-in-enum",
             ),
             pytest.param(
                 {
@@ -1082,6 +1180,49 @@ class TestStandardDataset:
                 "failed",
             }
             assert isinstance(status_response_json["createdAt"], str)
+        finally:
+            if dataset_uuid is not None:  # pragma: no branch
+                delete_response = requests.delete(
+                    url=f"{_VWS_HOST}/modeltargets/datasets/{dataset_uuid}",
+                    headers=headers,
+                    timeout=30,
+                )
+                assert delete_response.status_code in {
+                    HTTPStatus.OK,
+                    HTTPStatus.NO_CONTENT,
+                }
+
+    @staticmethod
+    def test_create_with_cad_data_blob(
+        *,
+        verify_model_target_mock_vuforia: VuforiaBackend,
+    ) -> None:
+        """A dataset can be created with inline CAD data."""
+        credentials = _credentials_for_backend(
+            backend=verify_model_target_mock_vuforia,
+        )
+        access_token = _get_access_token(
+            credentials=credentials,
+            backend=verify_model_target_mock_vuforia,
+        )
+        headers = {"Authorization": f"Bearer {access_token}"}
+        dataset_uuid: str | None = None
+
+        try:
+            create_response = requests.post(
+                url=f"{_VWS_HOST}/modeltargets/datasets",
+                headers=headers,
+                json=_blob_dataset_request(),
+                timeout=30,
+            )
+
+            assert create_response.status_code == HTTPStatus.CREATED
+            create_response_json: dict[str, Any] = json.loads(
+                s=create_response.text,
+            )
+            dataset_uuid_value = create_response_json["uuid"]
+            assert isinstance(dataset_uuid_value, str)
+            dataset_uuid = dataset_uuid_value
         finally:
             if dataset_uuid is not None:  # pragma: no branch
                 delete_response = requests.delete(

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import pytest
 import requests
+from beartype import beartype
 
 from mock_vws import MockVWS
 from mock_vws.model_target import ModelTargetDataset, ModelTargetDatasetType
@@ -48,6 +49,7 @@ def _dataset_request(*, cad_data_url: str) -> dict[str, Any]:
     }
 
 
+@beartype
 def _cad_data_blob() -> str:
     """Return a base64-encoded zipped model for inline CAD data."""
     zip_buffer = io.BytesIO()
@@ -59,6 +61,7 @@ def _cad_data_blob() -> str:
     return base64.b64encode(s=zip_buffer.getvalue()).decode(encoding="ascii")
 
 
+@beartype
 def _blob_dataset_request() -> dict[str, Any]:
     """Return a standard dataset request with inline CAD data."""
     return {

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -1206,34 +1206,33 @@ class TestStandardDataset:
             backend=verify_model_target_mock_vuforia,
         )
         headers = {"Authorization": f"Bearer {access_token}"}
-        dataset_uuid: str | None = None
 
-        try:
-            create_response = requests.post(
-                url=f"{_VWS_HOST}/modeltargets/datasets",
-                headers=headers,
-                json=_blob_dataset_request(),
-                timeout=30,
-            )
+        create_response = requests.post(
+            url=f"{_VWS_HOST}/modeltargets/datasets",
+            headers=headers,
+            json=_blob_dataset_request(),
+            timeout=30,
+        )
 
-            assert create_response.status_code == HTTPStatus.CREATED
-            create_response_json: dict[str, Any] = json.loads(
-                s=create_response.text,
-            )
-            dataset_uuid_value = create_response_json["uuid"]
-            assert isinstance(dataset_uuid_value, str)
-            dataset_uuid = dataset_uuid_value
-        finally:
-            if dataset_uuid is not None:  # pragma: no branch
-                delete_response = requests.delete(
-                    url=f"{_VWS_HOST}/modeltargets/datasets/{dataset_uuid}",
-                    headers=headers,
-                    timeout=30,
-                )
-                assert delete_response.status_code in {
-                    HTTPStatus.OK,
-                    HTTPStatus.NO_CONTENT,
-                }
+        assert create_response.status_code == HTTPStatus.CREATED
+        create_response_json: dict[str, Any] = json.loads(
+            s=create_response.text,
+        )
+        dataset_uuid = create_response_json["uuid"]
+        assert isinstance(dataset_uuid, str)
+
+        # There is nothing to assert between creating and deleting the
+        # dataset, so the delete does not need a ``finally`` block to avoid
+        # leaving a dataset behind on real Vuforia.
+        delete_response = requests.delete(
+            url=f"{_VWS_HOST}/modeltargets/datasets/{dataset_uuid}",
+            headers=headers,
+            timeout=30,
+        )
+        assert delete_response.status_code in {
+            HTTPStatus.OK,
+            HTTPStatus.NO_CONTENT,
+        }
 
 
 class TestModelTargetDatasetStatus:


### PR DESCRIPTION
Model Target dataset creation now accepts inline CAD data: each model must give one and only one of `cadDataUrl` and `cadDataBlob`, and `cadDataFormat` is validated against the documented enum (`DAE`, `FBX`, `GLB`, `IGES`, `OBJ`, `PVZ`, `STL`, `VRML`, `ZIP`) when it is given.
Verified fake tests cover the blob happy path and the both/neither and wrong-type/out-of-enum error cases.
`docs/source/differences-to-vws.rst` no longer says `cadDataUrl` is required and now records what stays out of scope: the mock does not check that a blob decodes to an archive of the named format, and it does not require `cadDataFormat` alongside `cadDataBlob`, since the OpenAPI page could not be fetched and the test account's real credentials currently xfail.

Closes #3347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)