### PR TITLE
Validate VuMark instance_id type in a shared validator

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -224,6 +224,15 @@ The mock returns a fixed minimal image in the requested format.
 The ``instance_id`` value is not encoded into the response image.
 Real Vuforia encodes the instance ID into the VuMark pattern.
 
+The mock returns an ``InvalidInstanceId`` result when the ``instance_id``
+value is a JSON array or object, or when it is an empty scalar value such as
+``""``, ``0``, ``false``, or ``null``.
+Other non-string scalar values, such as non-zero numbers and ``true``, are
+accepted.
+Real Vuforia's behavior for non-string instance IDs has not been verified,
+in particular for ``0`` against a VuMark template with a numeric instance ID
+type.
+
 Model Target datasets
 ---------------------
 

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -224,15 +224,6 @@ The mock returns a fixed minimal image in the requested format.
 The ``instance_id`` value is not encoded into the response image.
 Real Vuforia encodes the instance ID into the VuMark pattern.
 
-The mock returns an ``InvalidInstanceId`` result when the ``instance_id``
-value is a JSON array or object, or when it is an empty scalar value such as
-``""``, ``0``, ``false``, or ``null``.
-Other non-string scalar values, such as non-zero numbers and ``true``, are
-accepted.
-Real Vuforia's behavior for non-string instance IDs has not been verified,
-in particular for ``0`` against a VuMark template with a numeric instance ID
-type.
-
 Model Target datasets
 ---------------------
 

--- a/newsfragments/vumark-instance-id-type.change
+++ b/newsfragments/vumark-instance-id-type.change
@@ -1,1 +1,1 @@
-Reject VuMark instance generation requests whose ``instance_id`` is a JSON array or object with an ``InvalidInstanceId`` result, and move the ``instance_id`` check into a validator shared by both mock backends.
+Reject VuMark instance generation requests whose ``instance_id`` is not a string with a ``BadRequest`` result, as real Vuforia does, and move the ``instance_id`` checks into validators shared by both mock backends.

--- a/newsfragments/vumark-instance-id-type.change
+++ b/newsfragments/vumark-instance-id-type.change
@@ -1,0 +1,1 @@
+Reject VuMark instance generation requests whose ``instance_id`` is a JSON array or object with an ``InvalidInstanceId`` result, and move the ``instance_id`` check into a validator shared by both mock backends.

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -47,7 +47,6 @@ from mock_vws._services_validators import run_services_validators
 from mock_vws._services_validators.exceptions import (
     FailError,
     InvalidAcceptHeaderError,
-    InvalidInstanceIdError,
     InvalidTargetTypeError,
     TargetStatusNotSuccessError,
     TargetStatusProcessingError,
@@ -707,11 +706,6 @@ def generate_vumark_instance(target_id: str) -> Response:
     }
     if accept not in valid_accept_types:
         raise InvalidAcceptHeaderError
