### PR TITLE
Bump sphinx-substitution-extensions to 2026.8.13 and drop the toctree workaround

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,11 +42,6 @@ towncrier_draft_working_directory = f"{_pyproject_file.parent}"
 autodoc_use_legacy_class_based = True
 
 templates_path = ["_templates"]
-
-# These fragments are pulled into ``index.rst`` with ``include`` directives
-# rather than a toctree, so keep them out of the document collection to avoid
-# ``toc.not_included`` warnings.
-exclude_patterns = ["basic-example.rst", "httpx-example.rst"]
 source_suffix = ".rst"
 master_doc = "index"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ optional-dependencies.dev = [
     "sphinx-lint==1.0.2",
     "sphinx-paramlinks==0.6",
     "sphinx-pyproject==0.3.0",
-    "sphinx-substitution-extensions==2026.8.5",
+    "sphinx-substitution-extensions==2026.8.13",
     "sphinx-toolbox==4.3.0",
     "sphinxcontrib-httpdomain==2.0.0",
     "sphinxcontrib-spelling==8.0.2",
@@ -371,7 +371,6 @@ ignore_names = [
     "DatabaseDict",
     # Too difficult to test (see notes in the code)
     "DATE_RANGE_ERROR",
-    "exclude_patterns",
     "extensions",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -113,7 +113,6 @@ str
 stringify
 subprocess
 timestamp
-toctree
 todo
 travis
 txt

--- a/uv.lock
+++ b/uv.lock
@@ -2218,7 +2218,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-substitution-extensions"
-version = "2026.8.5"
+version = "2026.8.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "myst-parser" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/d9/d7bd4d3a396b05fa441b46e70d6b50971b219a521ffef5cc1f17f2aff7ed/sphinx_substitution_extensions-2026.8.5.tar.gz", hash = "sha256:c64c0c3cd4d2d4c59d761252876b0fd8367e1023bc54e333bf06b1a434965503", size = 42300, upload-time = "2026-08-05T12:21:17.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/39/d59f3efeea7bf81116f2cc832b6f7441b2cc1529082559de7bc0abd6a7ee/sphinx_substitution_extensions-2026.8.13.tar.gz", hash = "sha256:69c4f4aba98cf0546fe68e1676c9984bf164bf5ea78cddf899c748547dba412d", size = 44305, upload-time = "2026-08-13T09:09:04.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/2a/8d3315e55c53c56db1a178e78a6081d65fde7607f6ae8f9b81e91cf5e8d9/sphinx_substitution_extensions-2026.8.5-py3-none-any.whl", hash = "sha256:2eda9c056ccf760cf227c0f76cfc6e7875c89fa8edacf64e7518fcfbd029c623", size = 11773, upload-time = "2026-08-05T12:21:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/81/df/ccecfbfef61f007f9831d47f00f7c3a63e3b2f50bc65fc68fc1522a3ace7/sphinx_substitution_extensions-2026.8.13-py3-none-any.whl", hash = "sha256:31963b1364aea56661b4085d32555983ac44f5ac263f77a310bc34b9d00a9de6", size = 12078, upload-time = "2026-08-13T09:09:03.536Z" },
 ]
 
 [[package]]
@@ -2843,7 +2843,7 @@ requires-dist = [
     { name = "sphinx-lint", marker = "extra == 'dev'", specifier = "==1.0.2" },
     { name = "sphinx-paramlinks", marker = "extra == 'dev'", specifier = "==0.6" },
     { name = "sphinx-pyproject", marker = "extra == 'dev'", specifier = "==0.3.0" },
-    { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.8.5" },
+    { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.8.13" },
     { name = "sphinx-toolbox", marker = "extra == 'dev'", specifier = "==4.3.0" },
     { name = "sphinxcontrib-httpdomain", marker = "extra == 'dev'", specifier = "==2.0.0" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },


### PR DESCRIPTION
Bumps `sphinx-substitution-extensions` from 2026.8.5 to 2026.8.13.

2026.8.13 bases its `include` directive override on Sphinx's `Include` (adamtheturtle/sphinx-substitution-extensions#1632, #1633, #1634), restoring `env.note_included` tracking for included files. That makes the workaround added in #3433 unnecessary, so this also reverts it:

- the `exclude_patterns` entry in `docs/source/conf.py` for the include-only fragments
- the matching `exclude_patterns` vulture `ignore_names` entry
- the `toctree` spelling-dictionary word (only used by the removed comment)

Verified locally: `sphinx-build -M linkcheck/html/spelling -W` all succeed with the workaround removed, and the fragments still render into `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)