### PR TITLE
Add configurable Model Target failure responses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,7 @@ jobs:
           - tests/mock_vws/test_flask_app_usage.py
           - tests/mock_vws/test_model_target_generation_failure.py
           - tests/mock_vws/test_model_target_generation_warning.py
+          - tests/mock_vws/test_model_target_failure_response.py
           - tests/mock_vws/test_model_target_training_allowance.py
           - tests/mock_vws/test_model_target_web_api.py
           - tests/mock_vws/test_vumark_generation_api.py

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -196,6 +196,36 @@ The configured response bypasses normal Cloud Query validation and image
 matching. Omitting it preserves the normal successful-query behavior. This
 configuration is not supported by the Flask/Docker backend.
 
+Configurable Model Target failures
+----------------------------------
+
+Use :paramref:`mock_vws.MockVWS.model_target_failure_response` to return a
+particular HTTP failure from selected Model Target dataset request phases. The
+OAuth2 token request is still handled normally, so this exercises client
+behavior after successful token acquisition::
+
+    from mock_vws import (
+        MockVWS,
+        ModelTargetFailureResponse,
+        ModelTargetRequest,
+    )
+
+    failure = ModelTargetFailureResponse(
+        status_code=503,
+        headers={"Content-Type": "text/plain", "Retry-After": "10"},
+        body=b"Temporarily unavailable",
+        requests=frozenset({ModelTargetRequest.STATUS}),
+    )
+
+    with MockVWS(model_target_failure_response=failure):
+        # Model Target status calls return the configured response.
+        ...
+
+Omit ``requests`` to affect create, status, download, and delete requests.
+Other phases retain their normal behavior. This configuration works with
+the in-process ``requests`` and ``httpx`` backends and is not supported by the
+Flask/Docker backend.
+
 Other configurable result codes
 -------------------------------
 

--- a/docs/source/mock-api-reference.rst
+++ b/docs/source/mock-api-reference.rst
@@ -15,6 +15,14 @@ API Reference
    :members:
    :undoc-members:
 
+.. autoclass:: mock_vws.ModelTargetFailureResponse(*, status_code, headers={}, body=b'', requests=...)
+   :members:
+   :undoc-members:
+
+.. autoclass:: mock_vws.ModelTargetRequest
+   :members:
+   :undoc-members:
+
 .. autoclass:: mock_vws.VuMarkGenerationFailure
    :members:
    :undoc-members:

--- a/newsfragments/3495.change
+++ b/newsfragments/3495.change
@@ -1,0 +1,1 @@
+Add configurable Model Target HTTP failure responses for selected dataset request phases.

--- a/src/mock_vws/__init__.py
+++ b/src/mock_vws/__init__.py
@@ -4,8 +4,10 @@ from mock_vws._mock_common import MissingSchemeError
 from mock_vws.cloud_query import CloudQueryFailureResponse
 from mock_vws.decorators import MockVWS
 from mock_vws.model_target import (
+    ModelTargetFailureResponse,
     ModelTargetGenerationFailure,
     ModelTargetGenerationWarning,
+    ModelTargetRequest,
 )
 from mock_vws.vumark import VuMarkGenerationFailure
 
@@ -13,7 +15,9 @@ __all__ = [
     "CloudQueryFailureResponse",
     "MissingSchemeError",
     "MockVWS",
+    "ModelTargetFailureResponse",
     "ModelTargetGenerationFailure",
     "ModelTargetGenerationWarning",
+    "ModelTargetRequest",
     "VuMarkGenerationFailure",
 ]

--- a/src/mock_vws/_requests_mock_server/mock_web_services_api.py
+++ b/src/mock_vws/_requests_mock_server/mock_web_services_api.py
@@ -61,8 +61,10 @@ from mock_vws.database import VuMarkDatabase
 from mock_vws.image_matchers import ImageMatcher
 from mock_vws.model_target import (
     ModelTargetDatasetType,
+    ModelTargetFailureResponse,
     ModelTargetGenerationFailure,
     ModelTargetGenerationWarning,
+    ModelTargetRequest,
 )
 from mock_vws.target import ImageTarget
 from mock_vws.target_manager import TargetManager
