### PR TITLE
Accept asynchronous recognition summary updates

### DIFF
--- a/tests/mock_vws/test_database_summary.py
+++ b/tests/mock_vws/test_database_summary.py
@@ -300,12 +300,10 @@ class TestRecos:
         high_quality_image: io.BytesIO,
         vws_client: VWS,
     ) -> None:
-        """The ``*_recos`` counts seem to be delayed by a significant
-        amount of
-        time.
+        """Recognition counts are unchanged or incremented after a query.
 
-        We therefore test that they exist, are integers and do not
-        change between quick requests.
+        Vuforia used to update these counts after a significant delay, but it
+        can now expose the increment immediately.
         """
         target_id = vws_client.add_target(
             name=uuid.uuid4().hex,
@@ -320,11 +318,15 @@ class TestRecos:
         cloud_reco_client.query(image=high_quality_image)
 
         report_after = vws_client.get_database_summary_report()
-        assert report_before.total_recos == report_after.total_recos
-        assert (
-            report_before.current_month_recos
-            == report_after.current_month_recos
+        total_recos_change = (
+            report_after.total_recos - report_before.total_recos
         )
+        current_month_recos_change = (
+            report_after.current_month_recos
+            - report_before.current_month_recos
+        )
+        assert total_recos_change in {0, 1}
+        assert current_month_recos_change == total_recos_change
         assert (
             report_before.previous_month_recos
             == report_after.previous_month_recos

--- a/tests/mock_vws/test_database_summary.py
+++ b/tests/mock_vws/test_database_summary.py
@@ -300,11 +300,7 @@ class TestRecos:
         high_quality_image: io.BytesIO,
         vws_client: VWS,
     ) -> None:
-        """Recognition counts are unchanged or incremented after a query.
-
-        Vuforia used to update these counts after a significant delay, but it
-        can now expose the increment immediately.
-        """
+        """Recognition counts update asynchronously after a query."""
         target_id = vws_client.add_target(
             name=uuid.uuid4().hex,
             width=1,


### PR DESCRIPTION
## What

Allow a Vuforia query summary to show either the pre-update counters or the completed increment. The test requires total and current-month counters to move together by at most the single recognition performed, while the previous-month counter remains unchanged.

## Why

Recognition summary counters update asynchronously. A summary read immediately after a successful query can validly occur before or after that update becomes visible.

## Checks

- `uv run --extra=dev pytest tests/mock_vws/test_database_summary.py::TestRecos --skip-real --skip-docker_in_memory -q`
- `uv run --extra=dev pre-commit run --files tests/mock_vws/test_database_summary.py`
- pre-push partition, typing, manifest, and API checks