### PR TITLE
Correct the CI secrets setup procedure

### DIFF
--- a/docs/source/ci-setup.rst
+++ b/docs/source/ci-setup.rst
@@ -20,13 +20,16 @@ Create environment variable files for secrets:
 .. code-block:: console
 
    $ mkdir -p ci_secrets
+   $ cp vuforia_secrets.env.example ci_secrets/vuforia_secrets_0.env
    $ cp vuforia_secrets.env.example ci_secrets/vuforia_secrets_1.env
-   $ cp vuforia_secrets.env.example ci_secrets/vuforia_secrets_2.env
    $ ...
 
-Add Vuforia credentials for different target databases to the new files in the ``ci_secrets/`` directory.
-Add at least as many credentials files as there are builds in the GitHub test matrix.
-All credentials files can share the same credentials for an inactive database.
+Populate every variable listed in :file:`vuforia_secrets.env.example`.
+Each file needs distinct active Cloud database credentials so concurrent jobs
+do not modify the same database. The files can share the inactive Cloud,
+active and inactive VuMark, and Model Target credentials.
+Add at least as many consecutively numbered files, starting at zero, as there
+are builds in the GitHub test matrix.
 
 Choose a passphrase for the secrets.
 In the GitHub repository > Settings > Secrets, add a secret with the name ``PASSPHRASE_FOR_VUFORIA_SECRETS`` and the chosen passphrase.
@@ -35,7 +38,7 @@ Add the encrypted secrets files to the repository:
 
 .. code-block:: console
 
-   $ tar cvf secrets.tar ci_secrets/
+   $ tar cvf secrets.tar ci_secrets
    $ gpg --yes --batch --passphrase="${PASSPHRASE_FOR_VUFORIA_SECRETS}" --symmetric --cipher-algo AES256 secrets.tar
    $ git add secrets.tar.gpg
    $ git commit -m "Update secret archive"

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -102,17 +102,10 @@ To create databases without using the browser, use :file:`admin/create_secrets_f
       $ export NEW_SECRETS_DIR=...
       # You may have to run this a few times, but it is idempotent.
       $ python admin/create_secrets_files.py
-      # Each generated file gets its own Cloud database credentials and shares
-      # one VuMark database credential set.
-      # After creating the secrets, update the encrypted archive:
-      $ tar cvf secrets.tar "${NEW_SECRETS_DIR}"
-      $ gpg \
-         --yes \
-         --batch \
-         --passphrase="${PASSPHRASE_FOR_VUFORIA_SECRETS}" \
-         --symmetric \
-         --cipher-algo AES256 \
-         secrets.tar
+      # Each generated file gets its own active Cloud database credentials.
+
+For the complete archive and GitHub Actions setup procedure, see
+:doc:`ci-setup`.
 
 .. _Vuforia License Manager: https://developer.vuforia.com/vui/develop/licenses
 .. _Vuforia Target Manager: https://developer.vuforia.com/vui/develop/databases


### PR DESCRIPTION
Closes #3399.

## What
- Number CI credential files from zero, matching `strategy.job-index`.
- Clarify which credentials must be unique and which may be shared.
- Make the CI setup page the single source of truth for archive creation.

## Why
The previous example started at one and duplicated stale archive instructions, which could produce a missing credential file in CI.

## Checks
- `uv run prek run --files docs/source/ci-setup.rst docs/source/contributing.rst`