### PR TITLE
Return BadImage for a truncated image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
           - tests/mock_vws/test_update_target.py::TestImage::test_image_valid
           - tests/mock_vws/test_update_target.py::TestImage::test_bad_image_format_or_color_space
           - tests/mock_vws/test_update_target.py::TestImage::test_corrupted
+          - tests/mock_vws/test_update_target.py::TestImage::test_truncated
           - tests/mock_vws/test_update_target.py::TestImage::test_image_too_large
           - tests/mock_vws/test_update_target.py::TestImage::test_not_base64_encoded_processable
           - tests/mock_vws/test_update_target.py::TestImage::test_not_base64_encoded_not_processable

--- a/newsfragments/3498.change
+++ b/newsfragments/3498.change
@@ -1,0 +1,1 @@
+Return a ``BadImage`` response, rather than failing to respond, when an image given to the Target API is truncated before the end of its image data.

--- a/src/mock_vws/_services_validators/image_validators.py
+++ b/src/mock_vws/_services_validators/image_validators.py
@@ -43,7 +43,13 @@ def validate_image_integrity(*, request_body: bytes) -> None:
     with open_image(fp=image_file) as pil_image:
         try:
             pil_image.verify()
-        except SyntaxError as exc:
+        except (OSError, SyntaxError) as exc:
+            # ``verify`` raises ``SyntaxError`` for a damaged header and
+            # ``OSError`` for damaged image data, such as a PNG which is
+            # truncated before its ``IEND`` chunk.
+            # ``open_image`` runs outside this ``try``, so anything which
+            # cannot be opened at all is already rejected by
+            # ``validate_image_is_image``.
             _LOGGER.warning(msg="The image is not a valid image file.")
             raise BadImageError from exc
 

--- a/tests/mock_vws/test_add_target.py
+++ b/tests/mock_vws/test_add_target.py
@@ -29,6 +29,7 @@ from mock_vws._constants import ResultCodes
 from tests.mock_vws.utils import (
     make_decompression_bomb_image_file,
     make_single_color_image_file,
+    make_truncated_png_file,
 )
 from tests.mock_vws.utils.assertions import (
     assert_vws_failure,
@@ -495,6 +496,30 @@ class TestImage:
                 name="example_name",
                 width=1,
                 image=corrupted_image_file,
+                application_metadata=None,
+                active_flag=True,
+            )
+
+        assert_vws_failure(
+            response=exc.value.response,
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            result_code=ResultCodes.BAD_IMAGE,
+        )
+
+    @staticmethod
+    def test_truncated(vws_client: VWS) -> None:
+        """
+        An error is returned when the given image is truncated before
+        the
+        end of its image data.
+        """
+        image_file = make_truncated_png_file()
+
+        with pytest.raises(expected_exception=BadImageError) as exc:
+            vws_client.add_target(
+                name="example_name",
+                width=1,
+                image=image_file,
                 application_metadata=None,
                 active_flag=True,
             )

--- a/tests/mock_vws/test_update_target.py
+++ b/tests/mock_vws/test_update_target.py
@@ -25,6 +25,7 @@ from vws.response import Response
 from vws_test_fixtures.images import VWS_MAX_IMAGE_FILE_SIZE
 
 from mock_vws._constants import ResultCodes
+from tests.mock_vws.utils import make_truncated_png_file
 from tests.mock_vws.utils.assertions import (
     assert_vws_failure,
     assert_vws_response,
@@ -658,6 +659,31 @@ class TestImage:
             vws_client.update_target(
                 target_id=target_id,
                 image=corrupted_image_file,
+            )
+
+        assert_vws_failure(
+            response=exc.value.response,
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            result_code=ResultCodes.BAD_IMAGE,
+        )
+
+    @staticmethod
+    def test_truncated(
+        *,
+        vws_client: VWS,
+        target_id: str,
+    ) -> None:
+        """
+        An error is returned when the given image is truncated before
+        the
+        end of its image data.
+        """
+        image_file = make_truncated_png_file()
+
+        with pytest.raises(expected_exception=BadImageError) as exc:
+            vws_client.update_target(
+                target_id=target_id,
+                image=image_file,
             )
 
         assert_vws_failure(

--- a/tests/mock_vws/utils/__init__.py
+++ b/tests/mock_vws/utils/__init__.py
@@ -204,6 +204,27 @@ def make_single_color_image_file(*, width: int, height: int) -> io.BytesIO:
 
 
 @beartype
+def make_truncated_png_file() -> io.BytesIO:
+    """Return a PNG file whose image data is cut off before the end.
+
+    The file keeps a valid signature and header, so Pillow opens it, but the
+    ``IEND`` chunk which marks the end of the image is missing, so decoding
+    the image data fails.
+
+    Returns:
+        A PNG file which is truncated before its ``IEND`` chunk.
+    """
+    image = Image.frombytes(mode="RGB", size=(1, 1), data=b"\x01\x02\x03")
+    image_buffer = io.BytesIO()
+    image.save(fp=image_buffer, format="PNG", optimize=True)
+    image_bytes = image_buffer.getvalue()
+    # Remove the ``IEND`` chunk: its four length bytes, its four type bytes
+    # and its four checksum bytes.
+    truncated = image_bytes[: image_bytes.rindex(b"IEND") - 4]
+    return io.BytesIO(initial_bytes=truncated)
+
+
+@beartype
 def make_decompression_bomb_image_file() -> io.BytesIO:
     """Return a PNG file which is tiny on disk but huge when decoded.
 


### PR DESCRIPTION
Fixes #3498.

`Image.verify` raises `OSError` as well as `SyntaxError` — for example on a
PNG whose `IDAT` data is present but whose `IEND` chunk is missing.
`Image.open` succeeds for such a file, so `validate_image_is_image` does not
reject it first, and the bare `OSError` escaped the request: the mock failed
to respond at all.

`validate_image_integrity` now catches both. `open_image` runs outside the
`try`, so anything which cannot be opened at all is still rejected by
`validate_image_is_image`.

## Verification

`make_truncated_png_file` builds the file from the reproduction in the issue.
New `TestImage::test_truncated` tests for `add_target` and `update_target`
fail with `OSError: truncated PNG file` without the fix and pass with it, on
the in-memory mock, the in-memory Docker application and real Vuforia — real
Vuforia answers `422 BadImage`, so the mock now matches.

The Query API needs no change: it never calls `verify`, and real Vuforia
accepts the same truncated PNG there, returning an empty match list. Checked
against a live account.

The new `update_target` test needed a `ci_pattern` entry; the `add_target`
one is already covered by the `TestImage` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7tNiBpHomY5ShxZjQyWsf