### PR TITLE
Revert "ci: skip Real Vuforia on pull requests" (#3484)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,28 +172,16 @@ jobs:
           haskell: true
 
       - name: Run tests
-        env:
-          UV_PYTHON: ${{ matrix.python-version }}
-          EVENT_NAME: ${{ github.event_name }}
-          CI_PATTERN: ${{ matrix.ci_pattern }}
         run: |
-          # Several encrypted Vuforia projects are suspended, which fails Real
-          # Vuforia parametrization on a stable subset of matrix jobs. Keep Real
-          # coverage on main pushes and the daily schedule; skip it on PRs so
-          # dependency bumps are not permanently blocked.
-          # --skip-real is only registered for mock_vws tests.
-          extra_args=()
-          if [ "${EVENT_NAME}" = "pull_request" ] && [[ "${CI_PATTERN}" == tests/mock_vws/* ]]; then
-            extra_args+=(--skip-real)
-          fi
           uv run --extra=dev \
             coverage run -m pytest \
               -s \
               -vvv \
               --showlocals \
               --exitfirst \
-              "${extra_args[@]}" \
               ${{ matrix.ci_pattern }}
+        env:
+          UV_PYTHON: ${{ matrix.python-version }}
 
       - name: Sanitize pattern for artifact name
         id: sanitize
@@ -343,18 +331,7 @@ jobs:
 
       - name: Require 100% Coverage
         id: coverage
-        env:
-          EVENT_NAME: ${{ github.event_name }}
         run: |
-          # PRs skip Real Vuforia (suspended credential slots), so coverage
-          # lands around 99%. Keep a hard 100% gate on main and schedule.
-          # Lower the configured threshold before any coverage command that
-          # honors report.fail_under (including `coverage html`).
-          if [ "${EVENT_NAME}" = "pull_request" ]; then
-            perl -pi -e 's/^report\.fail_under = 100$/report.fail_under = 99/' pyproject.toml
-            grep -n 'fail_under' pyproject.toml
-          fi
-
           uv run --extra=dev coverage combine
           uv run --extra=dev coverage html --skip-covered --skip-empty
 
@@ -362,6 +339,7 @@ jobs:
           uv run --extra=dev coverage report --format=markdown \
             >> "$GITHUB_STEP_SUMMARY" || true
 
+          # Report again and fail if under 100%.
           uv run --extra=dev coverage report
 
       - name: Upload HTML report if check failed


### PR DESCRIPTION
Reverts #3484 (merge commit af8bee511548ae787965ba65a8a8221981a94ad5).

Restores the previous `.github/workflows/test.yml` behaviour:
- Real Vuforia backends run on `pull_request` again (no conditional `--skip-real`).
- The coverage gate is a hard 100% on every event (no `report.fail_under` rewrite on PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018x8C5AEJPVyoGeQESTtMRq