### PR TITLE
Replace local limit helpers with vws-test-fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ optional-dependencies.dev = [
     "vale==3.13.0.0",
     "vulture==2.16",
     "vws-python==2026.2.25.1",
-    "vws-test-fixtures==2026.8.16",
+    "vws-test-fixtures==2026.8.23",
     "vws-web-tools==2026.8.7",
     "yamlfix==1.19.1",
     "zizmor==1.29.0",

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -119,6 +119,7 @@ travis
 txt
 unlinks
 unmocked
+unrouted
 untagged
 url
 usefixtures

--- a/tests/mock_vws/test_add_target.py
+++ b/tests/mock_vws/test_add_target.py
@@ -23,11 +23,11 @@ from vws.exceptions.vws_exceptions import (
     TargetNameExistError,
 )
 from vws.response import Response
+from vws_test_fixtures.images import VWS_MAX_IMAGE_FILE_SIZE
 
 from mock_vws._constants import ResultCodes
 from tests.mock_vws.utils import (
     make_decompression_bomb_image_file,
-    make_image_file,
     make_single_color_image_file,
 )
 from tests.mock_vws.utils.assertions import (
@@ -531,7 +531,11 @@ class TestImage:
         )
 
     @staticmethod
-    def test_image_pixel_count_too_large(vws_client: VWS) -> None:
+    def test_image_pixel_count_too_large(
+        *,
+        vws_client: VWS,
+        pixel_count_too_large: io.BytesIO,
+    ) -> None:
         """
         An ``ImageTooLargeError`` result is returned if the image has
         more than 37748736 pixels, whatever its file size.
@@ -555,16 +559,11 @@ class TestImage:
             active_flag=True,
         )
 
-        image_too_many_pixels = make_single_color_image_file(
-            width=width + 1,
-            height=height,
-        )
-
         with pytest.raises(expected_exception=ImageTooLargeError) as exc:
             vws_client.add_target(
                 name="example_name_2",
                 width=1,
-                image=image_too_many_pixels,
+                image=pixel_count_too_large,
                 application_metadata=None,
                 active_flag=True,
             )
@@ -576,57 +575,33 @@ class TestImage:
         )
 
     @staticmethod
-    def test_image_file_size_too_large(vws_client: VWS) -> None:
+    def test_image_file_size_too_large(
+        *,
+        vws_client: VWS,
+        png_just_under_max_size: io.BytesIO,
+        png_too_large: io.BytesIO,
+    ) -> None:
         """
         An ``ImageTooLargeError`` result is returned if the image file
         size is
         above a certain threshold.
         """
-        max_bytes = 2.3 * 1024 * 1024
-        width = height = 886
-        png_not_too_large = make_image_file(
-            file_format="PNG",
-            color_space="RGB",
-            width=width,
-            height=height,
-        )
+        max_bytes = VWS_MAX_IMAGE_FILE_SIZE
 
-        image_data = png_not_too_large.getvalue()
-        image_content_size = len(image_data)
-        # We check that the image we created is just slightly smaller than the
-        # maximum file size.
-        #
-        # This is just because of the implementation details of
-        # ``max_image_file``.
+        image_content_size = len(png_just_under_max_size.getvalue())
         assert image_content_size < max_bytes
         assert (image_content_size * 1.05) > max_bytes
 
         vws_client.add_target(
             name="example_name",
             width=1,
-            image=png_not_too_large,
+            image=png_just_under_max_size,
             application_metadata=None,
             active_flag=True,
         )
 
-        width = width + 1
-        height = height + 1
-        png_too_large = make_image_file(
-            file_format="PNG",
-            color_space="RGB",
-            width=width,
-            height=height,
-        )
-
-        image_data = png_too_large.getvalue()
-        image_content_size = len(image_data)
-        # We check that the image we created is just slightly smaller than the
-        # maximum file size.
-        #
-        # This is just because of the implementation details of
-        # ``max_image_file``.
-        assert image_content_size < max_bytes
-        assert (image_content_size * 1.05) > max_bytes
+        image_content_size = len(png_too_large.getvalue())
+        assert image_content_size > max_bytes
 
         with pytest.raises(expected_exception=ImageTooLargeError) as exc:
             vws_client.add_target(
@@ -1077,16 +1052,19 @@ class TestApplicationMetadata:
         *,
         image_file_failed_state: io.BytesIO,
         vws_client: VWS,
+        application_metadata_near_size_limit: str,
     ) -> None:
         """
         A base64 encoded string of greater than 1024 * 1024 bytes is too
         large
         for application metadata.
         """
-        metadata = b"a" * (_MAX_METADATA_BYTES + 1)
-        metadata_encoded = base64.b64encode(s=metadata).decode(
-            encoding="ascii"
+        decoded_metadata = base64.b64decode(
+            s=application_metadata_near_size_limit.encode(encoding="ascii"),
         )
+        metadata_encoded = base64.b64encode(
+            s=decoded_metadata + b"x",
+        ).decode(encoding="ascii")
 
         with pytest.raises(expected_exception=MetadataTooLargeError) as exc:
             vws_client.add_target(

--- a/tests/mock_vws/test_query.py
+++ b/tests/mock_vws/test_query.py
@@ -1580,7 +1580,10 @@ class TestMaximumImageFileSize:
         assert response.text == _NGINX_REQUEST_ENTITY_TOO_LARGE_ERROR
 
     @staticmethod
-    def test_jpeg(cloud_reco_client: CloudRecoService) -> None:
+    def test_jpeg(
+        cloud_reco_client: CloudRecoService,
+        jpeg_too_large: io.BytesIO,
+    ) -> None:
         """
         According to
         https://developer.vuforia.com/library/web-api/vuforia-query-web-
@@ -1615,23 +1618,8 @@ class TestMaximumImageFileSize:
         results = cloud_reco_client.query(image=jpeg_not_too_large)
         assert results == []
 
-        width = height = 1866
-        jpeg_too_large = make_image_file(
-            file_format="JPEG",
-            color_space="RGB",
-            width=width,
-            height=height,
-        )
-
-        image_content = jpeg_too_large.getvalue()
-        image_content_size = len(image_content)
-        # We check that the image we created is just slightly larger than the
-        # maximum file size.
-        #
-        # This is just because of the implementation details of
-        # ``make_image_file``.
+        image_content_size = len(jpeg_too_large.getvalue())
         assert image_content_size > max_bytes
-        assert (image_content_size * 0.95) < max_bytes
 
         with pytest.raises(
             expected_exception=RequestEntityTooLargeError

--- a/tests/mock_vws/test_query.py
+++ b/tests/mock_vws/test_query.py
@@ -1462,9 +1462,22 @@ class TestBadImage:
         corrupted_image_file: io.BytesIO,
         cloud_reco_client: CloudRecoService,
     ) -> None:
-        """No error is returned when a corrupted image is given."""
-        results = cloud_reco_client.query(image=corrupted_image_file)
-        assert results == []
+        """A ``BadImage`` response is returned when a corrupted image is
+        given.
+        """
+        with pytest.raises(expected_exception=BadImageError) as exc_info:
+            cloud_reco_client.query(image=corrupted_image_file)
+
+        response = exc_info.value.response
+
+        assert_vwq_failure(
+            response=response,
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            content_type="application/json",
+            cache_control=None,
+            www_authenticate=None,
+            connection="keep-alive",
+        )
 
     @staticmethod
     def test_not_image(cloud_reco_client: CloudRecoService) -> None:

--- a/tests/mock_vws/test_update_target.py
+++ b/tests/mock_vws/test_update_target.py
@@ -22,9 +22,9 @@ from vws.exceptions.vws_exceptions import (
 )
 from vws.reports import TargetStatuses
 from vws.response import Response
+from vws_test_fixtures.images import VWS_MAX_IMAGE_FILE_SIZE
 
 from mock_vws._constants import ResultCodes
-from tests.mock_vws.utils import make_image_file
 from tests.mock_vws.utils.assertions import (
     assert_vws_failure,
     assert_vws_response,
@@ -417,16 +417,23 @@ class TestApplicationMetadata:
         )
 
     @staticmethod
-    def test_metadata_too_large(*, vws_client: VWS, target_id: str) -> None:
+    def test_metadata_too_large(
+        *,
+        vws_client: VWS,
+        target_id: str,
+        application_metadata_near_size_limit: str,
+    ) -> None:
         """
         A base64 encoded string of greater than 1024 * 1024 bytes is too
         large
         for application metadata.
         """
-        metadata = b"a" * (_MAX_METADATA_BYTES + 1)
-        metadata_encoded = base64.b64encode(s=metadata).decode(
-            encoding="ascii"
+        decoded_metadata = base64.b64decode(
+            s=application_metadata_near_size_limit.encode(encoding="ascii"),
         )
+        metadata_encoded = base64.b64encode(
+            s=decoded_metadata + b"x",
+        ).decode(encoding="ascii")
 
         with pytest.raises(expected_exception=MetadataTooLargeError) as exc:
             vws_client.update_target(
@@ -660,53 +667,33 @@ class TestImage:
         )
 
     @staticmethod
-    def test_image_too_large(*, target_id: str, vws_client: VWS) -> None:
+    def test_image_too_large(
+        *,
+        target_id: str,
+        vws_client: VWS,
+        png_just_under_max_size: io.BytesIO,
+        png_too_large: io.BytesIO,
+    ) -> None:
         """
         An `ImageTooLargeError` result is returned if the image is above
         a
         certain threshold.
         """
-        max_bytes = 2.3 * 1024 * 1024
-        width = height = 886
-        png_not_too_large = make_image_file(
-            file_format="PNG",
-            color_space="RGB",
-            width=width,
-            height=height,
-        )
+        max_bytes = VWS_MAX_IMAGE_FILE_SIZE
 
-        image_data = png_not_too_large.getvalue()
-        image_content_size = len(image_data)
-        # We check that the image we created is just slightly smaller than the
-        # maximum file size.
-        #
-        # This is just because of the implementation details of
-        # ``max_image_file``.
+        image_content_size = len(png_just_under_max_size.getvalue())
         assert image_content_size < max_bytes
         assert (image_content_size * 1.05) > max_bytes
 
-        vws_client.update_target(target_id=target_id, image=png_not_too_large)
+        vws_client.update_target(
+            target_id=target_id,
+            image=png_just_under_max_size,
+        )
 
         vws_client.wait_for_target_processed(target_id=target_id)
 
-        width = width + 1
-        height = height + 1
-        png_too_large = make_image_file(
-            file_format="PNG",
-            color_space="RGB",
-            width=width,
-            height=height,
-        )
-
-        image_data = png_too_large.getvalue()
-        image_content_size = len(image_data)
-        # We check that the image we created is just slightly smaller than the
-        # maximum file size.
-        #
-        # This is just because of the implementation details of
-        # ``max_image_file``.
-        assert image_content_size < max_bytes
-        assert (image_content_size * 1.05) > max_bytes
+        image_content_size = len(png_too_large.getvalue())
+        assert image_content_size > max_bytes
 
         with pytest.raises(expected_exception=ImageTooLargeError) as exc:
             vws_client.update_target(target_id=target_id, image=png_too_large)

--- a/uv.lock
+++ b/uv.lock
@@ -2864,7 +2864,7 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "vws-auth-tools", specifier = ">=2024.7.12" },
     { name = "vws-python", marker = "extra == 'dev'", specifier = "==2026.2.25.1" },
-    { name = "vws-test-fixtures", marker = "extra == 'dev'", specifier = "==2026.8.16" },
+    { name = "vws-test-fixtures", marker = "extra == 'dev'", specifier = "==2026.8.23" },
     { name = "vws-web-tools", marker = "extra == 'dev'", specifier = "==2026.8.7" },
     { name = "werkzeug", specifier = ">=3.1.2" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
@@ -2877,15 +2877,15 @@ dev = []
 
 [[package]]
 name = "vws-test-fixtures"
-version = "2026.8.16"
+version = "2026.8.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/62/b788605d463c8c06ff619b9e2839de073852c95eb271a166e689b1482fa2/vws_test_fixtures-2026.8.16.tar.gz", hash = "sha256:9f546e706e1d0c09ac1c1a76cfa289a879d268c206a63d30e45326ee68730b44", size = 67384, upload-time = "2026-08-16T09:17:39.223Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/aa/80f6eff03d0dd13f1ca6c8ee40f0fd1da529359b42f845d2b340b7539d2f/vws_test_fixtures-2026.8.23.tar.gz", hash = "sha256:fae520031fcafdab2a8eb9ba1c8a9bf9a7dca07ce3292a8bb7ecda524459d249", size = 73440, upload-time = "2026-08-23T13:31:50.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/12/423093602526eeefa22e59c60f6892ed90e304ad4a5ab78d2e2f2a4e4fde/vws_test_fixtures-2026.8.16-py3-none-any.whl", hash = "sha256:eb6654a6612b7e7f44dfeea2596f4e3d1dfaa2a2867c655792c790b5fc67a984", size = 49047, upload-time = "2026-08-16T09:17:37.921Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/02/575819f7d3d7179b5dafb36dccc724bd2cdd848343e8d7fcad95b711503e/vws_test_fixtures-2026.8.23-py3-none-any.whl", hash = "sha256:e9f0b9c71c7fe398d8631145fe322060eb80c95efb2362a89f57520cae7ddb15", size = 52208, upload-time = "2026-08-23T13:31:49.53Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `vws-test-fixtures` to 2026.8.23
- Use `png_just_under_max_size`, `png_too_large`, `pixel_count_too_large`, `jpeg_too_large`, and `application_metadata_near_size_limit` in limit tests

Fixes #3479

## Test plan
- [x] `test_add_target.py` image/metadata limit tests
- [x] `test_update_target.py` image/metadata limit tests
- [x] `test_query.py::TestMaximumImageFileSize::test_jpeg`