### PR TITLE
Mock exhausted Model Target training allowance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,7 @@ jobs:
           - tests/mock_vws/test_flask_app_usage.py
           - tests/mock_vws/test_model_target_generation_failure.py
           - tests/mock_vws/test_model_target_generation_warning.py
+          - tests/mock_vws/test_model_target_training_allowance.py
           - tests/mock_vws/test_model_target_web_api.py
           - tests/mock_vws/test_vumark_generation_api.py
           - tests/mock_vws/test_vumark_generation_failure.py

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -238,6 +238,12 @@ in-process Model Target datasets finish with a ``failed`` status and an
 :paramref:`~mock_vws.MockVWS.processing_time_seconds`, so callers can test
 both processing and failed states. This configuration is not supported by the
 Flask/Docker backend.
+Use
+:paramref:`mock_vws.MockVWS.model_target_training_allowance_exceeded` to make
+in-process Model Target dataset creation return Vuforia's
+``TRAINING_ALLOWANCE_EXCEEDED`` response. Set the
+:envvar:`MODEL_TARGET_TRAINING_ALLOWANCE_EXCEEDED` environment variable to
+``true`` to configure the same response in the Flask/Docker backend.
 Use :paramref:`mock_vws.MockVWS.model_target_generation_warning` to make
 successful in-process Model Target datasets include a Vuforia-shaped
 ``warning`` object after processing completes. This configuration is not

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -158,6 +158,13 @@ VWS container
 
    Default: ``2.0``
 
+.. envvar:: MODEL_TARGET_TRAINING_ALLOWANCE_EXCEEDED
+
+   Whether Model Target dataset creation returns Vuforia's
+   ``TRAINING_ALLOWANCE_EXCEEDED`` response.
+
+   Default: ``false``
+
 .. envvar:: VWS_BASE_URL
 
    The base URL which clients use to reach the VWS container.

--- a/newsfragments/3462.change
+++ b/newsfragments/3462.change
@@ -1,0 +1,1 @@
+- Add configurable Model Target ``TRAINING_ALLOWANCE_EXCEEDED`` responses to the in-process and Flask/Docker mocks.

--- a/src/mock_vws/_flask_server/vws.py
+++ b/src/mock_vws/_flask_server/vws.py
@@ -129,6 +129,7 @@ class VWSSettings(BaseSettings):
         _ImageMatcherChoice.STRUCTURAL_SIMILARITY
     )
     response_delay_seconds: float = 0.0
+    model_target_training_allowance_exceeded: bool = False
 
 
 @beartype
@@ -504,6 +505,9 @@ def create_standard_model_target_dataset() -> Response:
             dataset_type=ModelTargetDatasetType.STANDARD,
             generation_failure=None,
             generation_warning=None,
+            training_allowance_exceeded=(
+                settings.model_target_training_allowance_exceeded
+            ),
         ),
     )
 
@@ -524,6 +528,9 @@ def create_advanced_model_target_dataset() -> Response:
             dataset_type=ModelTargetDatasetType.ADVANCED,
             generation_failure=None,
             generation_warning=None,
+            training_allowance_exceeded=(
+                settings.model_target_training_allowance_exceeded
+            ),
         ),
     )
 

--- a/src/mock_vws/_model_target_web_api.py
+++ b/src/mock_vws/_model_target_web_api.py
@@ -1364,6 +1364,7 @@ def create_model_target_dataset(
     dataset_type: ModelTargetDatasetType,
     generation_failure: ModelTargetGenerationFailure | None,
     generation_warning: ModelTargetGenerationWarning | None,
+    training_allowance_exceeded: bool,
 ) -> _ResponseType:
     """Create a standard or advanced Model Target dataset."""
     content_length_error = _content_length_error(request=request)