@@ -144,6 +146,7 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         base_vws_url: str,
         processing_time_seconds: float,
         model_target_generation_failure: (ModelTargetGenerationFailure | None),
+        model_target_failure_response: ModelTargetFailureResponse | None,
         model_target_generation_warning: (ModelTargetGenerationWarning | None),
         model_target_training_allowance_exceeded: bool,
         duplicate_match_checker: ImageMatcher,
@@ -161,6 +164,9 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
               deterministic.
             model_target_generation_failure: A configured failure returned
                 after Model Target dataset processing completes.
+            model_target_failure_response: A configured response returned
+        for
+                selected Model Target dataset request phases.
             model_target_generation_warning: A configured warning returned
                 after Model Target dataset processing completes.
             model_target_training_allowance_exceeded: Whether Model Target
@@ -182,6 +188,7 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         self.routes = _ROUTES
         self._processing_time_seconds = processing_time_seconds
         self._model_target_generation_failure = model_target_generation_failure
+        self._model_target_failure_response = model_target_failure_response
         self._model_target_generation_warning = model_target_generation_warning
         self._model_target_training_allowance_exceeded = (
             model_target_training_allowance_exceeded
@@ -189,6 +196,18 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         self._duplicate_match_checker = duplicate_match_checker
         self._target_tracking_rater = target_tracking_rater
         self._vumark_generation_failure = vumark_generation_failure
+
+    def _configured_model_target_failure(
+        self,
+        request_phase: ModelTargetRequest,
+    ) -> _ResponseType | None:
+        """Return the configured failure for a Model Target request
+        phase.
+        """
+        failure = self._model_target_failure_response
+        if failure is None or request_phase not in failure.requests:
+            return None
+        return failure.status_code, failure.headers, failure.body
 
     @route(path_pattern="/oauth2/token", http_methods={HTTPMethod.POST})
     def oauth2_token(
@@ -270,6 +289,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Create a standard Model Target dataset."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.CREATE,
+        ):
+            return failure
         return create_model_target_dataset(
             request=request,
             dataset_store=self._target_manager,
@@ -291,6 +314,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Create an advanced Model Target dataset."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.CREATE,
+        ):
+            return failure
         return create_model_target_dataset(
             request=request,
             dataset_store=self._target_manager,
@@ -315,6 +342,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Return a standard Model Target dataset creation status."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.STATUS,
+        ):
+            return failure
         dataset_uuid = request.path.split(sep="/")[-2]
         return get_model_target_dataset_status(
             request=request,
@@ -335,6 +366,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Return an advanced Model Target dataset creation status."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.STATUS,
+        ):
+            return failure
         dataset_uuid = request.path.split(sep="/")[-2]
         return get_model_target_dataset_status(
             request=request,
@@ -355,6 +390,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Download a standard Model Target dataset."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.DOWNLOAD,
+        ):
+            return failure
         dataset_uuid = request.path.split(sep="/")[-2]
         return download_model_target_dataset(
             request=request,
@@ -375,6 +414,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Download an advanced Model Target dataset."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.DOWNLOAD,
+        ):
+            return failure
         dataset_uuid = request.path.split(sep="/")[-2]
         return download_model_target_dataset(
             request=request,
@@ -394,6 +437,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Delete a standard Model Target dataset."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.DELETE,
+        ):
+            return failure
         dataset_uuid = request.path.split(sep="/")[-1]
         return delete_model_target_dataset(
             request=request,
@@ -414,6 +461,10 @@ class MockVuforiaWebServicesAPI:  # pylint: disable=too-many-public-methods
         request: RequestData,
     ) -> _ResponseType:
         """Delete an advanced Model Target dataset."""
+        if failure := self._configured_model_target_failure(
+            request_phase=ModelTargetRequest.DELETE,
+        ):
+            return failure
         dataset_uuid = request.path.split(sep="/")[-1]
         return delete_model_target_dataset(
             request=request,

--- a/src/mock_vws/decorators.py
+++ b/src/mock_vws/decorators.py
@@ -29,6 +29,7 @@ from mock_vws.image_matchers import (
     StructuralSimilarityMatcher,
 )
 from mock_vws.model_target import (
+    ModelTargetFailureResponse,
     ModelTargetGenerationFailure,
     ModelTargetGenerationWarning,
 )
@@ -66,6 +67,7 @@ class _MockVWSOptions:
     query_match_checker: ImageMatcher
     processing_time_seconds: float
     model_target_generation_failure: ModelTargetGenerationFailure | None
+    model_target_failure_response: ModelTargetFailureResponse | None
     model_target_generation_warning: ModelTargetGenerationWarning | None
     model_target_training_allowance_exceeded: bool
     target_tracking_rater: TargetTrackingRater
@@ -105,6 +107,9 @@ class MockVWS:
         model_target_generation_failure: (
             ModelTargetGenerationFailure | None
         ) = None,
+        model_target_failure_response: (
+            ModelTargetFailureResponse | None
+        ) = None,
         model_target_generation_warning: (
             ModelTargetGenerationWarning | None
         ) = None,
@@ -131,6 +136,10 @@ class MockVWS:
             model_target_generation_failure: A failure to return after every
                 Model Target dataset finishes processing. By default, Model
                 Target datasets finish successfully.
+            model_target_failure_response: A response to return for the
+                selected Model Target dataset request phases, after OAuth2
+                token acquisition and before normal request validation. By
+                default, Model Target dataset requests are handled normally.
             model_target_generation_warning: A warning to return after every
                 Model Target dataset finishes processing. By default, Model
                 Target datasets finish without warnings. This cannot be
@@ -192,6 +201,7 @@ class MockVWS:
             query_match_checker=query_match_checker,
             processing_time_seconds=float(processing_time_seconds),
             model_target_generation_failure=model_target_generation_failure,
+            model_target_failure_response=model_target_failure_response,
             model_target_generation_warning=model_target_generation_warning,
             model_target_training_allowance_exceeded=(
                 model_target_training_allowance_exceeded
@@ -234,6 +244,7 @@ class MockVWS:
             model_target_generation_failure=(
                 options.model_target_generation_failure
             ),
+            model_target_failure_response=options.model_target_failure_response,
             model_target_generation_warning=(
                 options.model_target_generation_warning
             ),

--- a/src/mock_vws/model_target.py
+++ b/src/mock_vws/model_target.py
@@ -32,6 +32,41 @@ class ModelTargetDatasetType(StrEnum):
 
 
 @beartype
+class ModelTargetRequest(StrEnum):
+    """A Model Target dataset request phase."""
+
+    CREATE = "create"
+    STATUS = "status"
+    DOWNLOAD = "download"
+    DELETE = "delete"
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class ModelTargetFailureResponse:
+    """A configured failure returned by Model Target dataset requests.
+
+    OAuth2 token requests are always handled normally, so clients obtain a
+    token before a configured dataset-request failure is returned.
+
+    Args:
+        status_code: The HTTP status code to return.
+        headers: The HTTP response headers to return.
+        body: The raw response body. String bodies are encoded as UTF-8 by
+            the HTTP backend; byte bodies are returned unchanged.
+        requests: The dataset request phases which return this response.
+            By default, every dataset request phase returns it.
+    """
+
+    status_code: int
+    headers: dict[str, str] = field(default_factory=dict[str, str])
+    body: str | bytes = b""
+    requests: frozenset[ModelTargetRequest] = field(
+        default_factory=lambda: frozenset(ModelTargetRequest),
+    )
+
+
+@beartype
 @dataclass(frozen=True, kw_only=True)
 class OAuth2ClientCredential:
     """An OAuth2 client credential managed through the Vuforia Web API."""

--- a/tests/mock_vws/test_model_target_failure_response.py
+++ b/tests/mock_vws/test_model_target_failure_response.py
@@ -1,0 +1,210 @@
+"""Tests for configurable Model Target failure responses."""
+
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+import pytest
+import requests
+
+from mock_vws import MockVWS, ModelTargetFailureResponse, ModelTargetRequest
+
+_BASE_URL = "https://vws.vuforia.com"
+_CLIENT_ID = "client-id"
+_CLIENT_SECRET = "client-secret"
+type _HTTPResponse = requests.Response | httpx.Response
+type _DatasetRequestSender = Callable[[dict[str, Any]], _HTTPResponse]
+
+
+def _dataset_body() -> dict[str, Any]:
+    """Return an otherwise-valid Model Target dataset request body."""
+    return {
+        "name": "configured-failure-test",
+        "targetSdk": "10.18",
+        "models": [
+            {
+                "name": "model",
+                "cadDataUrl": "https://example.com/model.glb",
+                "views": [],
+            },
+        ],
+    }
+
+
+def _requests_create_dataset(body: dict[str, Any]) -> _HTTPResponse:
+    """Acquire a token and create a dataset using ``requests``."""
+    token_response = requests.post(
+        url=f"{_BASE_URL}/oauth2/token",
+        auth=(_CLIENT_ID, _CLIENT_SECRET),
+        data={"grant_type": "client_credentials"},
+        timeout=30,
+    )
+    token_response.raise_for_status()
+    token = token_response.json()["access_token"]
+    return requests.post(
+        url=f"{_BASE_URL}/modeltargets/datasets",
+        headers={"Authorization": f"Bearer {token}"},
+        json=body,
+        timeout=30,
+    )
+
+
+def _httpx_create_dataset(body: dict[str, Any]) -> _HTTPResponse:
+    """Acquire a token and create a dataset using ``httpx``."""
+    token_response = httpx.post(
+        url=f"{_BASE_URL}/oauth2/token",
+        auth=(_CLIENT_ID, _CLIENT_SECRET),
+        data={"grant_type": "client_credentials"},
+        timeout=30,
+    )
+    token_response.raise_for_status()
+    token = token_response.json()["access_token"]
+    return httpx.post(
+        url=f"{_BASE_URL}/modeltargets/datasets",
+        headers={"Authorization": f"Bearer {token}"},
+        json=body,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="send_request",
+    argvalues=[_requests_create_dataset, _httpx_create_dataset],
+    ids=["requests", "httpx"],
+)
+@pytest.mark.parametrize(
+    argnames=("status_code", "headers", "body", "expected_body"),
+    argvalues=[
+        pytest.param(
+            HTTPStatus.UNAUTHORIZED,
+            {"Content-Type": "application/json"},
+            '{"error":{"code":"AUTHENTICATION_ERROR","message":"No"}}',
+            b'{"error":{"code":"AUTHENTICATION_ERROR","message":"No"}}',
+            id="authentication-json",
+        ),
+        pytest.param(
+            HTTPStatus.FORBIDDEN,
+            {"Content-Type": "application/json"},
+            '{"error":{"code":"FORBIDDEN","message":"Denied"}}',
+            b'{"error":{"code":"FORBIDDEN","message":"Denied"}}',
+            id="generic-json",
+        ),
+        pytest.param(
+            HTTPStatus.CONFLICT,
+            {"Content-Type": "text/plain"},
+            "not json",
+            b"not json",
+            id="generic-non-json",
+        ),
+        pytest.param(
+            HTTPStatus.BAD_GATEWAY,
+            {"Content-Type": "application/octet-stream", "Retry-After": "5"},
+            b"\xffupstream failure",
+            b"\xffupstream failure",
+            id="server-error",
+        ),
+    ],
+)
+def test_configured_failure_response(
+    *,
+    send_request: _DatasetRequestSender,
+    status_code: HTTPStatus,
+    headers: dict[str, str],
+    body: str | bytes,
+    expected_body: bytes,
+) -> None:
+    """Both in-process backends preserve the configured response."""
+    failure = ModelTargetFailureResponse(
+        status_code=status_code,
+        headers=headers,
+        body=body,
+    )
+
+    with MockVWS(model_target_failure_response=failure):
+        response = send_request(_dataset_body())
+
+    assert response.status_code == status_code
+    assert response.content == expected_body
+    for name, value in headers.items():
+        assert response.headers[name] == value
+
+
+@pytest.mark.parametrize(
+    argnames="send_request",
+    argvalues=[_requests_create_dataset, _httpx_create_dataset],
+    ids=["requests", "httpx"],
+)
+def test_unselected_request_is_handled_normally(
+    *, send_request: _DatasetRequestSender
+) -> None:
+    """A failure configured for another phase does not affect creation."""
+    failure = ModelTargetFailureResponse(
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+        requests=frozenset({ModelTargetRequest.STATUS}),
+    )
+
+    with MockVWS(model_target_failure_response=failure):
+        response = send_request(_dataset_body())
+
+    assert response.status_code == HTTPStatus.CREATED
+
+
+@pytest.mark.parametrize(
+    argnames=("method", "path_suffix", "request_phase"),
+    argvalues=[
+        pytest.param("POST", "", ModelTargetRequest.CREATE, id="create"),
+        pytest.param(
+            "GET", "/dataset-id/status", ModelTargetRequest.STATUS, id="status"
+        ),
+        pytest.param(
+            "GET",
+            "/dataset-id/dataset",
+            ModelTargetRequest.DOWNLOAD,
+            id="download",
+        ),
+        pytest.param(
+            "DELETE", "/dataset-id", ModelTargetRequest.DELETE, id="delete"
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    argnames="collection",
+    argvalues=["datasets", "advancedDatasets"],
+    ids=["standard", "advanced"],
+)
+def test_selected_request_returns_failure(
+    *,
+    method: str,
+    path_suffix: str,
+    request_phase: ModelTargetRequest,
+    collection: str,
+) -> None:
+    """Every selected request phase and route family can fail."""
+    failure = ModelTargetFailureResponse(
+        status_code=HTTPStatus.TOO_MANY_REQUESTS,
+        headers={"Retry-After": "10"},
+        body="rate limited",
+        requests=frozenset({request_phase}),
+    )
+
+    with MockVWS(model_target_failure_response=failure):
+        token_response = requests.post(
+            url=f"{_BASE_URL}/oauth2/token",
+            auth=(_CLIENT_ID, _CLIENT_SECRET),
+            data={"grant_type": "client_credentials"},
+            timeout=30,
+        )
+        token_response.raise_for_status()
+        token = token_response.json()["access_token"]
+        response = requests.request(
+            method=method,
+            url=f"{_BASE_URL}/modeltargets/{collection}{path_suffix}",
+            headers={"Authorization": f"Bearer {token}"},
+            json=_dataset_body(),
+            timeout=30,
+        )
+
+    assert response.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert response.headers["Retry-After"] == "10"
+    assert response.text == "rate limited"


### PR DESCRIPTION
Closes #3495.

Adds a public `ModelTargetFailureResponse` configuration and `ModelTargetRequest` phase selector for Model Target dataset requests. OAuth token acquisition remains normal, while selected create, status, download, or delete requests return the configured status, headers, and raw body.

The configuration is supported by both in-process backends (`requests` and `httpx`). The documentation explicitly records that it is not yet available through Flask or Docker.

Tests cover authentication errors, JSON and non-JSON 4xx responses, binary 5xx responses, normal behavior for other phases, and all four phases for standard and advanced datasets.

Validation:
- `uv run prek run --all-files`
- `uv run prek run pytest-check-partition --all-files --hook-stage pre-push`
- `uv run prek run --all-files --hook-stage manual`
- `uv run pytest -q tests/mock_vws/test_model_target_failure_response.py` (18 passed)
- broader Model Target selection: 670 passed; 124 Real Vuforia cases could not run locally because credentials were unavailable