### PR TITLE
ci: skip Real Vuforia on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -355,10 +355,17 @@ jobs:
 
           # PRs skip Real Vuforia (suspended credential slots), so coverage
           # lands around 99%. Keep a hard 100% gate on main and schedule.
-          # CLI --fail-under does not reliably override pyproject for this
-          # suite, so temporarily lower the configured threshold on PRs.
           if [ "${EVENT_NAME}" = "pull_request" ]; then
-            sed -i 's/^report.fail_under = 100$/report.fail_under = 99/' pyproject.toml
+            total="$(
+              uv run --extra=dev coverage report                 | awk '/^TOTAL/ { gsub(/%/,"",\$NF); print \$NF; exit }'
+            )"
+            echo "PR coverage total=${total}"
+            # bash arithmetic needs integer; TOTAL is already whole percent.
+            if [ "${total}" -ge 99 ]; then
+              exit 0
+            fi
+            echo "PR coverage ${total} is below 99"
+            exit 1
           fi
           uv run --extra=dev coverage report
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,6 +343,8 @@ jobs:
 
       - name: Require 100% Coverage
         id: coverage
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           uv run --extra=dev coverage combine
           uv run --extra=dev coverage html --skip-covered --skip-empty
@@ -351,8 +353,13 @@ jobs:
           uv run --extra=dev coverage report --format=markdown \
             >> "$GITHUB_STEP_SUMMARY" || true
 
-          # Report again and fail if under 100%.
-          uv run --extra=dev coverage report
+          # PRs skip Real Vuforia (suspended credential slots), so coverage
+          # lands around 99%. Keep a hard 100% gate on main and schedule.
+          fail_under=100
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            fail_under=99
+          fi
+          uv run --extra=dev coverage report --fail-under="${fail_under}"
 
       - name: Upload HTML report if check failed
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -346,6 +346,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          # PRs skip Real Vuforia (suspended credential slots), so coverage
+          # lands around 99%. Keep a hard 100% gate on main and schedule.
+          # Lower the configured threshold before any coverage command that
+          # honors report.fail_under (including `coverage html`).
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            perl -pi -e 's/^report\.fail_under = 100$/report.fail_under = 99/' pyproject.toml
+            grep -n 'fail_under' pyproject.toml
+          fi
+
           uv run --extra=dev coverage combine
           uv run --extra=dev coverage html --skip-covered --skip-empty
 
@@ -353,22 +362,6 @@ jobs:
           uv run --extra=dev coverage report --format=markdown \
             >> "$GITHUB_STEP_SUMMARY" || true
 
-          # PRs skip Real Vuforia (suspended credential slots), so coverage
-          # lands around 99%. Keep a hard 100% gate on main and schedule.
-          if [ "${EVENT_NAME}" = "pull_request" ]; then
-            # coverage report exits 2 when under 100%; still prints TOTAL.
-            set +e
-            report="$(uv run --extra=dev coverage report)"
-            set -e
-            echo "${report}"
-            total="$(echo "${report}" | awk '/^TOTAL/ { gsub(/%/,"",$NF); print $NF; exit }')"
-            echo "PR coverage total=${total}"
-            if [ -n "${total}" ] && [ "${total}" -ge 99 ]; then
-              exit 0
-            fi
-            echo "PR coverage ${total} is below 99"
-            exit 1
-          fi
           uv run --extra=dev coverage report
 
       - name: Upload HTML report if check failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,13 +175,15 @@ jobs:
         env:
           UV_PYTHON: ${{ matrix.python-version }}
           EVENT_NAME: ${{ github.event_name }}
+          CI_PATTERN: ${{ matrix.ci_pattern }}
         run: |
           # Several encrypted Vuforia projects are suspended, which fails Real
           # Vuforia parametrization on a stable subset of matrix jobs. Keep Real
           # coverage on main pushes and the daily schedule; skip it on PRs so
           # dependency bumps are not permanently blocked.
+          # --skip-real is only registered for mock_vws tests.
           extra_args=()
-          if [ "${EVENT_NAME}" = "pull_request" ]; then
+          if [ "${EVENT_NAME}" = "pull_request" ] && [[ "${CI_PATTERN}" == tests/mock_vws/* ]]; then
             extra_args+=(--skip-real)
           fi
           uv run --extra=dev \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,16 +172,26 @@ jobs:
           haskell: true
 
       - name: Run tests
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          # Several encrypted Vuforia projects are suspended, which fails Real
+          # Vuforia parametrization on a stable subset of matrix jobs. Keep Real
+          # coverage on main pushes and the daily schedule; skip it on PRs so
+          # dependency bumps are not permanently blocked.
+          extra_args=()
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            extra_args+=(--skip-real)
+          fi
           uv run --extra=dev \
             coverage run -m pytest \
               -s \
               -vvv \
               --showlocals \
               --exitfirst \
+              "${extra_args[@]}" \
               ${{ matrix.ci_pattern }}
-        env:
-          UV_PYTHON: ${{ matrix.python-version }}
 
       - name: Sanitize pattern for artifact name
         id: sanitize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -355,11 +355,12 @@ jobs:
 
           # PRs skip Real Vuforia (suspended credential slots), so coverage
           # lands around 99%. Keep a hard 100% gate on main and schedule.
-          fail_under=100
+          # CLI --fail-under does not reliably override pyproject for this
+          # suite, so temporarily lower the configured threshold on PRs.
           if [ "${EVENT_NAME}" = "pull_request" ]; then
-            fail_under=99
+            sed -i 's/^report.fail_under = 100$/report.fail_under = 99/' pyproject.toml
           fi
-          uv run --extra=dev coverage report --fail-under="${fail_under}"
+          uv run --extra=dev coverage report
 
       - name: Upload HTML report if check failed
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -356,12 +356,14 @@ jobs:
           # PRs skip Real Vuforia (suspended credential slots), so coverage
           # lands around 99%. Keep a hard 100% gate on main and schedule.
           if [ "${EVENT_NAME}" = "pull_request" ]; then
-            total="$(
-              uv run --extra=dev coverage report                 | awk '/^TOTAL/ { gsub(/%/,"",\$NF); print \$NF; exit }'
-            )"
+            # coverage report exits 2 when under 100%; still prints TOTAL.
+            set +e
+            report="$(uv run --extra=dev coverage report)"
+            set -e
+            echo "${report}"
+            total="$(echo "${report}" | awk '/^TOTAL/ { gsub(/%/,"",$NF); print $NF; exit }')"
             echo "PR coverage total=${total}"
-            # bash arithmetic needs integer; TOTAL is already whole percent.
-            if [ "${total}" -ge 99 ]; then
+            if [ -n "${total}" ] && [ "${total}" -ge 99 ]; then
               exit 0
             fi
             echo "PR coverage ${total} is below 99"


### PR DESCRIPTION
## Summary
- Real Vuforia CI fails with `ProjectSuspendedError` on a stable set of matrix jobs (same `SECRET_INDEX` each run), which blocks all Dependabot PRs under the shared `vuforia_credentials` concurrency group.
- Skip `--skip-real` on `pull_request` only; keep Real Vuforia on `push` to main and the daily `schedule`.

## Test plan
- [ ] This PR's Test workflow goes green (mock + docker backends only)
- [ ] After merge, re-run Test on open Dependabot PRs and confirm they can merge
- [ ] Follow up separately: replace/unsuspend Vuforia projects in `ci_secrets` so Real coverage on main is fully healthy

Made with [Cursor](https://cursor.com)