### PR TITLE
Fix CI secret file index for matrix jobs beyond 99

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,10 @@ jobs:
           # See the "CI Setup" document for details of how this was set up.
           ci/decrypt_secret.sh
           tar xvf "${HOME}"/secrets/secrets.tar
-          cp "./ci_secrets/vuforia_secrets_${JOB_INDEX}.env" ./vuforia_secrets.env
+          # Matrix jobs are 0-based; only secrets 0-99 exist. Wrap for overflow
+          # (e.g. docs/ at index 100 after the suite grew past 100 patterns).
+          SECRET_INDEX=$((JOB_INDEX % 100))
+          cp "./ci_secrets/vuforia_secrets_${SECRET_INDEX}.env" ./vuforia_secrets.env
 
       # We have seen issues with running out of disk space on test_docker
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
## Summary
- The Test matrix has 101 `ci_pattern` entries, so `docs/` gets `strategy.job-index` 100 and fails with `cp: cannot stat './ci_secrets/vuforia_secrets_100.env'`.
- Wrap the job index onto the existing `vuforia_secrets_0.env`–`vuforia_secrets_99.env` set.

## Test plan
- [ ] Confirm `ci-tests (3.14, docs/)` passes on this PR
- [ ] Confirm Dependabot PRs blocked on docs/ can go green after merge

Made with [Cursor](https://cursor.com)