-
-    request_json = json.loads(s=request.data)
-    instance_id = request_json.get("instance_id", "")
-    if not instance_id:
-        raise InvalidInstanceIdError
 
     response_body = valid_accept_types[accept]
     content_type = accept

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -48,7 +48,6 @@ from mock_vws._services_validators import run_services_validators
 from mock_vws._services_validators.exceptions import (
     FailError,
     InvalidAcceptHeaderError,
-    InvalidInstanceIdError,
     InvalidTargetTypeError,
     TargetStatusNotSuccessError,
     TargetStatusProcessingError,
@@ -604,11 +603,6 @@ class MockVuforiaWebServicesAPI:
             accept = dict(request.headers).get("Accept", "")
             if accept not in valid_accept_types:
                 raise InvalidAcceptHeaderError
-
-            request_json = json.loads(s=request.body)
-            instance_id = request_json.get("instance_id", "")
-            if not instance_id:
-                raise InvalidInstanceIdError
         except ValidatorError as exc:
             return exc.status_code, exc.headers, exc.response_text
 

--- a/src/mock_vws/_services_validators/__init__.py
+++ b/src/mock_vws/_services_validators/__init__.py
@@ -35,7 +35,10 @@ from .image_validators import (
     validate_image_pixel_count,
     validate_image_size,
 )
-from .instance_id_validators import validate_instance_id
+from .instance_id_validators import (
+    validate_instance_id_not_empty,
+    validate_instance_id_type,
+)
 from .json_validators import validate_body_given, validate_json
 from .key_validators import validate_keys
 from .metadata_validators import (
@@ -158,7 +161,8 @@ def run_services_validators(
     validate_metadata_encoding(request_body=request_body)
     validate_metadata_size(request_body=request_body)
     validate_active_flag(request_body=request_body)
-    validate_instance_id(request_body=request_body)
+    validate_instance_id_type(request_body=request_body)
+    validate_instance_id_not_empty(request_body=request_body)
 
     validate_image_data_type(request_body=request_body)
     validate_image_encoding(request_body=request_body)

--- a/src/mock_vws/_services_validators/__init__.py
+++ b/src/mock_vws/_services_validators/__init__.py
@@ -35,6 +35,7 @@ from .image_validators import (
     validate_image_pixel_count,
     validate_image_size,
 )
+from .instance_id_validators import validate_instance_id
 from .json_validators import validate_body_given, validate_json
 from .key_validators import validate_keys
 from .metadata_validators import (
@@ -157,6 +158,7 @@ def run_services_validators(
     validate_metadata_encoding(request_body=request_body)
     validate_metadata_size(request_body=request_body)
     validate_active_flag(request_body=request_body)
+    validate_instance_id(request_body=request_body)
 
     validate_image_data_type(request_body=request_body)
     validate_image_encoding(request_body=request_body)

--- a/src/mock_vws/_services_validators/instance_id_validators.py
+++ b/src/mock_vws/_services_validators/instance_id_validators.py
@@ -1,0 +1,45 @@
+"""Validators for VuMark instance IDs."""
+
+import json
+import logging
+
+from beartype import beartype
+
+from mock_vws._services_validators.exceptions import InvalidInstanceIdError
+
+_LOGGER = logging.getLogger(name=__name__)
+
+
+@beartype
+def validate_instance_id(*, request_body: bytes) -> None:
+    """Validate the instance_id data given to the VuMark instance
+    generation endpoint.
+
+    Args:
+        request_body: The body of the request.
+
+    Raises:
+        InvalidInstanceIdError: There is instance_id data given to the
+            endpoint which is a JSON array or object, or which is empty.
+    """
+    if not request_body:
+        return
+
+    request_text = request_body.decode()
+    if "instance_id" not in json.loads(s=request_text):
+        return
+
+    instance_id = json.loads(s=request_text)["instance_id"]
+
+    if isinstance(instance_id, dict | list):
+        _LOGGER.warning(
+            msg=(
+                'The value of "instance_id" is a JSON array or object. '
+                "This is not allowed."
+            ),
+        )
+        raise InvalidInstanceIdError
+
+    if not instance_id:
+        _LOGGER.warning(msg='The value of "instance_id" is empty.')
+        raise InvalidInstanceIdError

--- a/src/mock_vws/_services_validators/instance_id_validators.py
+++ b/src/mock_vws/_services_validators/instance_id_validators.py
@@ -5,22 +5,25 @@ import logging
 
 from beartype import beartype
 
-from mock_vws._services_validators.exceptions import InvalidInstanceIdError
+from mock_vws._services_validators.exceptions import (
+    BadRequestError,
+    InvalidInstanceIdError,
+)
 
 _LOGGER = logging.getLogger(name=__name__)
 
 
 @beartype
-def validate_instance_id(*, request_body: bytes) -> None:
-    """Validate the instance_id data given to the VuMark instance
-    generation endpoint.
+def validate_instance_id_type(*, request_body: bytes) -> None:
+    """Validate the type of the instance_id data given to the VuMark
+    instance generation endpoint.
 
     Args:
         request_body: The body of the request.
 
     Raises:
-        InvalidInstanceIdError: There is instance_id data given to the
-            endpoint which is a JSON array or object, or which is empty.
+        BadRequestError: There is instance_id data given to the endpoint
+            which is not a string.
     """
     if not request_body:
         return
@@ -31,15 +34,38 @@ def validate_instance_id(*, request_body: bytes) -> None:
 
     instance_id = json.loads(s=request_text)["instance_id"]
 
-    if isinstance(instance_id, dict | list):
-        _LOGGER.warning(
-            msg=(
-                'The value of "instance_id" is a JSON array or object. '
-                "This is not allowed."
-            ),
-        )
-        raise InvalidInstanceIdError
+    if isinstance(instance_id, str):
+        return
 
-    if not instance_id:
-        _LOGGER.warning(msg='The value of "instance_id" is empty.')
-        raise InvalidInstanceIdError
+    _LOGGER.warning(
+        msg='The value of "instance_id" is not a string. This is not allowed.',
+    )
+    raise BadRequestError
+
+
+@beartype
+def validate_instance_id_not_empty(*, request_body: bytes) -> None:
+    """Validate that the instance_id data given to the VuMark instance
+    generation endpoint is not empty.
+
+    Args:
+        request_body: The body of the request.
+
+    Raises:
+        InvalidInstanceIdError: There is instance_id data given to the
+            endpoint which is an empty string.
+    """
+    if not request_body:
+        return
+
+    request_text = request_body.decode()
+    if "instance_id" not in json.loads(s=request_text):
+        return
+
+    instance_id = json.loads(s=request_text)["instance_id"]
+
+    if instance_id:
+        return
+
+    _LOGGER.warning(msg='The value of "instance_id" is empty.')
+    raise InvalidInstanceIdError

--- a/tests/mock_vws/test_vumark_generation_api.py
+++ b/tests/mock_vws/test_vumark_generation_api.py
@@ -204,25 +204,26 @@ class TestGenerateInstance:
     @pytest.mark.parametrize(
         argnames="instance_id",
         argvalues=[
+            pytest.param(5, id="int"),
+            pytest.param(0, id="zero"),
+            pytest.param(0.0, id="zero_float"),
+            pytest.param(1.5, id="float"),
+            pytest.param(True, id="true"),
+            pytest.param(False, id="false"),
             pytest.param([1], id="array"),
             pytest.param([], id="empty_array"),
             pytest.param({"a": 1}, id="object"),
             pytest.param({}, id="empty_object"),
-            pytest.param(0, id="zero"),
-            pytest.param(0.0, id="zero_float"),
-            pytest.param(False, id="false"),
             pytest.param(None, id="null"),
         ],
     )
     @staticmethod
-    def test_invalid_instance_id(
+    def test_non_string_instance_id(
         *,
         instance_id: object,
         vumark_vuforia_database: VuMarkCloudDatabase,
     ) -> None:
-        """A JSON array or object instance_id, or an empty scalar
-        instance_id, returns InvalidInstanceId.
-        """
+        """An instance_id which is not a string returns BadRequest."""
         response = _make_vumark_request(
             server_access_key=vumark_vuforia_database.server_access_key,
             server_secret_key=vumark_vuforia_database.server_secret_key,
@@ -231,40 +232,9 @@ class TestGenerateInstance:
             accept="image/png",
         )
 
-        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert response.status_code == HTTPStatus.BAD_REQUEST
         response_json = response.json()
-        assert (
-            response_json["result_code"]
-            == ResultCodes.INVALID_INSTANCE_ID.value
-        )
-
-    @pytest.mark.parametrize(
-        argnames="instance_id",
-        argvalues=[
-            pytest.param(5, id="int"),
-            pytest.param(1.5, id="float"),
-            pytest.param(True, id="true"),
-        ],
-    )
-    @staticmethod
-    def test_non_string_scalar_instance_id(
-        *,
-        instance_id: object,
-        vumark_vuforia_database: VuMarkCloudDatabase,
-    ) -> None:
-        """A non-empty scalar instance_id which is not a string is
-        accepted.
-        """
-        response = _make_vumark_request(
-            server_access_key=vumark_vuforia_database.server_access_key,
-            server_secret_key=vumark_vuforia_database.server_secret_key,
-            target_id=vumark_vuforia_database.target_id,
-            instance_id=instance_id,
-            accept="image/png",
-        )
-
-        assert response.status_code == HTTPStatus.OK
-        assert response.content.startswith(_PNG_SIGNATURE)
+        assert response_json["result_code"] == ResultCodes.BAD_REQUEST.value
 
     @staticmethod
     def test_unknown_target(

--- a/tests/mock_vws/test_vumark_generation_api.py
+++ b/tests/mock_vws/test_vumark_generation_api.py
@@ -24,6 +24,10 @@ from tests.mock_vws.fixtures.credentials import (
 )
 from tests.mock_vws.utils import make_image_file
 
+type _JsonValue = (
+    str | int | float | bool | list[_JsonValue] | dict[str, _JsonValue] | None
+)
+
 _VWS_HOST = "https://vws.vuforia.com"
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 _PDF_SIGNATURE = b"%PDF"
@@ -49,7 +53,7 @@ def _make_vumark_request(
     server_access_key: str,
     server_secret_key: str,
     target_id: str,
-    instance_id: object,
+    instance_id: _JsonValue,
     accept: str,
 ) -> requests.Response:
     """Send a VuMark instance generation request and return the
@@ -220,7 +224,7 @@ class TestGenerateInstance:
     @staticmethod
     def test_non_string_instance_id(
         *,
-        instance_id: object,
+        instance_id: _JsonValue,
         vumark_vuforia_database: VuMarkCloudDatabase,
     ) -> None:
         """An instance_id which is not a string returns BadRequest."""

--- a/tests/mock_vws/test_vumark_generation_api.py
+++ b/tests/mock_vws/test_vumark_generation_api.py
@@ -49,7 +49,7 @@ def _make_vumark_request(
     server_access_key: str,
     server_secret_key: str,
     target_id: str,
-    instance_id: str,
+    instance_id: object,
     accept: str,
 ) -> requests.Response:
     """Send a VuMark instance generation request and return the
@@ -200,6 +200,71 @@ class TestGenerateInstance:
             response_json["result_code"]
             == ResultCodes.INVALID_INSTANCE_ID.value
         )
+
+    @pytest.mark.parametrize(
+        argnames="instance_id",
+        argvalues=[
+            pytest.param([1], id="array"),
+            pytest.param([], id="empty_array"),
+            pytest.param({"a": 1}, id="object"),
+            pytest.param({}, id="empty_object"),
+            pytest.param(0, id="zero"),
+            pytest.param(0.0, id="zero_float"),
+            pytest.param(False, id="false"),
+            pytest.param(None, id="null"),
+        ],
+    )
+    @staticmethod
+    def test_invalid_instance_id(
+        *,
+        instance_id: object,
+        vumark_vuforia_database: VuMarkCloudDatabase,
+    ) -> None:
+        """A JSON array or object instance_id, or an empty scalar
+        instance_id, returns InvalidInstanceId.
+        """
+        response = _make_vumark_request(
+            server_access_key=vumark_vuforia_database.server_access_key,
+            server_secret_key=vumark_vuforia_database.server_secret_key,
+            target_id=vumark_vuforia_database.target_id,
+            instance_id=instance_id,
+            accept="image/png",
+        )
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        response_json = response.json()
+        assert (
+            response_json["result_code"]
+            == ResultCodes.INVALID_INSTANCE_ID.value
+        )
+
+    @pytest.mark.parametrize(
+        argnames="instance_id",
+        argvalues=[
+            pytest.param(5, id="int"),
+            pytest.param(1.5, id="float"),
+            pytest.param(True, id="true"),
+        ],
+    )
+    @staticmethod
+    def test_non_string_scalar_instance_id(
+        *,
+        instance_id: object,
+        vumark_vuforia_database: VuMarkCloudDatabase,
+    ) -> None:
+        """A non-empty scalar instance_id which is not a string is
+        accepted.
+        """
+        response = _make_vumark_request(
+            server_access_key=vumark_vuforia_database.server_access_key,
+            server_secret_key=vumark_vuforia_database.server_secret_key,
+            target_id=vumark_vuforia_database.target_id,
+            instance_id=instance_id,
+            accept="image/png",
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.content.startswith(_PNG_SIGNATURE)
 
     @staticmethod
     def test_unknown_target(


### PR DESCRIPTION
Closes #3395.

The VuMark instance generation endpoint checked `instance_id` only for truthiness, inline in both backends, so the accept/reject split followed Python truthiness rather than any rule about instance IDs.

**Verified against a real VuMark database** by sending each JSON type to `POST /targets/<id>/instances`:

| `instance_id` sent | Real VWS response |
|---|---|
| `"abc123"` | 200, VuMark image |
| `""` | 422 `InvalidInstanceId` |
| `5`, `0`, `0.0`, `1.5`, `true`, `false`, `[1]`, `[]`, `{"a": 1}`, `{}`, `null` | 400 `BadRequest` |

So the old truthiness behavior was wrong in both directions: it accepted truthy non-strings (`5`, `true`, `[1]`) which real Vuforia rejects with `BadRequest`, and it returned `InvalidInstanceId` for falsy non-strings (`0`, `false`, `null`) where real Vuforia also returns `BadRequest`. The numeric-zero question from the issue is settled: even `0` is a `BadRequest`, so instance IDs must always be JSON strings.

**Changes**

- New `_services_validators/instance_id_validators.py`, shared by both backends so they cannot drift, with `validate_instance_id_type` (non-string → 400 `BadRequest`) and `validate_instance_id_not_empty` (empty string → 422 `InvalidInstanceId`). The inline truthiness checks are removed from both handlers.
- New parametrized test covering all eleven non-string values, expecting `BadRequest`; the raw-request helper's `instance_id` parameter widened from `str` to `object`.
- The whole `TestGenerateInstance` class passes against real Vuforia (one initial `TooManyRequests` flake on fixture setup passed on re-run), and all 1146 tests pass against the mock backends.

One behavioral note: the check now runs in the services validator chain, before the target-type, target-status, and Accept-header checks in the handlers, rather than after them. Only requests that are invalid in more than one way are affected, and no existing test depended on that ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)