### PR TITLE
Reject non-object JSON request bodies cleanly

### DIFF
--- a/src/mock_vws/_services_validators/json_validators.py
+++ b/src/mock_vws/_services_validators/json_validators.py
@@ -61,9 +61,15 @@ def validate_json(*, request_body: bytes, request_path: str) -> None:
         return
 
     try:
-        json.loads(s=request_body.decode())
+        request_json = json.loads(s=request_body.decode())
     except JSONDecodeError as exc:
         _LOGGER.warning(msg="The request body is not valid JSON.")
         if request_path.endswith("/instances"):
             raise BadRequestError from exc
         raise FailError(status_code=HTTPStatus.BAD_REQUEST) from exc
+
+    if not isinstance(request_json, dict):
+        _LOGGER.warning(msg="The request body is not a JSON object.")
+        if request_path.endswith("/instances"):
+            raise BadRequestError
+        raise FailError(status_code=HTTPStatus.BAD_REQUEST)

--- a/tests/mock_vws/test_invalid_json.py
+++ b/tests/mock_vws/test_invalid_json.py
@@ -26,9 +26,12 @@ class TestInvalidJSON:
     """Tests for giving invalid JSON to endpoints."""
 
     @staticmethod
-    def test_invalid_json(endpoint: Endpoint) -> None:
-        """Giving invalid JSON to endpoints returns error responses."""
-        content = b"a"
+    @pytest.mark.parametrize(
+        argnames="content",
+        argvalues=[b"a", b"[]", b'"hello"', b"5", b"null", b"true"],
+    )
+    def test_invalid_json(endpoint: Endpoint, content: bytes) -> None:
+        """Giving invalid or non-object JSON returns error responses."""
         gmt = ZoneInfo(key="GMT")
         now = datetime.now(tz=gmt)
         time_to_freeze = now


### PR DESCRIPTION
Closes #3391.

## What
Reject valid JSON values that are not objects during the common JSON validation step. Expand the existing invalid-JSON integration test across arrays, strings, numbers, `null`, and booleans.

## Why
Downstream validators assume a mapping and previously leaked `AttributeError` or `TypeError`, producing exceptions or HTTP 500 responses instead of a VWS error.

## Checks
- Real Vuforia `POST /targets` cases
- Mock invalid-JSON regression cases
- `uv run --extra=dev prek run --files src/mock_vws/_services_validators/json_validators.py tests/mock_vws/test_invalid_json.py`