@@ -1395,12 +1396,20 @@ def create_model_target_dataset(
         if state_scope_error is not None:
             return state_scope_error
 
-    validation_error = _validate_dataset_request(
+    creation_error = _validate_dataset_request(
         request_json=request_json_or_error,
         dataset_type=dataset_type,
     )
-    if validation_error is not None:
-        return validation_error
+    if creation_error is None and training_allowance_exceeded:
+        creation_error = _error_response(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            code="TRAINING_ALLOWANCE_EXCEEDED",
+            message="User has reached total number of allowed trainings",
+            target=_MOCK_USER_TARGET,
+            details=None,
+        )
+    if creation_error is not None:
+        return creation_error
 
     dataset = ModelTargetDataset(
         request_body=request_json_or_error,

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -145,6 +145,7 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         processing_time_seconds: float,
         model_target_generation_failure: (ModelTargetGenerationFailure | None),
         model_target_generation_warning: (ModelTargetGenerationWarning | None),
+        model_target_training_allowance_exceeded: bool,
         duplicate_match_checker: ImageMatcher,
         target_tracking_rater: TargetTrackingRater,
         vumark_generation_failure: VuMarkGenerationFailure | None,
@@ -162,6 +163,9 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
                 after Model Target dataset processing completes.
             model_target_generation_warning: A configured warning returned
                 after Model Target dataset processing completes.
+            model_target_training_allowance_exceeded: Whether Model Target
+                dataset creation is rejected because the account has no
+                training allowance remaining.
             duplicate_match_checker: A callable which takes two image
         values
               and returns whether they are duplicates.
@@ -179,6 +183,9 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         self._processing_time_seconds = processing_time_seconds
         self._model_target_generation_failure = model_target_generation_failure
         self._model_target_generation_warning = model_target_generation_warning
+        self._model_target_training_allowance_exceeded = (
+            model_target_training_allowance_exceeded
+        )
         self._duplicate_match_checker = duplicate_match_checker
         self._target_tracking_rater = target_tracking_rater
         self._vumark_generation_failure = vumark_generation_failure
@@ -270,6 +277,9 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
             dataset_type=ModelTargetDatasetType.STANDARD,
             generation_failure=self._model_target_generation_failure,
             generation_warning=self._model_target_generation_warning,
+            training_allowance_exceeded=(
+                self._model_target_training_allowance_exceeded
+            ),
         )
 
     @route(
@@ -288,6 +298,9 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
             dataset_type=ModelTargetDatasetType.ADVANCED,
             generation_failure=self._model_target_generation_failure,
             generation_warning=self._model_target_generation_warning,
+            training_allowance_exceeded=(
+                self._model_target_training_allowance_exceeded
+            ),
         )
 
     @route(

--- a/src/mock_vws/decorators.py
+++ b/src/mock_vws/decorators.py
@@ -70,6 +70,7 @@ class MockVWS(ContextDecorator):
         model_target_generation_warning: (
             ModelTargetGenerationWarning | None
         ) = None,
+        model_target_training_allowance_exceeded: bool = False,
         target_tracking_rater: TargetTrackingRater = _BRISQUE_TRACKING_RATER,
         real_http: bool = False,
         response_delay_seconds: float = 0.0,
@@ -96,6 +97,10 @@ class MockVWS(ContextDecorator):
                 Model Target dataset finishes processing. By default, Model
                 Target datasets finish without warnings. This cannot be
                 combined with ``model_target_generation_failure``.
+            model_target_training_allowance_exceeded: Whether Model Target
+                dataset creation returns Vuforia's
+                ``TRAINING_ALLOWANCE_EXCEEDED`` response. By default, creation
+                is allowed.
             base_vwq_url: The base URL for the VWQ API.
             base_vws_url: The base URL for the VWS API.
             cloud_query_failure_response: A response to return for every Cloud
@@ -153,6 +158,9 @@ class MockVWS(ContextDecorator):
             processing_time_seconds=float(processing_time_seconds),
             model_target_generation_failure=model_target_generation_failure,
             model_target_generation_warning=model_target_generation_warning,
+            model_target_training_allowance_exceeded=(
+                model_target_training_allowance_exceeded
+            ),
             duplicate_match_checker=duplicate_match_checker,
             target_tracking_rater=target_tracking_rater,
             vumark_generation_failure=vumark_generation_failure,

--- a/tests/mock_vws/test_model_target_training_allowance.py
+++ b/tests/mock_vws/test_model_target_training_allowance.py
@@ -1,0 +1,96 @@
+"""Tests for exhausted Model Target training allowance responses."""
+
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+import requests
+
+from mock_vws import MockVWS
+from mock_vws._flask_server.vws import VWS_FLASK_APP
+
+_AUTHORIZATION = (
+    "Bearer eyJhbGciOiJtb2NrIn0."
+    "eyJzY29wZSI6Im1vZGVsdGFyZ2V0cy5hbGwifQ."
+    "c2lnbmF0dXJl"
+)
+_REQUEST_BODY: dict[str, Any] = {
+    "name": "dataset-name",
+    "targetSdk": "10.18",
+    "models": [
+        {
+            "name": "model-name",
+            "cadDataUrl": "https://example.com/model.glb",
+            "views": [
+                {
+                    "name": "view-name",
+                    "guideViewPosition": {
+                        "translation": [0, 0, 5],
+                        "rotation": [0, 0, 0, 1],
+                    },
+                },
+            ],
+        },
+    ],
+}
+_EXPECTED_BODY = {
+    "error": {
+        "code": "TRAINING_ALLOWANCE_EXCEEDED",
+        "message": "User has reached total number of allowed trainings",
+        "target": "userId:mock",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    argnames="dataset_path",
+    argvalues=[
+        pytest.param("modeltargets/datasets", id="standard"),
+        pytest.param("modeltargets/advancedDatasets", id="advanced"),
+    ],
+)
+def test_requests_mock_training_allowance_exceeded(dataset_path: str) -> None:
+    """The in-process mock can reject creation when allowance is spent."""
+    with MockVWS(model_target_training_allowance_exceeded=True):
+        response = requests.post(
+            url=f"https://vws.vuforia.com/{dataset_path}",
+            headers={"Authorization": _AUTHORIZATION},
+            json=_REQUEST_BODY,
+            timeout=30,
+        )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.json() == _EXPECTED_BODY
+
+
+@pytest.mark.parametrize(
+    argnames="dataset_path",
+    argvalues=[
+        pytest.param("/modeltargets/datasets", id="standard"),
+        pytest.param("/modeltargets/advancedDatasets", id="advanced"),
+    ],
+)
+def test_flask_training_allowance_exceeded(
+    *,
+    dataset_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Flask mock supports the exhausted allowance configuration."""
+    monkeypatch.setenv(
+        name="MODEL_TARGET_TRAINING_ALLOWANCE_EXCEEDED",
+        value="true",
+    )
+    monkeypatch.setenv(
+        name="TARGET_MANAGER_BASE_URL",
+        value="http://target-manager.example.com",
+    )
+
+    with VWS_FLASK_APP.test_client() as client:
+        response = client.post(
+            path=dataset_path,
+            headers={"Authorization": _AUTHORIZATION},
+            json=_REQUEST_BODY,
+        )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.json == _EXPECTED_BODY


### PR DESCRIPTION
Closes #3462

## What changed

- add an opt-in `model_target_training_allowance_exceeded` setting to `MockVWS`
- return Vuforia-style HTTP 422 `TRAINING_ALLOWANCE_EXCEEDED` responses for standard and advanced dataset creation
- support the same behavior in the Flask/Docker backend through `MODEL_TARGET_TRAINING_ALLOWANCE_EXCEEDED=true`
- document both configuration paths and add a release note
- assign the new test module to the CI partition matrix

The setting affects dataset creation only. Existing status, download, and deletion behavior is unchanged. Live Vuforia tests are not skipped when its allowance is exhausted.

## Why

An exhausted Vuforia training allowance could previously be exercised only against a live account after its quota had been consumed. Client handling for that state can now be tested deterministically without weakening the real-Vuforia contract tests.

## Validation

- `uv run pytest -q --skip-real tests/mock_vws/test_model_target_web_api.py tests/mock_vws/test_model_target_training_allowance.py` — 518 passed, 244 skipped
- focused generation failure/warning and exhausted-allowance tests — 13 passed
- `uv run pre-commit run --all-files`
- pre-push partition, mypy, pyright, verifytypes, ty, pyrefly, and manifest checks