### PR TITLE
Pin moving third-party GitHub Actions references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
 
       - name: Calver calculate version
-        uses: StephaneBour/actions-calver@master
+        uses: StephaneBour/actions-calver@a9d6843abbe165bcc6497584cc08c3a42bb0c188  # master
         id: calver
         with:
           date_format: '%Y.%m.%d'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
 
       # We have seen issues with running out of disk space on test_docker
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
         if: matrix.ci_pattern == 'tests/mock_vws/test_docker.py'
         with:
           # All of these default to true (meaning they are removed).


### PR DESCRIPTION
Closes #3376.

## What
- Pin `StephaneBour/actions-calver` and `jlumbroso/free-disk-space` to full commit SHAs.
- Retain comments showing the branches those SHAs were resolved from.

## Why
Moving branch references can change without review and allow upstream changes to execute with workflow permissions.

## Checks
- `uv run prek run --files .github/workflows/test.yml .github/workflows/release.yml`