### PR TITLE
Update permanently redirected documentation links

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -197,7 +197,7 @@ The ``request_count`` in a database summary is always ``0``.
 The documentation for the target summary report says "Note: tracking_rating and ``reco_rating`` are provided only when status = success.".
 However, ``reco_rating`` is never provided and ``tracking_rating`` is provided even when the status is "failed".
 
-.. _Vuforia Query Web API: https://developer.vuforia.com/library/web-api/vuforia-query-web-api
+.. _Vuforia Query Web API: https://developer.vuforia.com/library/vuforia-engine/web-api/vuforia-query-web-api/
 
 Release Process
 ---------------

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -110,7 +110,7 @@ Result codes
 ------------
 
 Result codes are returned by requests to Vuforia to help with debugging.
-See `VWS API Result Codes <https://developer.vuforia.com/library/web-api/cloud-targets-web-services-api#result-codes>`_ for details of the available result codes.
+See `VWS API Result Codes <https://developer.vuforia.com/library/vuforia-engine/web-api/cloud-targets-web-services-api/#result-codes>`_ for details of the available result codes.
 There are some result codes which the mock cannot return.
 
 These are:

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -93,7 +93,7 @@ To delete a database use the following endpoint:
    :endpoints: delete_cloud_database
 
 
-.. _Target Manager: https://developer.vuforia.com/target-manager
+.. _Target Manager: https://developer.vuforia.com/library/vuforia-engine/getting-started/engine-developer-portal/vuforia-target-manager/
 
 
 Configuration options

--- a/src/mock_vws/target.py
+++ b/src/mock_vws/target.py
@@ -66,9 +66,7 @@ def _time_now() -> datetime.datetime:
 @beartype(conf=BeartypeConf(is_pep484_tower=True))
 @dataclass(frozen=True, eq=True, kw_only=True)
 class ImageTarget:
-    """A Vuforia image target as managed in
-    https://developer.vuforia.com/target-manager.
-    """
+    """A Vuforia image target as managed in the Vuforia Target Manager."""
 
     active_flag: bool
     application_metadata: str | None
@@ -235,8 +233,7 @@ class ImageTarget:
 @dataclass(frozen=True, eq=True, kw_only=True)
 class VuMarkTarget:
     """
-    A VuMark target as managed in
-    https://developer.vuforia.com/target-manager.
+    A VuMark target as managed in the Vuforia Target Manager.
 
     Unlike ImageTarget, VuMark targets do not require an image — they use a
     VuMark template.

--- a/src/mock_vws/target_manager.py
+++ b/src/mock_vws/target_manager.py
@@ -23,7 +23,7 @@ class TargetManager:
     """
     A target manager.
 
-    See https://developer.vuforia.com/target-manager.
+    See https://developer.vuforia.com/library/vuforia-engine/getting-started/engine-developer-portal/vuforia-target-manager/.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
Closes #3358.

## What

- Update the Target Manager link to its current public Vuforia documentation page.
- Update the Cloud Query and Cloud Targets links to the current Vuforia Engine library paths.
- Preserve the working `result-codes` anchor.
- Remove duplicate deep links from model docstrings while retaining the canonical documentation link.

## Checks

- `uv run --extra=dev prek run --files docs/source/docker.rst docs/source/contributing.rst docs/source/differences-to-vws.rst src/mock_vws/target.py src/mock_vws/target_manager.py`
- `uv run --extra=dev sphinx-build -W --keep-going -b linkcheck docs/source docs/build/linkcheck`