### PR TITLE
Reject Model Target request bodies which are not valid UTF-8

### DIFF
--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -248,6 +248,11 @@ token revocation.
 
 Dataset creation request bodies which are valid JSON but not JSON objects are
 reported as missing every required top-level field.
+Dataset creation request bodies which cannot be decoded as UTF-8 are reported
+as invalid JSON, as malformed JSON bodies are.
+An OAuth2 token request body which cannot be decoded as UTF-8 is treated as one
+which does not name a grant type; the real response to such a body has not been
+observed.
 Dataset creation requests are validated for the required top-level ``models``,
 ``name`` and ``targetSdk`` fields, for those fields' types, for each ``models``
 entry being a JSON object, and for the number of models.

--- a/newsfragments/model-target-non-utf-8-body.change
+++ b/newsfragments/model-target-non-utf-8-body.change
@@ -1,0 +1,1 @@
+Reject Model Target dataset creation requests with a body which cannot be decoded as UTF-8, rather than raising an error in the mock, and decode OAuth2 token request bodies leniently.

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -338,7 +338,12 @@ def _fake_jwt(*, token_source: bytes) -> str:
 def oauth2_token(request: RequestData) -> _ResponseType:
     """Return a fake OAuth2 access token."""
     auth_header = _get_header(request=request, name="Authorization")
-    form = parse_qs(qs=request.body.decode(encoding="utf-8"))
+    # A form body which is not valid UTF-8 is decoded leniently rather than
+    # raising, so that a body which cannot be decoded is treated as one which
+    # does not name a grant type.
+    form = parse_qs(
+        qs=request.body.decode(encoding="utf-8", errors="replace"),
+    )
     grant_type = form.get("grant_type", ["client_credentials"])[0]
     if grant_type != "client_credentials":
         return _oauth2_error_response(
@@ -397,8 +402,10 @@ def _load_request_json(request: RequestData) -> dict[str, Any] | _ResponseType:
             details=None,
         )
     try:
-        request_json: dict[str, Any] = json.loads(s=request.body)
-    except json.JSONDecodeError as exc:
+        request_json: dict[str, Any] = json.loads(
+            s=request.body.decode(encoding="utf-8"),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         return _error_response(
             status_code=HTTPStatus.BAD_REQUEST,
             code="ERROR",

--- a/tests/mock_vws/test_model_target_web_api.py
+++ b/tests/mock_vws/test_model_target_web_api.py
@@ -435,6 +435,41 @@ class TestInvalidJson:
         assert "target" not in error
 
     @staticmethod
+    def test_body_not_utf_8(
+        *,
+        verify_model_target_mock_vuforia: VuforiaBackend,
+        model_target_endpoint: ModelTargetEndpoint,
+    ) -> None:
+        """Bodies which are not valid UTF-8 are rejected with 400 by
+        endpoints which read a body, and are ignored elsewhere.
+        """
+        access_token = _access_token_for_backend(
+            backend=verify_model_target_mock_vuforia,
+        )
+        content = b"\xff{}"
+        new_endpoint = dataclasses.replace(
+            model_target_endpoint,
+            headers={
+                **model_target_endpoint.headers,
+                "Authorization": f"Bearer {access_token}",
+                "Content-Length": str(object=len(content)),
+            },
+            data=content,
+        )
+
+        response = new_endpoint.send()
+
+        if not model_target_endpoint.takes_json_body:
+            _assert_unknown_dataset(response=response)
+            return
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        error = json.loads(s=response.text)["error"]
+        assert error["code"] == "ERROR"
+        assert error["message"].startswith("Invalid Json")
+        assert "target" not in error
+
+    @staticmethod
     @pytest.mark.parametrize(
         argnames="body",
         argvalues=[
@@ -1281,6 +1316,31 @@ class TestMockOnlyErrors:
         assert error["details"][0]["code"] == "VALIDATION_ERROR"
 
         assert standard_response.status_code == HTTPStatus.CREATED
+
+    @staticmethod
+    def test_oauth2_token_body_not_utf_8(
+        *,
+        model_target_mock_only_vuforia: VuforiaBackend,
+    ) -> None:
+        """An OAuth2 token request with a body which is not valid UTF-8 is
+        treated as one which does not name a grant type.
+
+        Mock-only because the real response to a form body which cannot be
+        decoded has not been observed.
+        """
+        credentials = credentials_for_backend(
+            backend=model_target_mock_only_vuforia,
+        )
+
+        response = requests.post(
+            url=f"{_VWS_HOST}/oauth2/token",
+            auth=(credentials.client_id, credentials.client_secret),
+            data=b"\xff",
+            timeout=30,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["token_type"] == "bearer"
 
     @staticmethod
     def test_processing_dataset_cannot_be_downloaded() -> None:


### PR DESCRIPTION
Towards #3193.

## What

`POST /modeltargets/datasets`, `POST /modeltargets/advancedDatasets` and `POST /oauth2/token` raised an uncaught `UnicodeDecodeError` when given a request body which is not valid UTF-8.

Dataset creation passed the raw body to `json.loads`, which decodes internally and raises `UnicodeDecodeError` — a `ValueError` but not a `JSONDecodeError`, so it fell through the `except json.JSONDecodeError` clause. The OAuth2 token route called `request.body.decode(encoding="utf-8")` with no handling at all.

This is the same category as #3391 and #3392: a body-parsing path which raises rather than returning an error response.

## Changes

- Dataset creation decodes the body explicitly and returns the existing Vuforia-shaped `400` / `ERROR` / `Invalid Json: ...` response for a body which is not valid UTF-8, as it already does for malformed JSON.
- The OAuth2 token route decodes its form body leniently, so a body which cannot be decoded is treated as one which does not name a grant type.
- Verified fake test `TestInvalidJson::test_body_not_utf_8`, which runs over every Model Target endpoint via the `model_target_endpoint` fixture: body-reading endpoints return the error, body-less endpoints ignore the body as before.
- `TestMockOnlyErrors::test_oauth2_token_body_not_utf_8` is mock-only because the real response to a form body which cannot be decoded has not been observed.
- `docs/source/differences-to-vws.rst` records both behaviours.

## Testing

`tests/mock_vws/test_model_target_web_api.py` passes against the in-memory and Docker-in-memory backends. The real-Vuforia parametrisations need CI secrets and are not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)